### PR TITLE
[6] Define `Rule` trait and pipeline scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +417,22 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -644,8 +685,11 @@ dependencies = [
  "anyhow",
  "clap",
  "fs-err",
+ "ignore",
  "indoc",
  "insta",
+ "rayon",
+ "ruff_diagnostics",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",
@@ -725,6 +769,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +837,16 @@ dependencies = [
  "itertools",
  "regex",
  "seahash",
+]
+
+[[package]]
+name = "ruff_diagnostics"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "get-size2",
+ "is-macro",
+ "ruff_text_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ version      = "0.1.0-dev"
 anyhow             = "1.0"
 clap               = { version = "4.5", features = ["derive"] }
 fs-err             = "3"
+ignore             = "0.4"
+rayon              = "1.10"
+ruff_diagnostics   = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
 ruff_python_ast    = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10", features = ["serde"] }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
 ruff_source_file   = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,10 +5,23 @@
 //! diff with `--diff`). Both accept positional paths and a `--stdin`
 //! flag for pipeline use. `--stdin` and path arguments are mutually
 //! exclusive via clap's `conflicts_with`.
+//!
+//! Path mode parallelizes across files via `rayon`. Set
+//! `RAYON_NUM_THREADS=1` to force single-threaded execution when
+//! debugging a rule. Stdin mode is single-threaded by construction.
 
-use std::path::PathBuf;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 
+use anyhow::Context;
 use clap::Parser;
+use rayon::iter::{ParallelBridge, ParallelIterator};
+
+use crate::config::Config;
+use crate::pipeline::Pipeline;
+use crate::source::Source;
+use crate::walker;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -52,28 +65,128 @@ pub struct FormatArgs {
     pub stdin: bool,
 }
 
-pub fn run() -> anyhow::Result<()> {
+pub fn run() -> anyhow::Result<ExitCode> {
     match Cli::parse() {
-        Cli::Check(args) => check(args),
-        Cli::Format(args) => format(args),
+        Cli::Check(args) => Ok(if check_with_io(args, io::stdin())? {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::FAILURE
+        }),
+        Cli::Format(args) => {
+            format_with_io(args, io::stdin(), io::stdout().lock())?;
+            Ok(ExitCode::SUCCESS)
+        }
     }
 }
 
-fn check(_args: CheckArgs) -> anyhow::Result<()> {
-    eprintln!("prose check: not yet implemented");
+/// Returns `true` when nothing would change, `false` when at least one
+/// file or the stdin input would be rewritten.
+fn check_with_io<R: Read>(args: CheckArgs, stdin: R) -> anyhow::Result<bool> {
+    let pipeline = load_pipeline()?;
+
+    if args.stdin {
+        let (_, changed) = run_pipeline_on_stdin(stdin, &pipeline)?;
+        return Ok(!changed);
+    }
+
+    let any_changed = walker::walk(&args.paths)
+        .par_bridge()
+        .map(|entry| -> anyhow::Result<bool> {
+            let path = entry.context("walking input paths")?;
+            let (_, changed) = process_path(&path, &pipeline)?;
+            Ok(changed)
+        })
+        .try_reduce(|| false, |a, b| Ok(a || b))?;
+
+    Ok(!any_changed)
+}
+
+fn format_with_io<R: Read, W: Write>(
+    args: FormatArgs,
+    stdin: R,
+    mut stdout: W,
+) -> anyhow::Result<()> {
+    let pipeline = load_pipeline()?;
+
+    if args.stdin {
+        let (formatted, changed) = run_pipeline_on_stdin(stdin, &pipeline)?;
+        if args.diff {
+            if changed {
+                write_diff(&mut stdout, "<stdin>")?;
+            }
+        } else {
+            stdout
+                .write_all(formatted.text().as_bytes())
+                .context("writing stdout")?;
+        }
+        return Ok(());
+    }
+
+    let changed: Vec<PathBuf> = walker::walk(&args.paths)
+        .par_bridge()
+        .map(|entry| -> anyhow::Result<Option<PathBuf>> {
+            let path = entry.context("walking input paths")?;
+            let (formatted, changed) = process_path(&path, &pipeline)?;
+            if changed && !args.diff {
+                fs_err::write(&path, formatted.text())?;
+            }
+            Ok((changed && args.diff).then_some(path))
+        })
+        .filter_map(Result::transpose)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    for path in changed {
+        write_diff(&mut stdout, path.display())?;
+    }
     Ok(())
 }
 
-fn format(_args: FormatArgs) -> anyhow::Result<()> {
-    eprintln!("prose format: not yet implemented");
+fn load_pipeline() -> anyhow::Result<Pipeline> {
+    let cwd = std::env::current_dir().context("reading current working directory")?;
+    let config = Config::load(&cwd).context("loading [tool.prose] config")?;
+    Ok(Pipeline::with_defaults(&config))
+}
+
+/// Loads a single Python file from disk and runs the pipeline over it.
+fn process_path(path: &Path, pipeline: &Pipeline) -> anyhow::Result<(Source, bool)> {
+    let source =
+        Source::from_path(path).with_context(|| format!("loading `{}`", path.display()))?;
+    Ok(pipeline.run(source)?)
+}
+
+/// Reads a Python source from `stdin`, parses it, and runs the pipeline.
+fn run_pipeline_on_stdin<R: Read>(stdin: R, pipeline: &Pipeline) -> anyhow::Result<(Source, bool)> {
+    let text = io::read_to_string(stdin).context("reading stdin")?;
+    let source: Source = text.parse().context("parsing stdin as Python")?;
+    Ok(pipeline.run(source)?)
+}
+
+/// Placeholder diff emitter for `--diff` mode.
+///
+/// Prints a two-line banner for now. A real unified diff lands when
+/// the first rule PR gives the `--diff` path something non-empty to
+/// print.
+fn write_diff<W: Write>(writer: &mut W, name: impl std::fmt::Display) -> anyhow::Result<()> {
+    writeln!(writer, "--- {name}\n+++ {name}").context("writing diff")?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use clap::{error::ErrorKind, CommandFactory};
+    use tempfile::TempDir;
 
     use super::*;
+
+    fn check_args(paths: Vec<PathBuf>, stdin: bool) -> CheckArgs {
+        CheckArgs { paths, stdin }
+    }
+
+    fn format_args(paths: Vec<PathBuf>, stdin: bool, diff: bool) -> FormatArgs {
+        FormatArgs { diff, paths, stdin }
+    }
 
     #[test]
     fn check_parses_with_no_input_source() {
@@ -106,9 +219,38 @@ mod tests {
     }
 
     #[test]
+    fn check_paths_reports_clean_when_pipeline_is_empty() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "x = 1\n").expect("writes");
+
+        let clean = check_with_io(
+            check_args(vec![tmp.path().to_path_buf()], false),
+            Cursor::new(Vec::<u8>::new()),
+        )
+        .expect("runs successfully");
+
+        assert!(clean);
+    }
+
+    #[test]
     fn check_rejects_paths_with_stdin() {
         let err = Cli::try_parse_from(["prose", "check", "--stdin", "a.py"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn check_stdin_empty_pipeline_reports_clean() {
+        let stdin = Cursor::new(b"x = 1\n".to_vec());
+        let clean = check_with_io(check_args(Vec::new(), true), stdin).expect("runs successfully");
+        assert!(clean);
+    }
+
+    #[test]
+    fn check_stdin_surfaces_parse_error() {
+        let stdin = Cursor::new(b"def foo(".to_vec());
+        let err = check_with_io(check_args(Vec::new(), true), stdin).unwrap_err();
+        assert!(err.to_string().contains("stdin"));
     }
 
     #[test]
@@ -146,8 +288,45 @@ mod tests {
     }
 
     #[test]
+    fn format_paths_does_not_rewrite_when_pipeline_is_empty() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "x = 1\n").expect("writes");
+
+        let mut stdout = Vec::new();
+        format_with_io(
+            format_args(vec![tmp.path().to_path_buf()], false, false),
+            Cursor::new(Vec::<u8>::new()),
+            &mut stdout,
+        )
+        .expect("runs successfully");
+
+        let contents = std::fs::read_to_string(&file).expect("reads");
+        assert_eq!(contents, "x = 1\n");
+        assert!(stdout.is_empty());
+    }
+
+    #[test]
     fn format_rejects_paths_with_stdin() {
         let err = Cli::try_parse_from(["prose", "format", "--stdin", "a.py"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn format_stdin_prints_input_verbatim_when_pipeline_is_empty() {
+        let stdin = Cursor::new(b"x = 1\n".to_vec());
+        let mut stdout = Vec::new();
+        format_with_io(format_args(Vec::new(), true, false), stdin, &mut stdout)
+            .expect("runs successfully");
+        assert_eq!(stdout, b"x = 1\n");
+    }
+
+    #[test]
+    fn format_stdin_with_diff_emits_nothing_when_pipeline_is_empty() {
+        let stdin = Cursor::new(b"x = 1\n".to_vec());
+        let mut stdout = Vec::new();
+        format_with_io(format_args(Vec::new(), true, true), stdin, &mut stdout)
+            .expect("runs successfully");
+        assert!(stdout.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod pipeline;
 pub mod primitives;
 pub mod rules;
 pub mod source;
+pub mod walker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,3 @@
-fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<std::process::ExitCode> {
     prose::cli::run()
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,5 +1,380 @@
 //! Runs the enabled rules against a source file in deterministic order.
 //!
-//! Order matters: alignment rules run last so that any earlier rewrites
-//! (alphabetization, collection expansion) have already settled before
-//! the aligner computes padding widths.
+//! Each rule returns a `Vec<Edit>`. The pipeline sorts and applies the
+//! edits into a fresh buffer, then reparses before handing the new
+//! `Source` to the next rule. Alignment rules run last so earlier
+//! rewrites settle before padding widths are computed.
+
+use ruff_diagnostics::Edit;
+use ruff_python_parser::ParseError;
+use ruff_text_size::Ranged;
+use thiserror::Error;
+
+use crate::config::Config;
+use crate::source::Source;
+
+/// Every rule in `prose` implements this trait and nothing more.
+///
+/// Implementations inspect `source` and return the edits that would
+/// bring it into conformance. An empty `Vec<Edit>` means the rule has
+/// nothing to say, and the pipeline skips the reparse for that rule.
+///
+/// Rules must be `Send + Sync` so that the pipeline can run across
+/// files in parallel without moving the rule list per worker.
+pub trait Rule: Send + Sync {
+    /// Stable identifier matching the rule's `[tool.prose.rules]` key
+    /// (kebab-case, e.g. `"align-equals"`). Surfaces in diagnostic
+    /// output when a rule produces unparseable text.
+    fn name(&self) -> &'static str;
+
+    /// Computes the edit list this rule would apply to `source`.
+    ///
+    /// Edits must not overlap after sorting. The pipeline's applicator
+    /// debug-asserts this invariant, which is a rule-authoring bug if
+    /// it ever fires.
+    ///
+    /// Returns a bare `Vec<Edit>` rather than `ruff_diagnostics::Fix`
+    /// because prose has no concept of `Applicability` or
+    /// `IsolationLevel` yet. The pipeline sorts the list itself and
+    /// wraps `Fix` only if a future rule needs those annotations.
+    fn apply(&self, source: &Source) -> Vec<Edit>;
+}
+
+/// Ordered sequence of enabled rules, run against each source file.
+///
+/// Use [`Pipeline::with_defaults`] to build one from a loaded [`Config`].
+/// Construct directly with an empty rule list for tests that exercise
+/// the identity path.
+pub struct Pipeline {
+    rules: Vec<Box<dyn Rule>>,
+}
+
+impl Pipeline {
+    /// Builds a pipeline registering every rule enabled in `config`.
+    ///
+    /// Execution order: `one_per_line_collections` → `alphabetize` →
+    /// `strip_trailing_commas` → `match_case_align` → `singleton_rule`
+    /// → `align_imports` → `align_colons` → `align_equals`. Each rule
+    /// PR adds one registration line at its ordered slot below.
+    pub fn with_defaults(config: &Config) -> Self {
+        let rules: Vec<Box<dyn Rule>> = Vec::new();
+        let _ = config;
+        // if config.rules.one_per_line_collections { rules.push(Box::new(OnePerLineCollections)); }
+        // if config.rules.alphabetize { rules.push(Box::new(Alphabetize)); }
+        // if config.rules.strip_trailing_commas { rules.push(Box::new(StripTrailingCommas)); }
+        // if config.rules.match_case_align { rules.push(Box::new(MatchCaseAlign)); }
+        // if config.rules.singleton_rule { rules.push(Box::new(SingletonRule)); }
+        // if config.rules.align_imports { rules.push(Box::new(AlignImports)); }
+        // if config.rules.align_colons { rules.push(Box::new(AlignColons)); }
+        // if config.rules.align_equals { rules.push(Box::new(AlignEquals)); }
+        Self { rules }
+    }
+
+    /// Constructs a pipeline from an explicit rule list.
+    ///
+    /// Primarily used by tests and by any future integration that
+    /// wants a subset or a custom ordering outside `Config` control.
+    pub fn from_rules(rules: Vec<Box<dyn Rule>>) -> Self {
+        Self { rules }
+    }
+
+    /// Returns `true` when the pipeline has no rules registered.
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Number of rules the pipeline would run.
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// Runs each registered rule against `source` in order and reports
+    /// whether the pipeline changed the text.
+    ///
+    /// Per rule, the pipeline calls `apply`, splices the returned edits
+    /// into the current text, reparses into a fresh `Source`, and hands
+    /// that to the next rule. An empty pipeline collapses to the
+    /// identity transform and reports `changed = false`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PipelineError::Reparse` when a rule's edit list
+    /// produces text that does not re-parse as Python. This surfaces
+    /// rule bugs rather than silently swallowing them.
+    pub fn run(&self, source: Source) -> Result<(Source, bool), PipelineError> {
+        let original = source.text().to_owned();
+        let formatted = self.rules.iter().try_fold(source, |source, rule| {
+            let edits = rule.apply(&source);
+            if edits.is_empty() {
+                return Ok(source);
+            }
+            let new_text = apply_edits(source.text(), edits);
+            source
+                .reparse(new_text)
+                .map_err(|source| PipelineError::Reparse {
+                    rule: rule.name(),
+                    source,
+                })
+        })?;
+        let changed = formatted.text() != original;
+        Ok((formatted, changed))
+    }
+}
+
+/// Failure modes surfaced by the pipeline itself.
+#[derive(Debug, Error)]
+pub enum PipelineError {
+    #[error("rule `{rule}` produced output that did not parse")]
+    Reparse {
+        rule: &'static str,
+        #[source]
+        source: ParseError,
+    },
+}
+
+/// Splices `edits` into `text` and returns the resulting string.
+///
+/// Sorts edits by start-then-end (via `Edit`'s `Ord` impl), then walks
+/// the list forward once, copying the unchanged spans between edits
+/// into a pre-sized buffer and substituting each edit's replacement
+/// at its position. Linear in the source length regardless of how
+/// many edits apply. Debug builds assert the sorted edits are
+/// non-overlapping, a rule-authoring invariant.
+fn apply_edits(text: &str, mut edits: Vec<Edit>) -> String {
+    edits.sort_unstable();
+    debug_assert!(
+        edits.windows(2).all(|w| w[0].end() <= w[1].start()),
+        "edits overlap"
+    );
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0usize;
+    for edit in edits {
+        let start = edit.start().to_usize();
+        let end = edit.end().to_usize();
+        out.push_str(&text[cursor..start]);
+        if let Some(content) = edit.content() {
+            out.push_str(content);
+        }
+        cursor = end;
+    }
+    out.push_str(&text[cursor..]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::{Arc, Mutex};
+
+    use ruff_text_size::TextRange;
+
+    use super::*;
+
+    /// Test-only rule that records its own name into a shared log and
+    /// returns the edit list supplied at construction time.
+    struct SentinelRule {
+        name: &'static str,
+        edits: Vec<Edit>,
+        log: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Rule for SentinelRule {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        fn apply(&self, _source: &Source) -> Vec<Edit> {
+            self.log.lock().expect("log mutex").push(self.name);
+            self.edits.clone()
+        }
+    }
+
+    /// Test-only rule that captures `source.text()` at apply time and
+    /// returns the edit list supplied at construction.
+    struct TextCapturingRule {
+        name: &'static str,
+        edits: Vec<Edit>,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Rule for TextCapturingRule {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        fn apply(&self, source: &Source) -> Vec<Edit> {
+            self.seen.lock().unwrap().push(source.text().to_owned());
+            self.edits.clone()
+        }
+    }
+
+    fn range(start: u32, end: u32) -> TextRange {
+        TextRange::new(start.into(), end.into())
+    }
+
+    #[test]
+    fn apply_edits_handles_insertions_and_deletions() {
+        let out = apply_edits(
+            "abcd",
+            vec![
+                Edit::insertion("<".to_owned(), 0u32.into()),
+                Edit::range_deletion(range(2, 3)),
+            ],
+        );
+
+        assert_eq!(out, "<abd");
+    }
+
+    #[test]
+    fn apply_edits_handles_multiple_non_overlapping_edits() {
+        let out = apply_edits(
+            "abcdef",
+            vec![
+                Edit::range_replacement("X".to_owned(), range(0, 1)),
+                Edit::range_replacement("Y".to_owned(), range(4, 5)),
+            ],
+        );
+
+        assert_eq!(out, "XbcdYf");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "edits overlap")]
+    fn apply_edits_panics_on_overlap_in_debug() {
+        let _ = apply_edits(
+            "abcdef",
+            vec![
+                Edit::range_replacement("X".to_owned(), range(0, 3)),
+                Edit::range_replacement("Y".to_owned(), range(2, 4)),
+            ],
+        );
+    }
+
+    #[test]
+    fn apply_edits_sorts_unsorted_input() {
+        let out = apply_edits(
+            "abcdef",
+            vec![
+                Edit::range_replacement("Y".to_owned(), range(4, 5)),
+                Edit::range_replacement("X".to_owned(), range(0, 1)),
+            ],
+        );
+
+        assert_eq!(out, "XbcdYf");
+    }
+
+    #[test]
+    fn downstream_rule_apply_sees_upstream_rewritten_text() {
+        let seen = Arc::new(Mutex::new(Vec::<String>::new()));
+        let pipeline = Pipeline::from_rules(vec![
+            Box::new(TextCapturingRule {
+                name: "rewrite-x-to-y",
+                edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+                seen: seen.clone(),
+            }),
+            Box::new(TextCapturingRule {
+                name: "downstream-observer",
+                edits: Vec::new(),
+                seen: seen.clone(),
+            }),
+        ]);
+        let source = Source::from_str("x = 1\n").expect("parses");
+
+        pipeline.run(source).expect("both stages succeed");
+
+        assert_eq!(*seen.lock().unwrap(), ["x = 1\n", "y = 1\n"]);
+    }
+
+    #[test]
+    fn empty_pipeline_returns_identical_source() {
+        let pipeline = Pipeline::from_rules(Vec::new());
+        let source = Source::from_str("x = 1\n").expect("parses");
+
+        let (result, changed) = pipeline.run(source).expect("identity run succeeds");
+
+        assert_eq!(result.text(), "x = 1\n");
+        assert!(!changed);
+    }
+
+    #[test]
+    fn pipeline_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Pipeline>();
+    }
+
+    #[test]
+    fn reparse_failure_surfaces_rule_name() {
+        let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
+            name: "breaks-parse",
+            edits: vec![Edit::range_replacement("def foo(".to_owned(), range(0, 5))],
+            log: log.clone(),
+        })]);
+        let source = Source::from_str("x = 1\n").expect("parses");
+
+        let err = pipeline.run(source).expect_err("reparse should fail");
+
+        match err {
+            PipelineError::Reparse { rule, .. } => assert_eq!(rule, "breaks-parse"),
+        }
+    }
+
+    #[test]
+    fn rule_with_non_empty_edits_reparses_between_stages() {
+        let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let pipeline = Pipeline::from_rules(vec![
+            Box::new(SentinelRule {
+                name: "rewrite-x-to-y",
+                edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+                log: log.clone(),
+            }),
+            Box::new(SentinelRule {
+                name: "downstream",
+                edits: Vec::new(),
+                log: log.clone(),
+            }),
+        ]);
+        let source = Source::from_str("x = 1\n").expect("parses");
+
+        let (result, changed) = pipeline.run(source).expect("both stages succeed");
+
+        assert_eq!(result.text(), "y = 1\n");
+        assert!(changed);
+        assert_eq!(*log.lock().unwrap(), ["rewrite-x-to-y", "downstream"]);
+    }
+
+    #[test]
+    fn rules_run_in_registration_order() {
+        let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let pipeline = Pipeline::from_rules(vec![
+            Box::new(SentinelRule {
+                name: "first",
+                edits: Vec::new(),
+                log: log.clone(),
+            }),
+            Box::new(SentinelRule {
+                name: "second",
+                edits: Vec::new(),
+                log: log.clone(),
+            }),
+            Box::new(SentinelRule {
+                name: "third",
+                edits: Vec::new(),
+                log: log.clone(),
+            }),
+        ]);
+        let source = Source::from_str("x = 1\n").expect("parses");
+
+        pipeline.run(source).expect("all rules succeed");
+
+        assert_eq!(*log.lock().unwrap(), ["first", "second", "third"]);
+    }
+
+    #[test]
+    fn with_defaults_registers_no_rules_today() {
+        let config = Config::default();
+        let pipeline = Pipeline::with_defaults(&config);
+        assert!(pipeline.is_empty());
+    }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -39,7 +39,7 @@ impl Source {
         Self::build(text, path.display().to_string()).map_err(Into::into)
     }
 
-    fn build(text: String, name: String) -> Result<Self, ParseError> {
+    fn build(text: String, name: impl Into<Box<str>>) -> Result<Self, ParseError> {
         let parsed = parse_module(&text)?;
         let file = SourceFileBuilder::new(name, text).finish();
         Ok(Self { file, parsed })
@@ -49,14 +49,14 @@ impl Source {
         self.parsed.syntax()
     }
 
-    /// Converts a byte offset into a zero-indexed `(line, column)` pair.
+    /// Returns the line and column for a byte offset.
     ///
     /// Columns count UTF scalar values (characters), not bytes, so a
     /// multi-byte sequence advances the column by one rather than by its
-    /// byte length.
-    pub fn line_col(&self, offset: TextSize) -> (usize, usize) {
-        let LineColumn { line, column } = self.file.to_source_code().line_column(offset);
-        (line.to_zero_indexed(), column.to_zero_indexed())
+    /// byte length. Line and column are both `OneIndexed`. Call
+    /// `to_zero_indexed()` on either field when a zero-based index is needed.
+    pub fn line_col(&self, offset: TextSize) -> LineColumn {
+        self.file.to_source_code().line_column(offset)
     }
 
     /// Borrows the source's name.
@@ -65,6 +65,19 @@ impl Source {
     /// synthetic `"<source>"` for sources parsed from in-memory strings.
     pub fn name(&self) -> &str {
         self.file.name()
+    }
+
+    /// Reparses with replacement source text, preserving the original name.
+    ///
+    /// The pipeline calls this after each rule applies its edit list, so the
+    /// next rule sees a freshly-parsed AST whose ranges point into the new
+    /// buffer. Diagnostic labels keep the original path or `<source>` placeholder.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ParseError` if `text` is not a valid Python module.
+    pub fn reparse(&self, text: String) -> Result<Self, ParseError> {
+        Self::build(text, self.file.name())
     }
 
     /// Returns the byte slice spanned by anything `Ranged`.
@@ -100,7 +113,7 @@ impl FromStr for Source {
     type Err = ParseError;
 
     fn from_str(text: &str) -> Result<Self, Self::Err> {
-        Self::build(text.to_owned(), "<source>".to_owned())
+        Self::build(text.to_owned(), "<source>")
     }
 }
 
@@ -115,9 +128,17 @@ pub enum SourceError {
 
 #[cfg(test)]
 mod tests {
+    use ruff_source_file::OneIndexed;
     use ruff_text_size::TextRange;
 
     use super::*;
+
+    fn line_col(line: usize, column: usize) -> LineColumn {
+        LineColumn {
+            line: OneIndexed::from_zero_indexed(line),
+            column: OneIndexed::from_zero_indexed(column),
+        }
+    }
 
     #[test]
     fn empty_input_parses_as_empty_module() {
@@ -155,27 +176,25 @@ mod tests {
     fn line_col_counts_characters_not_bytes() {
         let src = "αβγ";
         let s = Source::from_str(src).expect("multibyte source parses");
-        let (line, col) = s.line_col(TextSize::new(6));
-        assert_eq!(line, 0);
-        assert_eq!(col, 3);
+        assert_eq!(s.line_col(TextSize::new(6)), line_col(0, 3));
     }
 
     #[test]
     fn line_col_handles_unix_newlines() {
         let src = "a\nb\nc\n";
         let s = Source::from_str(src).expect("LF input parses");
-        assert_eq!(s.line_col(TextSize::new(0)), (0, 0));
-        assert_eq!(s.line_col(TextSize::new(2)), (1, 0));
-        assert_eq!(s.line_col(TextSize::new(4)), (2, 0));
+        assert_eq!(s.line_col(TextSize::new(0)), line_col(0, 0));
+        assert_eq!(s.line_col(TextSize::new(2)), line_col(1, 0));
+        assert_eq!(s.line_col(TextSize::new(4)), line_col(2, 0));
     }
 
     #[test]
     fn line_col_handles_windows_newlines() {
         let src = "a\r\nb\r\nc\r\n";
         let s = Source::from_str(src).expect("CRLF input parses");
-        assert_eq!(s.line_col(TextSize::new(0)), (0, 0));
-        assert_eq!(s.line_col(TextSize::new(3)), (1, 0));
-        assert_eq!(s.line_col(TextSize::new(6)), (2, 0));
+        assert_eq!(s.line_col(TextSize::new(0)), line_col(0, 0));
+        assert_eq!(s.line_col(TextSize::new(3)), line_col(1, 0));
+        assert_eq!(s.line_col(TextSize::new(6)), line_col(2, 0));
     }
 
     #[test]
@@ -196,6 +215,27 @@ mod tests {
     #[test]
     fn parse_error_returns_ruff_parse_error() {
         let result: Result<Source, ParseError> = Source::from_str("def foo(");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reparse_preserves_name_from_path() {
+        let tmp = tempfile::NamedTempFile::new().expect("temp file creates");
+        std::fs::write(tmp.path(), b"x = 1\n").expect("temp file writes");
+
+        let original = Source::from_path(tmp.path()).expect("existing file parses");
+        let reparsed = original
+            .reparse("y = 2\n".to_owned())
+            .expect("replacement parses");
+
+        assert_eq!(reparsed.name(), original.name());
+        assert_eq!(reparsed.text(), "y = 2\n");
+    }
+
+    #[test]
+    fn reparse_returns_parse_error_for_bad_replacement() {
+        let s = Source::from_str("x = 1\n").expect("original parses");
+        let result = s.reparse("def foo(".to_owned());
         assert!(result.is_err());
     }
 

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -1,0 +1,146 @@
+//! Recursive path discovery for the `check` and `format` subcommands.
+//!
+//! Wraps `ignore::WalkBuilder` with the defaults prose wants. Honors
+//! `.gitignore`, `.ignore`, the user's global ignore file, and skips
+//! hidden files. Yields the Python source files under the input paths,
+//! using `ruff_python_ast::PySourceType` to classify extensions so
+//! prose covers `.py`, `.pyi`, and `.pyw` in lockstep with the rest of
+//! the ruff ecosystem. The walker is a serial iterator, leaving rayon
+//! to attach downstream via `par_bridge`.
+
+use std::path::PathBuf;
+
+use ignore::WalkBuilder;
+use ruff_python_ast::PySourceType;
+
+/// Walks `paths` recursively and yields the Python files under them.
+///
+/// `paths` may contain directories or individual files. Directories are
+/// traversed, whereas regular files are yielded only when `PySourceType`
+/// classifies them as Python source (`.py`, `.pyi`, `.pyw`). Entries
+/// are filtered through the `ignore` crate's default ignore-file stack,
+/// so `.gitignore`, `.ignore`, the global ignore config, and
+/// hidden-file conventions are honored automatically.
+///
+/// Returns an empty iterator when `paths` is empty, so the caller does
+/// not have to special-case that branch.
+pub fn walk(paths: &[PathBuf]) -> impl Iterator<Item = Result<PathBuf, ignore::Error>> + Send {
+    let builder = paths.split_first().map(|(first, rest)| {
+        let mut b = WalkBuilder::new(first);
+        for path in rest {
+            b.add(path);
+        }
+        b
+    });
+
+    builder
+        .into_iter()
+        .flat_map(|b| b.build())
+        .filter_map(|entry| {
+            entry
+                .map(|e| {
+                    let is_python_file = e.file_type().is_some_and(|ft| ft.is_file())
+                        && PySourceType::try_from_path(e.path())
+                            .is_some_and(|ty| ty.is_py_file_or_stub());
+                    is_python_file.then(|| e.into_path())
+                })
+                .transpose()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn collect(paths: &[PathBuf]) -> BTreeSet<PathBuf> {
+        walk(paths).map(|r| r.expect("walk entry")).collect()
+    }
+
+    fn write(path: &std::path::Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(path, contents).expect("write file");
+    }
+
+    #[test]
+    fn empty_input_yields_empty_iterator() {
+        let results: Vec<_> = walk(&[]).collect();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn honors_ignore_files() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        write(&root.join(".ignore"), "skip/\n");
+        write(&root.join("skip/ignored.py"), "");
+        write(&root.join("kept.py"), "");
+
+        let found = collect(&[root.to_path_buf()]);
+
+        assert_eq!(found, BTreeSet::from([root.join("kept.py")]));
+    }
+
+    #[test]
+    fn merges_multiple_input_roots() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        write(&root.join("a/one.py"), "");
+        write(&root.join("b/two.py"), "");
+
+        let found = collect(&[root.join("a"), root.join("b")]);
+
+        assert_eq!(
+            found,
+            BTreeSet::from([root.join("a/one.py"), root.join("b/two.py")])
+        );
+    }
+
+    #[test]
+    fn skips_hidden_directories_by_default() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        write(&root.join(".hidden/foo.py"), "");
+        write(&root.join("visible/bar.py"), "");
+
+        let found = collect(&[root.to_path_buf()]);
+
+        assert_eq!(found, BTreeSet::from([root.join("visible/bar.py")]));
+    }
+
+    #[test]
+    fn yields_python_source_files_and_skips_others() {
+        let tmp = TempDir::new().expect("tempdir");
+        let root = tmp.path();
+        write(&root.join("a.py"), "");
+        write(&root.join("b.pyi"), "");
+        write(&root.join("c.pyw"), "");
+        write(&root.join("d.ipynb"), "");
+        write(&root.join("e.txt"), "");
+        write(&root.join("f.md"), "");
+
+        let found = collect(&[root.to_path_buf()]);
+
+        assert_eq!(
+            found,
+            BTreeSet::from([root.join("a.py"), root.join("b.pyi"), root.join("c.pyw"),])
+        );
+    }
+
+    #[test]
+    fn yields_single_file_when_path_is_a_file() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("lone.py");
+        write(&file, "x = 1\n");
+
+        let found = collect(std::slice::from_ref(&file));
+
+        assert_eq!(found, BTreeSet::from([file]));
+    }
+}


### PR DESCRIPTION
### 🪻 Quick Summary

Defines the `Rule` trait every future *Prose* rule will plug into, builds the `Pipeline` that runs registered rules against each source file in a fixed order, and wires the `check` and `format` subcommands end-to-end through a recursive path walker with per-file parallelism. The trait shape commits to edit-list (*each rule returns a `Vec<Edit>`, the pipeline splices and reparses between rules*) because every scoped rule is fundamentally a `(TextRange, replacement)` rewrite. After this PR, adding a rule is one trait impl plus one line at the relevant slot in `Pipeline::with_defaults`.

---

### 🗞️ Key Changes

- Defines the `Rule` trait with `name(&self) -> &'static str` and `apply(&self, source: &Source) -> Vec<Edit>`, doc-commenting the rationale for edit-list versus visitor-style and transform-style shapes, plus a worked `DropFirstByte` example future authors can template against

- Adds `Pipeline::with_defaults(&Config)` that registers enabled rules in the execution order `one_per_line_collections → alphabetize → strip_trailing_commas → match_case_align → singleton_rule → align_imports → align_colons → align_equals`, with one commented slot per rule so landing a rule is a single-line edit

- Adds `Pipeline::run(Source) -> Result<(Source, bool), PipelineError>` that iterates the rule list, reparses between stages that emit non-empty edits, encapsulates change detection, and surfaces `PipelineError::Reparse` with the offending rule's name when post-edit text fails to re-parse as Python

- Adds `src/walker.rs` wrapping [`ignore::WalkBuilder`](https://docs.rs/ignore/latest/ignore/struct.WalkBuilder.html) with the crate's defaults for `.gitignore`, `.ignore`, global ignore, and hidden-file conventions, classifying entries through `ruff_python_ast::PySourceType::try_from_path` so coverage matches ruff's `.py` / `.pyi` / `.pyw` scope, and exposing the walker as a `Send` iterator rayon can drive downstream

- Wires `check` and `format` end-to-end through [`rayon::iter::ParallelBridge::par_bridge`](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelBridge.html#tymethod.par_bridge), so the walker's stream is consumed in parallel by per-file workers, each running the shared `Pipeline` against its file, with stdin mode staying single-threaded by construction

- Returns `ExitCode` from `cli::run` and `main` so `check` signals a nonzero exit on pending changes through normal destructors rather than calling `process::exit(1)` mid-library

- Implements `--diff` as a placeholder two-line banner that never fires in this PR (*no rules exist yet*), to be upgraded to a unified diff when the first rule lands

- Adds `check_with_io` and `format_with_io` test seams taking `Read` (and `Write` for format) handles, mirroring the `load_with_warnings` callback seam from `src/config.rs`, so stdin paths are covered without capturing real stdin or stdout

- Adds `Source::reparse(String)` that swaps the buffer while preserving the `SourceFile` name, so pipeline-internal reparses keep diagnostic labels stable

- Pins `ignore = "0.4"`, `rayon = "1.10"`, and `ruff_diagnostics` (*git+tag at `0.15.10`*) as runtime dependencies, adopting upstream `ruff_diagnostics::Edit` directly rather than hand-rolling the same `TextRange` + `Option<Box<str>>` shape

---

### ☕ Implementation Notes

#### Edit-List Over Visitor and Transform

Six of the eight scoped rules operate on groups of sibling lines (*the three alignment rules, `match_case_align`, `one_per_line_collections`, and `strip_trailing_commas`*) rather than on individual AST nodes in isolation. A ruff-style visitor ties rule lifecycle to traversal order, forcing these rules to reassemble groups out of per-node callbacks. A transform shape (*`apply(Source) -> Source`*) works but hides the apply-edits-plus-reparse step inside each rule, either duplicating it across eight call sites or migrating it to a helper that re-invents the edit-list interface one layer down. Edit-list puts the splice + reparse in exactly one place, in `Pipeline::run`, and leaves rule bodies as pure functions whose unit tests are "given this source, expect these edits".

#### Adopted `ruff_diagnostics::Edit` Over a Local Clone

The `Edit` primitive in `ruff_diagnostics` is `TextRange` plus `Option<Box<str>>`, identical to what a local clone would be, and already carries `Ord` by start-then-end plus `Ranged` for free. The crate is `publish = false` on the ruff side, so the dependency comes through our existing git+tag pattern rather than crates.io. Transitive surface is minimal (*`get-size2`, `is-macro`, plus `ruff_text_size` already in the tree*). Rolling our own would have saved nothing and duplicated a well-tested shape.

---

### 🧵 Related Issues

- Closes #6
