### PR TITLE
[5] Add config loader for `[tool.prose]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,14 +644,17 @@ dependencies = [
  "anyhow",
  "clap",
  "fs-err",
+ "indoc",
  "insta",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",
  "ruff_text_size",
  "serde",
+ "serde_ignored",
  "tempfile",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -915,6 +927,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +947,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1015,6 +1046,47 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -1161,6 +1233,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,12 @@ ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10
 ruff_source_file   = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
 ruff_text_size     = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
 serde              = { version = "1.0", features = ["derive"] }
+serde_ignored      = "0.1"
 thiserror          = "2.0"
+toml               = "0.8"
 
 [dev-dependencies]
+indoc    = "2"
 insta    = { version = "1.39", features = ["glob", "yaml"] }
 tempfile = "3"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -118,7 +118,10 @@ mod tests {
 
     #[test]
     fn command_version_matches_crate() {
-        assert_eq!(Cli::command().get_version(), Some(env!("CARGO_PKG_VERSION")));
+        assert_eq!(
+            Cli::command().get_version(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,16 @@
 //! Parses the `[tool.prose]` section from `pyproject.toml`.
 //!
-//! Every rule is independently toggleable. Defaults mirror the
-//! enabled-everywhere preset described in the README.
+//! `Config::load` walks upward from a starting path toward the
+//! filesystem root, stopping at the first `pyproject.toml` that
+//! carries a `[tool.prose]` section. Reaching the root without a match
+//! resolves to full defaults, so *Prose* works on a fresh Python
+//! project with no configuration step.
 
-use std::num::NonZeroUsize;
+use std::{num::NonZeroUsize, path::Path};
 
 use ruff_python_ast::PythonVersion;
-use serde::Deserialize;
+use serde::{de::IntoDeserializer, Deserialize};
+use thiserror::Error;
 
 /// The `[tool.prose]` section of a user's `pyproject.toml`.
 ///
@@ -19,6 +23,66 @@ pub struct Config {
     pub line_length: Option<NonZeroUsize>,
     pub rules: RuleToggles,
     pub target_version: Option<PythonVersion>,
+}
+
+impl Config {
+    /// Walks upward from `from` and returns the first `[tool.prose]`
+    /// section found in a `pyproject.toml` along the way, or
+    /// `Config::default()` if no such section exists on the chain.
+    ///
+    /// Unknown keys under `[tool.prose]` are logged to stderr as
+    /// warnings and ignored, keeping the loader forward-compatible
+    /// with rules added in future releases.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigError::Io` if a `pyproject.toml` is found but
+    /// cannot be read, and `ConfigError::Toml` if its contents are not
+    /// valid TOML.
+    pub fn load<P: AsRef<Path>>(from: P) -> Result<Self, ConfigError> {
+        Self::load_with_warnings(from, |key| {
+            eprintln!("warning: unknown key `{key}` in [tool.prose]");
+        })
+    }
+
+    /// Shared implementation backing `load`, factored out so tests can
+    /// inspect the unknown-key callback without capturing stderr.
+    fn load_with_warnings<P, F>(from: P, mut on_unknown: F) -> Result<Self, ConfigError>
+    where
+        P: AsRef<Path>,
+        F: FnMut(&str),
+    {
+        let start = from.as_ref();
+        let initial = if start.is_dir() {
+            Some(start)
+        } else {
+            start.parent()
+        };
+
+        for dir in std::iter::successors(initial, |p| p.parent()) {
+            let candidate = dir.join("pyproject.toml");
+            match fs_err::read_to_string(&candidate) {
+                Ok(contents) => {
+                    if let Some(config) = parse_prose_section(&contents, &mut on_unknown)? {
+                        return Ok(config);
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        Ok(Self::default())
+    }
+}
+
+/// Failure to load a `[tool.prose]` configuration from a `pyproject.toml`.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Toml(#[from] toml::de::Error),
 }
 
 /// Per-rule on/off flags parsed from `[tool.prose.rules]`.
@@ -50,5 +114,158 @@ impl Default for RuleToggles {
             singleton_rule: true,
             strip_trailing_commas: true,
         }
+    }
+}
+
+fn parse_prose_section<F>(contents: &str, on_unknown: &mut F) -> Result<Option<Config>, ConfigError>
+where
+    F: FnMut(&str),
+{
+    let value: toml::Value = toml::from_str(contents)?;
+    let Some(prose) = value.get("tool").and_then(|t| t.get("prose")).cloned() else {
+        return Ok(None);
+    };
+
+    let config: Config = serde_ignored::deserialize(prose.into_deserializer(), |path| {
+        on_unknown(&path.to_string())
+    })?;
+
+    Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_pyproject(dir: &Path, contents: &str) {
+        std::fs::write(dir.join("pyproject.toml"), contents).expect("pyproject writes");
+    }
+
+    #[test]
+    fn load_absent_file_returns_defaults() {
+        let tmp = TempDir::new().expect("tempdir");
+        let config = Config::load(tmp.path()).expect("loads");
+
+        assert_eq!(config.line_length, None);
+        assert_eq!(config.target_version, None);
+        assert!(config.rules.align_equals);
+    }
+
+    #[test]
+    fn load_absent_prose_section_returns_defaults() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[project]\nname = \"x\"\n");
+
+        let config = Config::load(tmp.path()).expect("loads");
+
+        assert_eq!(config.line_length, None);
+        assert!(config.rules.align_equals);
+    }
+
+    #[test]
+    fn load_full_override() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(
+            tmp.path(),
+            indoc! {r#"
+                [tool.prose]
+                line-length = 100
+                target-version = "3.12"
+
+                [tool.prose.rules]
+                align-colons = false
+                align-equals = false
+                align-imports = false
+                alphabetize = false
+                match-case-align = false
+                one-per-line-collections = false
+                singleton-rule = false
+                strip-trailing-commas = false
+            "#},
+        );
+
+        let config = Config::load(tmp.path()).expect("loads");
+
+        assert_eq!(config.line_length, NonZeroUsize::new(100));
+        assert_eq!(config.target_version, Some(PythonVersion::PY312));
+        assert!(!config.rules.align_colons);
+        assert!(!config.rules.strip_trailing_commas);
+    }
+
+    #[test]
+    fn load_malformed_toml_returns_toml_error() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[this is not valid TOML");
+
+        let result = Config::load(tmp.path());
+
+        assert!(matches!(result, Err(ConfigError::Toml(_))));
+    }
+
+    #[test]
+    fn load_partial_override_preserves_other_rule_defaults() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
+
+        let config = Config::load(tmp.path()).expect("loads");
+
+        assert!(!config.rules.align_equals);
+        assert!(config.rules.align_colons);
+        assert!(config.rules.strip_trailing_commas);
+    }
+
+    #[test]
+    fn load_picks_nearest_ancestor_when_multiple_configs_exist() {
+        let tmp = TempDir::new().expect("tempdir");
+        let nested = tmp.path().join("a/b");
+        std::fs::create_dir_all(&nested).expect("nested dirs create");
+
+        write_pyproject(tmp.path(), "[tool.prose]\nline-length = 80\n");
+        write_pyproject(&nested, "[tool.prose]\nline-length = 120\n");
+
+        let config = Config::load(&nested).expect("loads");
+
+        assert_eq!(config.line_length, NonZeroUsize::new(120));
+    }
+
+    #[test]
+    fn load_rejects_malformed_target_version() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose]\ntarget-version = \"py310\"\n");
+
+        let result = Config::load(tmp.path());
+
+        assert!(matches!(result, Err(ConfigError::Toml(_))));
+    }
+
+    #[test]
+    fn load_unknown_key_invokes_callback() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(
+            tmp.path(),
+            "[tool.prose]\nunknown-future-key = \"whatever\"\n",
+        );
+
+        let mut captured = Vec::new();
+        let config = Config::load_with_warnings(tmp.path(), |key| captured.push(key.to_owned()))
+            .expect("loads");
+
+        assert_eq!(captured, ["unknown-future-key"]);
+        assert!(config.rules.align_equals);
+    }
+
+    #[test]
+    fn load_walks_up_to_ancestor_directory() {
+        let tmp = TempDir::new().expect("tempdir");
+        let nested = tmp.path().join("a/b/c");
+        std::fs::create_dir_all(&nested).expect("nested dirs create");
+        write_pyproject(tmp.path(), "[tool.prose]\nline-length = 120\n");
+
+        let config = Config::load(&nested).expect("loads");
+
+        assert_eq!(config.line_length, NonZeroUsize::new(120));
     }
 }


