### PR TITLE
[7] Build `Aligner` primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde              = { version = "1.0", features = ["derive"] }
 serde_ignored      = "0.1"
 thiserror          = "2.0"
 toml               = "0.8"
+unicode-width      = "0.2"
 
 [dev-dependencies]
 indoc    = "2"

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ Tasks are defined in `mise.toml` and discoverable via `mise tasks`:
 | `mise review` | Interactively accept pending snapshot diffs |
 | `mise wheel` | Build the wheel and install into `.venv` |
 | `mise lint` | Run `clippy` with all warnings as errors |
-| `mise fmt` | Format Rust source with `rustfmt` |
+| `mise format` | Format Rust source with `rustfmt` |
+| `mise check` | Verify Rust source matches `rustfmt` without rewriting |
 | `mise ci` | Lint + test + wheel (full local sweep) |
 
 ### Editor

--- a/README.md
+++ b/README.md
@@ -192,11 +192,11 @@ mise install
 
 | Tool | Purpose |
 |---|---|
-| `rust` (stable) | Rust toolchain via rustup |
-| `python` (3.14) | Python interpreter for wheel builds |
-| `uv` | Python package and venv manager |
-| `maturin` | Rust → Python wheel builder |
 | `cargo-insta` | Snapshot test review |
+| `maturin` | Rust → Python wheel builder |
+| `python` (3.14) | Python interpreter for wheel builds |
+| `rust` (stable) | Rust toolchain via rustup |
+| `uv` | Python package and venv manager |
 
 ### Daily workflow
 
@@ -205,13 +205,13 @@ Tasks are defined in `mise.toml` and discoverable via `mise tasks`:
 | Command | What it does |
 |---|---|
 | `mise build` | Compile in debug mode |
-| `mise test` | Run all tests including `insta` snapshots |
-| `mise review` | Interactively accept pending snapshot diffs |
-| `mise wheel` | Build the wheel and install into `.venv` |
-| `mise lint` | Run `clippy` with all warnings as errors |
-| `mise format` | Format Rust source with `rustfmt` |
 | `mise check` | Verify Rust source matches `rustfmt` without rewriting |
 | `mise ci` | Lint + test + wheel (full local sweep) |
+| `mise format` | Format Rust source with `rustfmt` |
+| `mise lint` | Run `clippy` with all warnings as errors |
+| `mise review` | Interactively accept pending snapshot diffs |
+| `mise test` | Run all tests including `insta` snapshots |
+| `mise wheel` | Build the wheel and install into `.venv` |
 
 ### Editor
 

--- a/mise.toml
+++ b/mise.toml
@@ -20,17 +20,17 @@ python.uv_venv_auto = "create|source"
 description = "Build the prose binary in debug mode"
 run         = "cargo build"
 
-[tasks.ci]
-depends     = ["fmt-check", "lint", "test", "wheel"]
-description = "Full local CI: fmt-check, lint, test, build wheel"
-
-[tasks.fmt]
-description = "Format Rust source with rustfmt"
-run         = "cargo fmt --all"
-
-[tasks."fmt-check"]
+[tasks.check]
 description = "Verify Rust source matches rustfmt without rewriting"
 run         = "cargo fmt --all --check"
+
+[tasks.ci]
+depends     = ["check", "lint", "test", "wheel"]
+description = "Full local CI: check, lint, test, build wheel"
+
+[tasks.format]
+description = "Format Rust source with rustfmt"
+run         = "cargo fmt --all"
 
 [tasks.lint]
 description = "Run clippy with all warnings treated as errors"

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -1,0 +1,57 @@
+//! Computes per-line padding widths for alignment rules.
+//!
+//! `compute` is a stateless helper shared by `align_equals`,
+//! `align_colons`, `align_imports`, and `match_case_align`. Group
+//! boundaries stay rule-specific; only the padding math lives here.
+
+use unicode_width::UnicodeWidthStr;
+
+/// Returns the per-line padding widths that align a shared token.
+///
+/// The target column is `max(width(s))` across `befores`. Each returned
+/// padding is `target - width(s)`, leaving zero padding on the longest
+/// line. Widths use `unicode-width` conventions, so zero-width combining
+/// marks, CJK full-width, and East Asian ambiguous characters all
+/// contribute correctly.
+///
+/// Returns an empty `Vec` for empty input and `vec![0]` for a single
+/// item, leaving the singleton rule free to apply its own spacing.
+pub fn compute(befores: &[&str]) -> Vec<usize> {
+    let target = befores.iter().map(|s| s.width()).max().unwrap_or(0);
+    befores.iter().map(|s| target - s.width()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_pads_shorter_to_longest() {
+        assert_eq!(compute(&["a", "abc", "ab"]), vec![2, 0, 1]);
+    }
+
+    #[test]
+    fn cjk_counts_as_double_width() {
+        assert_eq!(compute(&["中", "ab", "a"]), vec![0, 0, 1]);
+    }
+
+    #[test]
+    fn combining_marks_are_zero_width() {
+        assert_eq!(compute(&["a\u{0301}", "ab"]), vec![1, 0]);
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert_eq!(compute(&[]), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn identical_widths_all_zero() {
+        assert_eq!(compute(&["ab", "cd", "ef"]), vec![0, 0, 0]);
+    }
+
+    #[test]
+    fn single_item_returns_zero() {
+        assert_eq!(compute(&["x"]), vec![0]);
+    }
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -3,3 +3,5 @@
 //! `aligner` computes padding widths for any group of lines that share
 //! an alignable token. `orderer` reshuffles sibling AST nodes and
 //! regenerates source for the alphabetization rules.
+
+pub mod aligner;


### PR DESCRIPTION
### 🪻 Quick Summary

Builds the shared alignment math that *Prose*'s alignment rules delegate to. `aligner::compute` takes a slice of before-token content strings and returns the per-line padding widths that land each line's token at a common column, using [`unicode-width`](https://docs.rs/unicode-width/latest/unicode_width/) conventions so zero-width combining marks, full-width CJK, and East Asian ambiguous characters all contribute correctly. `align_equals`, `align_colons`, `align_imports`, and `match_case_align` will each call this helper with their own grouped inputs. A `mise.toml` cleanup renames the rustfmt tasks so they stop colliding with mise's built-in `fmt` subcommand.

---

### 🗞️ Key Changes

- Adds `aligner::compute(befores: &[&str]) -> Vec<usize>` as a stateless free function in `src/primitives/aligner.rs`, computing the target column as `max(width)` across inputs and returning `target - width` per line with a two-pass iterator chain and no intermediate allocation beyond the returned `Vec`

- Pins `unicode-width = "0.2"` as a direct dependency, surfacing an already-transitive crate that `ruff_linter` and `ruff_formatter` both use for the same visual-width purpose, so no new compilation enters the build graph

- Covers the alignment-math edge cases with six inline unit tests: empty input, single item, multi-ASCII, identical widths, zero-width combining marks, and full-width CJK

- Renames `mise.toml` tasks `fmt` → `format` and `fmt-check` → `check`, updates the `ci` task's `depends` list and the `README.md` task table to match, and re-alphabetizes the task blocks

---

### ☕ Implementation Notes

#### `mise fmt` Shadow Avoidance

`mise fmt` is a built-in mise subcommand that rewrites `mise.toml` and strips its vertical `=` alignment. The previous `[tasks.fmt]` alias was silently shadowed, so invoking `mise fmt` reformatted the file rather than running `cargo fmt`. Renaming the tasks to `format` and `check` removes the collision, with `mise ci`'s depends list and the `README.md` table moving along.

---

### 🧵 Related Issues

- Closes #7
