### PR TITLE
[4] Wire CLI skeleton with `clap` subcommands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,33 +1,150 @@
 //! Command-line interface.
 //!
-//! Exposes two subcommands: `check` reports violations without modifying files,
-//! `format` rewrites files in place (or prints a diff with `--diff`).
+//! Exposes two subcommands: `check` reports violations without
+//! modifying files, `format` rewrites in place (or prints a unified
+//! diff with `--diff`). Both accept positional paths and a `--stdin`
+//! flag for pipeline use. `--stdin` and path arguments are mutually
+//! exclusive via clap's `conflicts_with`.
 
 use std::path::PathBuf;
 
 use clap::Parser;
 
-#[derive(Parser)]
-#[command(name = "prose", version, about)]
+#[derive(Debug, Parser)]
+#[command(
+    about,
+    arg_required_else_help = true,
+    name = "prose",
+    propagate_version = true,
+    version
+)]
 pub enum Cli {
     /// Check files for formatting violations without rewriting.
-    Check { paths: Vec<PathBuf> },
+    Check(CheckArgs),
 
     /// Rewrite files to conform to the prose style.
-    Format {
-        /// Show a unified diff instead of writing changes.
-        #[arg(long)]
-        diff: bool,
+    Format(FormatArgs),
+}
 
-        paths: Vec<PathBuf>,
-    },
+#[derive(Debug, clap::Args)]
+pub struct CheckArgs {
+    /// One or more files or directories to check. Omit when using `--stdin`.
+    #[arg(conflicts_with = "stdin", value_name = "PATH")]
+    pub paths: Vec<PathBuf>,
+
+    /// Read source from stdin instead of the filesystem.
+    #[arg(long)]
+    pub stdin: bool,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct FormatArgs {
+    /// Show a unified diff instead of writing changes.
+    #[arg(long)]
+    pub diff: bool,
+
+    /// One or more files or directories to format. Omit when using `--stdin`.
+    #[arg(conflicts_with = "stdin", value_name = "PATH")]
+    pub paths: Vec<PathBuf>,
+
+    /// Read source from stdin instead of the filesystem.
+    #[arg(long)]
+    pub stdin: bool,
 }
 
 pub fn run() -> anyhow::Result<()> {
-    let subcommand = match Cli::parse() {
-        Cli::Check { .. } => "check",
-        Cli::Format { .. } => "format",
-    };
-    eprintln!("prose {subcommand}: not yet implemented");
+    match Cli::parse() {
+        Cli::Check(args) => check(args),
+        Cli::Format(args) => format(args),
+    }
+}
+
+fn check(_args: CheckArgs) -> anyhow::Result<()> {
+    eprintln!("prose check: not yet implemented");
     Ok(())
+}
+
+fn format(_args: FormatArgs) -> anyhow::Result<()> {
+    eprintln!("prose format: not yet implemented");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{error::ErrorKind, CommandFactory};
+
+    use super::*;
+
+    #[test]
+    fn check_parses_with_no_input_source() {
+        let cli = Cli::try_parse_from(["prose", "check"]).expect("parses");
+        let Cli::Check(args) = cli else {
+            panic!("expected Check variant");
+        };
+        assert!(args.paths.is_empty());
+        assert!(!args.stdin);
+    }
+
+    #[test]
+    fn check_parses_with_paths() {
+        let cli = Cli::try_parse_from(["prose", "check", "a.py", "b/"]).expect("parses");
+        let Cli::Check(args) = cli else {
+            panic!("expected Check variant");
+        };
+        assert_eq!(args.paths, [PathBuf::from("a.py"), PathBuf::from("b/")]);
+        assert!(!args.stdin);
+    }
+
+    #[test]
+    fn check_parses_with_stdin() {
+        let cli = Cli::try_parse_from(["prose", "check", "--stdin"]).expect("parses");
+        let Cli::Check(args) = cli else {
+            panic!("expected Check variant");
+        };
+        assert!(args.paths.is_empty());
+        assert!(args.stdin);
+    }
+
+    #[test]
+    fn check_rejects_paths_with_stdin() {
+        let err = Cli::try_parse_from(["prose", "check", "--stdin", "a.py"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn command_is_well_formed() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn command_version_matches_crate() {
+        assert_eq!(Cli::command().get_version(), Some(env!("CARGO_PKG_VERSION")));
+    }
+
+    #[test]
+    fn format_parses_with_diff_and_paths() {
+        let cli = Cli::try_parse_from(["prose", "format", "--diff", "a.py"]).expect("parses");
+        let Cli::Format(args) = cli else {
+            panic!("expected Format variant");
+        };
+        assert!(args.diff);
+        assert_eq!(args.paths, [PathBuf::from("a.py")]);
+        assert!(!args.stdin);
+    }
+
+    #[test]
+    fn format_parses_with_stdin() {
+        let cli = Cli::try_parse_from(["prose", "format", "--stdin"]).expect("parses");
+        let Cli::Format(args) = cli else {
+            panic!("expected Format variant");
+        };
+        assert!(args.paths.is_empty());
+        assert!(args.stdin);
+    }
+
+    #[test]
+    fn format_rejects_paths_with_stdin() {
+        let err = Cli::try_parse_from(["prose", "format", "--stdin", "a.py"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,17 +3,28 @@
 //! Every rule is independently toggleable. Defaults mirror the
 //! enabled-everywhere preset described in the README.
 
+use std::num::NonZeroUsize;
+
 use ruff_python_ast::PythonVersion;
 use serde::Deserialize;
 
+/// The `[tool.prose]` section of a user's `pyproject.toml`.
+///
+/// `None` on a field means the user did not set that key in their
+/// `pyproject.toml`; downstream consumers apply their own fallback
+/// rather than reading a synthesized default here.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
-    pub line_length: Option<usize>,
-    pub target_version: Option<PythonVersion>,
+    pub line_length: Option<NonZeroUsize>,
     pub rules: RuleToggles,
+    pub target_version: Option<PythonVersion>,
 }
 
+/// Per-rule on/off flags parsed from `[tool.prose.rules]`.
+///
+/// Every flag defaults to `true`. Users opt a rule out by setting it
+/// to `false` in their `pyproject.toml`.
 #[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct RuleToggles {

--- a/src/source.rs
+++ b/src/source.rs
@@ -18,6 +18,7 @@ use thiserror::Error;
 ///
 /// Holds the source text, the parsed AST, the token stream, and a lazy
 /// line index.
+#[derive(Debug)]
 pub struct Source {
     file: SourceFile,
     parsed: Parsed<ModModule>,
@@ -123,6 +124,15 @@ mod tests {
         let s = Source::from_str("").expect("empty source parses");
         assert_eq!(s.text(), "");
         assert!(s.ast().body.is_empty());
+    }
+
+    #[test]
+    fn from_path_bad_syntax_returns_parse_error() {
+        let tmp = tempfile::NamedTempFile::new().expect("temp file creates");
+        std::fs::write(tmp.path(), b"def foo(").expect("temp file writes");
+
+        let result = Source::from_path(tmp.path());
+        assert!(matches!(result, Err(SourceError::Parse(_))));
     }
 
     #[test]


### PR DESCRIPTION
### 🪻 Quick Summary

Wires the parse surface for *Prose*'s two subcommands, `check` and `format`, behind [`clap`](https://docs.rs/clap/latest/clap/)'s derive macros. Both accept positional paths and a `--stdin` flag for pipeline use, and `format` additionally takes `--diff`. Each subcommand prints `not yet implemented` and exits 0, so future rule-landing issues can drop real behavior into a working invocation flow without also having to design the CLI.

---

### 🗞️ Key Changes

- Adds a `Cli` enum with typed `Check(CheckArgs)` and `Format(FormatArgs)` payloads, dispatching to per-subcommand handler functions whose placeholder bodies print `not yet implemented` and exit 0

- Models `<PATH>...` and `--stdin` as mutually exclusive via clap's [`conflicts_with`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.conflicts_with), with `--diff` added to the format surface for the eventual unified-diff output

- Sets `propagate_version = true` so `prose check --version` and `prose format --version` also answer, plus `arg_required_else_help = true` so bare invocation prints help instead of a terse usage error

- Covers the parse surface with nine unit tests spanning path / stdin conflicts, empty invocations, the diff flag, a `clap::Command::debug_assert` sanity check, and an assertion pinning the command's version to `CARGO_PKG_VERSION`

- Strengthens `Config::line_length` to `Option<NonZeroUsize>` so zero is rejected at `toml::from_str` time rather than by a downstream validator, and alphabetizes `Config` fields to match the project's ordering convention

- Derives `Debug` on `Source` now that both `SourceFile` and `Parsed<ModModule>` impl it upstream, and adds `from_path_bad_syntax_returns_parse_error` covering the IO-succeeds-parse-fails arm the existing tests missed

---

### ☕ Implementation Notes

#### Parser on the Subcommand Enum

`Cli` itself derives `Parser` and each variant is a subcommand, rather than the more common `struct Cli { #[command(subcommand)] command: Command }` wrapper with `#[derive(Subcommand)]` on an inner enum. Clap has accepted this shape since 4.x. It drops a layer of indirection at the dispatch site (*`match Cli::parse() { ... }` instead of `match Cli::parse().command { ... }`*) and eliminates a struct whose only field was the subcommand.

---

### 🧵 Related Issues

- Closes #4