### PR DESCRIPTION
### 🪻 Quick Summary

Adds the `Config::load` loader that walks upward from a starting path, picks up the first `[tool.prose]` section it finds in a `pyproject.toml`, and resolves to full defaults when no match exists on the ancestor chain. Unknown keys under `[tool.prose]` log a warning via `serde_ignored` and fall through to the default, keeping the loader forward-compatible with rules added in future releases.

---

### 🗞️ Key Changes

- Adds `Config::load(from)` walking ancestors via `std::iter::successors` for the first `[tool.prose]` section, falling back to `Config::default()` when no match exists on the chain

- Adopts [`serde_ignored`](https://docs.rs/serde_ignored/latest/serde_ignored/) so unknown keys under `[tool.prose]` log a warning rather than fail parsing, with an internal `load_with_warnings(from, callback)` seam so tests can inspect the warning stream without capturing stderr

- Defines `ConfigError` with transparent `Io` and `Toml` variants mirroring `SourceError`, so malformed TOML surfaces as `ConfigError::Toml` with the upstream error intact

- Strengthens `line-length` and `target-version` to `Option<NonZeroUsize>` and `Option<PythonVersion>` so bad TOML values (*`line-length = 0`, `target-version = "py310"`*) fail at parse time rather than through a runtime validator

- Covers the loader with nine tests across absent, partial, full, malformed, unknown-key, nearest-ancestor, walk-up, and target-version-rejection paths

- Pins `serde_ignored = "0.1"` and `toml = "0.8"` as runtime deps. Adds `indoc = "2"` as a dev-dep for multi-line TOML fixtures that indent with their surrounding code

---

### ☕ Implementation Notes

#### Extracting the Subtable Before Deserializing

An earlier draft passed the full `pyproject.toml` through `serde_ignored::deserialize` as a [`toml::Deserializer`](https://docs.rs/toml/latest/toml/de/struct.Deserializer.html), expecting the callback to fire on unknown keys anywhere in the tree. It did not, because `toml 0.8`'s `Deserializer` and `serde_ignored` do not interact cleanly for nested-table paths, meaning unknown-key reports never emit. Extracting the `[tool.prose]` subtable from a parsed `toml::Value` and feeding that subtable into `serde_ignored` directly sidesteps the issue and gives callback paths that are already relative to the subtable (*`unknown-future-key` rather than `tool.prose.unknown-future-key`*).

---

### 🧵 Related Issues

- Closes #5
