### PR TITLE
[8] Implement `align_equals` rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,11 +1026,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1124,44 +1124,42 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -1315,9 +1313,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license      = "MIT"
 name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
-rust-version = "1.80"
+rust-version = "1.82"
 version      = "0.1.0-dev"
 
 [dependencies]
@@ -24,7 +24,7 @@ ruff_text_size     = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10
 serde              = { version = "1.0", features = ["derive"] }
 serde_ignored      = "0.1"
 thiserror          = "2.0"
-toml               = "0.8"
+toml               = "0.9"
 unicode-width      = "0.2"
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,10 +17,12 @@ use thiserror::Error;
 /// `None` on a field means the user did not set that key in their
 /// `pyproject.toml`; downstream consumers apply their own fallback
 /// rather than reading a synthesized default here.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
     pub line_length: Option<NonZeroUsize>,
+    pub max_align_shift: NonZeroUsize,
+    pub max_align_shift_policy: MaxAlignShiftPolicy,
     pub rules: RuleToggles,
     pub target_version: Option<PythonVersion>,
 }
@@ -52,14 +54,7 @@ impl Config {
         P: AsRef<Path>,
         F: FnMut(&str),
     {
-        let start = from.as_ref();
-        let initial = if start.is_dir() {
-            Some(start)
-        } else {
-            start.parent()
-        };
-
-        for dir in std::iter::successors(initial, |p| p.parent()) {
+        for dir in from.as_ref().ancestors() {
             let candidate = dir.join("pyproject.toml");
             match fs_err::read_to_string(&candidate) {
                 Ok(contents) => {
@@ -76,6 +71,18 @@ impl Config {
     }
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            line_length: None,
+            max_align_shift: NonZeroUsize::new(8).expect("8 is non-zero"),
+            max_align_shift_policy: MaxAlignShiftPolicy::default(),
+            rules: RuleToggles::default(),
+            target_version: None,
+        }
+    }
+}
+
 /// Failure to load a `[tool.prose]` configuration from a `pyproject.toml`.
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -83,6 +90,40 @@ pub enum ConfigError {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     Toml(#[from] toml::de::Error),
+}
+
+/// What to do when an alignment group's widest padding exceeds
+/// `max-align-shift`.
+///
+/// `Split` greedily partitions the group so each contiguous
+/// sub-group satisfies the cap, and each sub-group of size `>= 2`
+/// aligns independently. `Drop` excludes the widest member(s) from
+/// the padding calculation until the cap is satisfied, leaving those
+/// members at their original spacing while neighbors align around
+/// them. `Skip` leaves the entire group unaligned.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum MaxAlignShiftPolicy {
+    Drop,
+    Skip,
+    #[default]
+    Split,
+}
+
+fn parse_prose_section<F>(contents: &str, on_unknown: &mut F) -> Result<Option<Config>, ConfigError>
+where
+    F: FnMut(&str),
+{
+    let value: toml::Value = toml::from_str(contents)?;
+    let Some(prose) = value.get("tool").and_then(|t| t.get("prose")).cloned() else {
+        return Ok(None);
+    };
+
+    let config: Config = serde_ignored::deserialize(prose.into_deserializer(), |path| {
+        on_unknown(&path.to_string())
+    })?;
+
+    Ok(Some(config))
 }
 
 /// Per-rule on/off flags parsed from `[tool.prose.rules]`.
@@ -115,22 +156,6 @@ impl Default for RuleToggles {
             strip_trailing_commas: true,
         }
     }
-}
-
-fn parse_prose_section<F>(contents: &str, on_unknown: &mut F) -> Result<Option<Config>, ConfigError>
-where
-    F: FnMut(&str),
-{
-    let value: toml::Value = toml::from_str(contents)?;
-    let Some(prose) = value.get("tool").and_then(|t| t.get("prose")).cloned() else {
-        return Ok(None);
-    };
-
-    let config: Config = serde_ignored::deserialize(prose.into_deserializer(), |path| {
-        on_unknown(&path.to_string())
-    })?;
-
-    Ok(Some(config))
 }
 
 #[cfg(test)]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -11,6 +11,7 @@ use ruff_text_size::Ranged;
 use thiserror::Error;
 
 use crate::config::Config;
+use crate::rules::align_equals::AlignEquals;
 use crate::source::Source;
 
 /// Every rule in `prose` implements this trait and nothing more.
@@ -50,6 +51,14 @@ pub struct Pipeline {
 }
 
 impl Pipeline {
+    /// Constructs a pipeline from an explicit rule list.
+    ///
+    /// Primarily used by tests and by any future integration that
+    /// wants a subset or a custom ordering outside `Config` control.
+    pub fn from_rules(rules: Vec<Box<dyn Rule>>) -> Self {
+        Self { rules }
+    }
+
     /// Builds a pipeline registering every rule enabled in `config`.
     ///
     /// Execution order: `one_per_line_collections` → `alphabetize` →
@@ -57,8 +66,7 @@ impl Pipeline {
     /// → `align_imports` → `align_colons` → `align_equals`. Each rule
     /// PR adds one registration line at its ordered slot below.
     pub fn with_defaults(config: &Config) -> Self {
-        let rules: Vec<Box<dyn Rule>> = Vec::new();
-        let _ = config;
+        let mut rules: Vec<Box<dyn Rule>> = Vec::new();
         // if config.rules.one_per_line_collections { rules.push(Box::new(OnePerLineCollections)); }
         // if config.rules.alphabetize { rules.push(Box::new(Alphabetize)); }
         // if config.rules.strip_trailing_commas { rules.push(Box::new(StripTrailingCommas)); }
@@ -66,15 +74,9 @@ impl Pipeline {
         // if config.rules.singleton_rule { rules.push(Box::new(SingletonRule)); }
         // if config.rules.align_imports { rules.push(Box::new(AlignImports)); }
         // if config.rules.align_colons { rules.push(Box::new(AlignColons)); }
-        // if config.rules.align_equals { rules.push(Box::new(AlignEquals)); }
-        Self { rules }
-    }
-
-    /// Constructs a pipeline from an explicit rule list.
-    ///
-    /// Primarily used by tests and by any future integration that
-    /// wants a subset or a custom ordering outside `Config` control.
-    pub fn from_rules(rules: Vec<Box<dyn Rule>>) -> Self {
+        if config.rules.align_equals {
+            rules.push(Box::new(AlignEquals::from_config(config)));
+        }
         Self { rules }
     }
 
@@ -102,22 +104,27 @@ impl Pipeline {
     /// produces text that does not re-parse as Python. This surfaces
     /// rule bugs rather than silently swallowing them.
     pub fn run(&self, source: Source) -> Result<(Source, bool), PipelineError> {
-        let original = source.text().to_owned();
-        let formatted = self.rules.iter().try_fold(source, |source, rule| {
-            let edits = rule.apply(&source);
-            if edits.is_empty() {
-                return Ok(source);
-            }
-            let new_text = apply_edits(source.text(), edits);
-            source
-                .reparse(new_text)
-                .map_err(|source| PipelineError::Reparse {
-                    rule: rule.name(),
-                    source,
-                })
-        })?;
-        let changed = formatted.text() != original;
-        Ok((formatted, changed))
+        self.rules
+            .iter()
+            .try_fold((source, false), |(source, changed), rule| {
+                let edits = rule.apply(&source);
+                if edits.is_empty() {
+                    return Ok((source, changed));
+                }
+                let new_text = apply_edits(source.text(), edits);
+                debug_assert!(
+                    new_text != source.text(),
+                    "rule `{}` emitted edits that produced identical text",
+                    rule.name(),
+                );
+                source
+                    .reparse(new_text)
+                    .map(|src| (src, true))
+                    .map_err(|source| PipelineError::Reparse {
+                        rule: rule.name(),
+                        source,
+                    })
+            })
     }
 }
 
@@ -143,19 +150,15 @@ pub enum PipelineError {
 fn apply_edits(text: &str, mut edits: Vec<Edit>) -> String {
     edits.sort_unstable();
     debug_assert!(
-        edits.windows(2).all(|w| w[0].end() <= w[1].start()),
+        edits.is_sorted_by(|a, b| a.end() <= b.start()),
         "edits overlap"
     );
     let mut out = String::with_capacity(text.len());
     let mut cursor = 0usize;
     for edit in edits {
-        let start = edit.start().to_usize();
-        let end = edit.end().to_usize();
-        out.push_str(&text[cursor..start]);
-        if let Some(content) = edit.content() {
-            out.push_str(content);
-        }
-        cursor = end;
+        out.push_str(&text[cursor..edit.start().to_usize()]);
+        out.push_str(edit.content().unwrap_or_default());
+        cursor = edit.end().to_usize();
     }
     out.push_str(&text[cursor..]);
     out
@@ -173,9 +176,9 @@ mod tests {
     /// Test-only rule that records its own name into a shared log and
     /// returns the edit list supplied at construction time.
     struct SentinelRule {
-        name: &'static str,
         edits: Vec<Edit>,
         log: Arc<Mutex<Vec<&'static str>>>,
+        name: &'static str,
     }
 
     impl Rule for SentinelRule {
@@ -192,8 +195,8 @@ mod tests {
     /// Test-only rule that captures `source.text()` at apply time and
     /// returns the edit list supplied at construction.
     struct TextCapturingRule {
-        name: &'static str,
         edits: Vec<Edit>,
+        name: &'static str,
         seen: Arc<Mutex<Vec<String>>>,
     }
 
@@ -269,13 +272,13 @@ mod tests {
         let seen = Arc::new(Mutex::new(Vec::<String>::new()));
         let pipeline = Pipeline::from_rules(vec![
             Box::new(TextCapturingRule {
-                name: "rewrite-x-to-y",
                 edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+                name: "rewrite-x-to-y",
                 seen: seen.clone(),
             }),
             Box::new(TextCapturingRule {
-                name: "downstream-observer",
                 edits: Vec::new(),
+                name: "downstream-observer",
                 seen: seen.clone(),
             }),
         ]);
@@ -307,9 +310,9 @@ mod tests {
     fn reparse_failure_surfaces_rule_name() {
         let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
         let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
-            name: "breaks-parse",
             edits: vec![Edit::range_replacement("def foo(".to_owned(), range(0, 5))],
             log: log.clone(),
+            name: "breaks-parse",
         })]);
         let source = Source::from_str("x = 1\n").expect("parses");
 
@@ -321,47 +324,23 @@ mod tests {
     }
 
     #[test]
-    fn rule_with_non_empty_edits_reparses_between_stages() {
-        let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
-        let pipeline = Pipeline::from_rules(vec![
-            Box::new(SentinelRule {
-                name: "rewrite-x-to-y",
-                edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
-                log: log.clone(),
-            }),
-            Box::new(SentinelRule {
-                name: "downstream",
-                edits: Vec::new(),
-                log: log.clone(),
-            }),
-        ]);
-        let source = Source::from_str("x = 1\n").expect("parses");
-
-        let (result, changed) = pipeline.run(source).expect("both stages succeed");
-
-        assert_eq!(result.text(), "y = 1\n");
-        assert!(changed);
-        assert_eq!(*log.lock().unwrap(), ["rewrite-x-to-y", "downstream"]);
-    }
-
-    #[test]
     fn rules_run_in_registration_order() {
         let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
         let pipeline = Pipeline::from_rules(vec![
             Box::new(SentinelRule {
+                edits: Vec::new(),
+                log: log.clone(),
                 name: "first",
-                edits: Vec::new(),
-                log: log.clone(),
             }),
             Box::new(SentinelRule {
+                edits: Vec::new(),
+                log: log.clone(),
                 name: "second",
-                edits: Vec::new(),
-                log: log.clone(),
             }),
             Box::new(SentinelRule {
-                name: "third",
                 edits: Vec::new(),
                 log: log.clone(),
+                name: "third",
             }),
         ]);
         let source = Source::from_str("x = 1\n").expect("parses");
@@ -372,8 +351,31 @@ mod tests {
     }
 
     #[test]
-    fn with_defaults_registers_no_rules_today() {
+    fn run_reports_changed_when_a_rule_rewrites_text() {
+        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
+            edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+            log: Arc::new(Mutex::new(Vec::new())),
+            name: "rewrite-x-to-y",
+        })]);
+        let source = Source::from_str("x = 1\n").expect("parses");
+
+        let (result, changed) = pipeline.run(source).expect("rewrite succeeds");
+
+        assert_eq!(result.text(), "y = 1\n");
+        assert!(changed);
+    }
+
+    #[test]
+    fn with_defaults_registers_align_equals_when_enabled() {
         let config = Config::default();
+        let pipeline = Pipeline::with_defaults(&config);
+        assert_eq!(pipeline.len(), 1);
+    }
+
+    #[test]
+    fn with_defaults_respects_rule_toggle() {
+        let mut config = Config::default();
+        config.rules.align_equals = false;
         let pipeline = Pipeline::with_defaults(&config);
         assert!(pipeline.is_empty());
     }

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -1,24 +1,26 @@
 //! Computes per-line padding widths for alignment rules.
 //!
-//! `compute` is a stateless helper shared by `align_equals`,
-//! `align_colons`, `align_imports`, and `match_case_align`. Group
-//! boundaries stay rule-specific; only the padding math lives here.
-
-use unicode_width::UnicodeWidthStr;
+//! `compute` is a stateless helper for the alignment rules that do
+//! not track group min/max themselves: `align_colons`,
+//! `align_imports`, and `match_case_align`. `align_equals` inlines
+//! the padding math because its shift-limit policy already carries
+//! min and max in hand, so calling `compute` would re-scan for the
+//! max. Group boundaries stay rule-specific, leaving only the
+//! padding math here.
 
 /// Returns the per-line padding widths that align a shared token.
 ///
-/// The target column is `max(width(s))` across `befores`. Each returned
-/// padding is `target - width(s)`, leaving zero padding on the longest
-/// line. Widths use `unicode-width` conventions, so zero-width combining
-/// marks, CJK full-width, and East Asian ambiguous characters all
-/// contribute correctly.
+/// `widths` is the display width of each row's left-hand-side region
+/// (the text preceding the shared token). The target column is
+/// `max(widths)` and each returned padding is `target - widths[i]`,
+/// leaving zero padding on the widest row. Callers add any
+/// post-target spacing (typically one space) themselves.
 ///
 /// Returns an empty `Vec` for empty input and `vec![0]` for a single
 /// item, leaving the singleton rule free to apply its own spacing.
-pub fn compute(befores: &[&str]) -> Vec<usize> {
-    let target = befores.iter().map(|s| s.width()).max().unwrap_or(0);
-    befores.iter().map(|s| target - s.width()).collect()
+pub fn compute(widths: &[usize]) -> Vec<usize> {
+    let target = widths.iter().copied().max().unwrap_or(0);
+    widths.iter().map(|&w| target - w).collect()
 }
 
 #[cfg(test)]
@@ -26,18 +28,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ascii_pads_shorter_to_longest() {
-        assert_eq!(compute(&["a", "abc", "ab"]), vec![2, 0, 1]);
-    }
-
-    #[test]
-    fn cjk_counts_as_double_width() {
-        assert_eq!(compute(&["中", "ab", "a"]), vec![0, 0, 1]);
-    }
-
-    #[test]
-    fn combining_marks_are_zero_width() {
-        assert_eq!(compute(&["a\u{0301}", "ab"]), vec![1, 0]);
+    fn ascending_widths_pad_shorter_to_longest() {
+        assert_eq!(compute(&[1, 3, 2]), vec![2, 0, 1]);
     }
 
     #[test]
@@ -47,11 +39,11 @@ mod tests {
 
     #[test]
     fn identical_widths_all_zero() {
-        assert_eq!(compute(&["ab", "cd", "ef"]), vec![0, 0, 0]);
+        assert_eq!(compute(&[2, 2, 2]), vec![0, 0, 0]);
     }
 
     #[test]
     fn single_item_returns_zero() {
-        assert_eq!(compute(&["x"]), vec![0]);
+        assert_eq!(compute(&[5]), vec![0]);
     }
 }

--- a/src/rules/align_equals.rs
+++ b/src/rules/align_equals.rs
@@ -1,0 +1,291 @@
+//! Aligns the `=` character vertically within consecutive assignment
+//! groups.
+//!
+//! A group is a run of `Stmt::Assign` (single-target), `Stmt::AugAssign`,
+//! and `Stmt::AnnAssign` (with an initializer value) statements at the
+//! same block indentation on directly adjacent source lines. Any blank
+//! line, comment, or non-assignment statement breaks the group. The
+//! alignment target is the `=` character, meaning `+=` rows place
+//! their `+` one column before the shared `=` column rather than
+//! pushing the `=` right.
+//!
+//! Chained assignments (`a = b = 1`) carry two equals signs and are
+//! skipped. Annotated assignments without an initializer (`x: int`)
+//! are skipped because they have no `=` to align.
+//!
+//! A lone assignment, or any singleton sub-group produced by the
+//! shift-limit policy, still has its pre-`=` whitespace collapsed to
+//! a single space, matching the whitespace-normalization default for
+//! all `=` operators.
+//!
+//! When a group's widest padding exceeds `max_shift`, the configured
+//! policy takes over. `Split` greedily partitions the group so each
+//! contiguous sub-group satisfies the cap. `Drop` excludes the widest
+//! member(s) from alignment math while leaving their spacing
+//! untouched. `Skip` leaves the whole group alone.
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::statement_visitor::{walk_body, StatementVisitor};
+use ruff_python_ast::token::TokenKind;
+use ruff_python_ast::Stmt;
+use ruff_source_file::LineRanges;
+use ruff_text_size::{Ranged, TextRange, TextSize};
+use unicode_width::UnicodeWidthStr;
+
+use crate::config::{Config, MaxAlignShiftPolicy};
+use crate::pipeline::Rule;
+use crate::source::Source;
+
+pub struct AlignEquals {
+    max_shift: usize,
+    policy: MaxAlignShiftPolicy,
+}
+
+impl AlignEquals {
+    pub fn from_config(config: &Config) -> Self {
+        Self {
+            max_shift: config.max_align_shift.get(),
+            policy: config.max_align_shift_policy,
+        }
+    }
+}
+
+impl Default for AlignEquals {
+    fn default() -> Self {
+        Self::from_config(&Config::default())
+    }
+}
+
+impl Rule for AlignEquals {
+    fn name(&self) -> &'static str {
+        "align-equals"
+    }
+
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let mut visitor = Visitor {
+            edits: Vec::new(),
+            max_shift: self.max_shift,
+            policy: self.policy,
+            source,
+        };
+        visitor.visit_body(&source.ast().body);
+        visitor.edits
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Member {
+    /// Display-column width from `target.start()` up to the `=`.
+    effective_width: usize,
+    /// Whitespace between the effective-LHS region and the operator.
+    gap: TextRange,
+    /// Full source range of the originating statement, for adjacency checks.
+    stmt_range: TextRange,
+}
+
+struct Visitor<'a> {
+    edits: Vec<Edit>,
+    max_shift: usize,
+    policy: MaxAlignShiftPolicy,
+    source: &'a Source,
+}
+
+impl<'a> StatementVisitor<'a> for Visitor<'a> {
+    fn visit_body(&mut self, body: &'a [Stmt]) {
+        self.process_body(body);
+        walk_body(self, body);
+    }
+}
+
+impl<'a> Visitor<'a> {
+    /// Sort by width, then keep only members whose width is within
+    /// `max_shift` of the minimum. Retained members align among
+    /// themselves. Dropped members get no edit, leaving their
+    /// original spacing.
+    fn emit_drop(&mut self, members: &[Member]) {
+        let mut sorted = members.to_vec();
+        sorted.sort_unstable_by_key(|m| m.effective_width);
+        let Some(min) = sorted.first().map(|m| m.effective_width) else {
+            return;
+        };
+        let kept_end = sorted.partition_point(|m| m.effective_width <= min + self.max_shift);
+        let kept = &sorted[..kept_end];
+        if kept.len() < 2 {
+            return;
+        }
+        let max_w = kept.last().expect("kept non-empty").effective_width;
+        let paddings: Vec<usize> = kept.iter().map(|m| max_w - m.effective_width).collect();
+        self.emit_with_paddings(kept, &paddings);
+    }
+
+    fn emit_group(&mut self, members: &[Member]) {
+        let max_w = members.iter().map(|m| m.effective_width).max().unwrap_or(0);
+        let min_w = members.iter().map(|m| m.effective_width).min().unwrap_or(0);
+        if max_w - min_w <= self.max_shift {
+            let paddings: Vec<usize> = members.iter().map(|m| max_w - m.effective_width).collect();
+            self.emit_with_paddings(members, &paddings);
+            return;
+        }
+        match self.policy {
+            MaxAlignShiftPolicy::Skip => {}
+            MaxAlignShiftPolicy::Drop => self.emit_drop(members),
+            MaxAlignShiftPolicy::Split => self.emit_split(members),
+        }
+    }
+
+    /// Greedy partitioning: extend the current sub-group while its
+    /// widest padding stays under the cap, then start a new sub-group.
+    /// Each contiguous sub-group aligns independently. An outlier that
+    /// falls into a singleton sub-group collapses to a single space,
+    /// matching the whitespace-normalization default for lone `=`.
+    fn emit_split(&mut self, members: &[Member]) {
+        let mut cursor = 0;
+        while cursor < members.len() {
+            let mut min_w = members[cursor].effective_width;
+            let mut max_w = min_w;
+            let mut end = cursor + 1;
+            while end < members.len() {
+                let w = members[end].effective_width;
+                let new_min = min_w.min(w);
+                let new_max = max_w.max(w);
+                if new_max - new_min > self.max_shift {
+                    break;
+                }
+                min_w = new_min;
+                max_w = new_max;
+                end += 1;
+            }
+            let sub = &members[cursor..end];
+            let paddings: Vec<usize> = sub.iter().map(|m| max_w - m.effective_width).collect();
+            self.emit_with_paddings(sub, &paddings);
+            cursor = end;
+        }
+    }
+
+    fn emit_with_paddings(&mut self, members: &[Member], paddings: &[usize]) {
+        let source = self.source;
+        self.edits
+            .extend(members.iter().zip(paddings).filter_map(|(m, &p)| {
+                let target_len = 1 + p;
+                let gap_text = source.slice(m.gap);
+                let already_correct =
+                    gap_text.len() == target_len && gap_text.bytes().all(|b| b == b' ');
+                (!already_correct).then(|| Edit::range_replacement(" ".repeat(target_len), m.gap))
+            }));
+    }
+
+    /// Returns `true` when the gap between adjacent statements carries
+    /// exactly one logical or physical newline and no comment, meaning
+    /// the surrounding statements sit on directly adjacent source lines.
+    fn is_line_adjacent(&self, gap: TextRange) -> bool {
+        self.source
+            .tokens()
+            .in_range(gap)
+            .iter()
+            .try_fold(0usize, |n, t| match t.kind() {
+                k if k.is_comment() => None,
+                k if k.is_any_newline() => Some(n + 1),
+                _ => Some(n),
+            })
+            == Some(1)
+    }
+
+    fn process_body(&mut self, body: &[Stmt]) {
+        let mut iter = body.iter().peekable();
+        while let Some(stmt) = iter.next() {
+            let Some(first) = self.qualify(stmt) else {
+                continue;
+            };
+            let mut cursor_end = first.stmt_range.end();
+            let mut members = vec![first];
+            while let Some(next) = iter
+                .peek()
+                .and_then(|&s| self.qualify(s))
+                .filter(|m| self.is_line_adjacent(TextRange::new(cursor_end, m.stmt_range.start())))
+            {
+                cursor_end = next.stmt_range.end();
+                members.push(next);
+                iter.next();
+            }
+            self.emit_group(&members);
+        }
+    }
+
+    /// Returns the alignment member for `stmt` when it is a shape this
+    /// rule can rewrite, or `None` otherwise.
+    ///
+    /// Three AST shapes qualify. Plain `x = 1` (single-target
+    /// `Stmt::Assign`), augmented `x += 1` (`Stmt::AugAssign`), and
+    /// annotated `x: int = 1` (`Stmt::AnnAssign` with a value). For
+    /// each, the `effective_width` is the display-column distance from
+    /// `target.start()` to the `=` character, and the `gap` is the
+    /// whitespace the rule may rewrite. Returns `None` when the region
+    /// between `target.start()` and the `=` contains a line break,
+    /// since rewriting across a continuation would flatten the
+    /// author's multi-line layout.
+    fn qualify(&self, stmt: &Stmt) -> Option<Member> {
+        let text = self.source.text();
+        let tokens = self.source.tokens();
+        let (gap, effective_width) = match stmt {
+            Stmt::Assign(a) => {
+                let [target] = a.targets.as_slice() else {
+                    return None;
+                };
+                let target_range = target.range();
+                let equal = tokens
+                    .in_range(TextRange::new(target_range.end(), a.value.range().start()))
+                    .iter()
+                    .find(|t| t.kind() == TokenKind::Equal)?;
+                if text.contains_line_break(TextRange::new(target_range.start(), equal.start())) {
+                    return None;
+                }
+                (
+                    TextRange::new(target_range.end(), equal.start()),
+                    self.source.slice(target_range).width(),
+                )
+            }
+            Stmt::AugAssign(a) => {
+                let target_range = a.target.range();
+                let op = tokens
+                    .in_range(TextRange::new(target_range.end(), a.value.range().start()))
+                    .iter()
+                    .find(|t| t.kind().as_augmented_assign_operator().is_some())?;
+                let op_prefix = op.range().sub_end(TextSize::new(1));
+                if text.contains_line_break(TextRange::new(target_range.start(), op_prefix.end())) {
+                    return None;
+                }
+                (
+                    TextRange::new(target_range.end(), op.start()),
+                    self.source.slice(target_range).width() + op_prefix.len().to_usize(),
+                )
+            }
+            Stmt::AnnAssign(a) => {
+                let value = a.value.as_deref()?;
+                let target_range = a.target.range();
+                let annotation_range = a.annotation.range();
+                let equal = tokens
+                    .in_range(TextRange::new(
+                        annotation_range.end(),
+                        value.range().start(),
+                    ))
+                    .iter()
+                    .find(|t| t.kind() == TokenKind::Equal)?;
+                if text.contains_line_break(TextRange::new(target_range.start(), equal.start())) {
+                    return None;
+                }
+                (
+                    TextRange::new(annotation_range.end(), equal.start()),
+                    self.source
+                        .slice(target_range.cover(annotation_range))
+                        .width(),
+                )
+            }
+            _ => return None,
+        };
+        Some(Member {
+            effective_width,
+            gap,
+            stmt_range: stmt.range(),
+        })
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -2,3 +2,5 @@
 //!
 //! Each rule is added as its corresponding issue lands. Modules are
 //! declared here as they come online.
+
+pub mod align_equals;

--- a/tests/fixtures/align_equals/annotated.input.py
+++ b/tests/fixtures/align_equals/annotated.input.py
@@ -1,0 +1,10 @@
+"""
+Annotated assignment with an initializer (`x: int = 1`) participates
+in the group. The effective left-hand-side width extends through the
+annotation, so the `=` of `beta: int` aligns with the `=` of plain
+assignments alongside.
+"""
+
+alpha = 1
+beta: int = 2
+gamma_long = 3

--- a/tests/fixtures/align_equals/augmented.input.py
+++ b/tests/fixtures/align_equals/augmented.input.py
@@ -1,0 +1,9 @@
+"""
+Augmented assignment (`+=`) participates in the group. Its `=`
+character aligns with neighboring `=` operators, meaning the `+`
+sits one column before the shared `=` column.
+"""
+
+alpha = 1
+beta += 2
+gamma_long = 3

--- a/tests/fixtures/align_equals/basic.input.py
+++ b/tests/fixtures/align_equals/basic.input.py
@@ -1,0 +1,7 @@
+"""
+Three consecutive single-target assignments with varying LHS widths.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3

--- a/tests/fixtures/align_equals/blank_line.input.py
+++ b/tests/fixtures/align_equals/blank_line.input.py
@@ -1,0 +1,9 @@
+"""
+A blank line between two runs splits them into independent groups.
+"""
+
+alpha = 1
+beta = 2
+
+long_name = 3
+short = 4

--- a/tests/fixtures/align_equals/chained.input.py
+++ b/tests/fixtures/align_equals/chained.input.py
@@ -1,0 +1,6 @@
+"""
+Chained assignment (`a = b = 1`) carries two equals signs and is skipped.
+"""
+
+a = b = 1
+xx = 2

--- a/tests/fixtures/align_equals/cjk_target.input.py
+++ b/tests/fixtures/align_equals/cjk_target.input.py
@@ -1,0 +1,10 @@
+"""
+CJK identifiers count as two display columns per character. Padding
+math uses display columns, not bytes, so a two-character CJK target
+sits four columns wide and the rule lines up its `=` with ASCII
+neighbors by display position rather than by byte length.
+"""
+
+alpha = 1
+名前 = 2
+longer = 3

--- a/tests/fixtures/align_equals/continuation_before_equals.input.py
+++ b/tests/fixtures/align_equals/continuation_before_equals.input.py
@@ -1,0 +1,8 @@
+"""
+A backslash continuation between the target and the `=` sits out the
+group, leaving neighboring assignments unaligned.
+"""
+
+foo \
+    = 1
+bar = 2

--- a/tests/fixtures/align_equals/idempotent.input.py
+++ b/tests/fixtures/align_equals/idempotent.input.py
@@ -1,0 +1,7 @@
+"""
+An already-aligned group that the rule leaves untouched.
+"""
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/fixtures/align_equals/multi_line_target.input.py
+++ b/tests/fixtures/align_equals/multi_line_target.input.py
@@ -1,0 +1,11 @@
+"""
+A target that spans multiple lines leaves the group intact but the
+multi-line entry does not participate.
+"""
+
+alpha = 1
+(
+    x,
+    y,
+) = 2, 3
+beta = 4

--- a/tests/fixtures/align_equals/nested_blocks.input.py
+++ b/tests/fixtures/align_equals/nested_blocks.input.py
@@ -1,0 +1,18 @@
+"""
+Independent groups at module, function-body, and class-body scope.
+"""
+
+outer = 1
+answer = 42
+
+
+def foo():
+    x = 1
+    quux = 2
+    return x
+
+
+class Bar:
+    a = 1
+    bb = 2
+    ccc = 3

--- a/tests/fixtures/align_equals/shift_limit_split.input.py
+++ b/tests/fixtures/align_equals/shift_limit_split.input.py
@@ -1,0 +1,13 @@
+"""
+An outlier target partitions the group under the default `split`
+policy. Members above the outlier align among themselves, members
+below align among themselves, and the outlier falls to a singleton
+that collapses to one space. The two sub-groups settle on different
+`=` columns because each one's widest target is different.
+"""
+
+short = 1
+medium_size = 2
+really_really_long_target = 3
+longer = 4
+tiny = 5

--- a/tests/fixtures/align_equals/single_assignment.input.py
+++ b/tests/fixtures/align_equals/single_assignment.input.py
@@ -1,0 +1,6 @@
+"""
+A lone assignment collapses its pre-`=` whitespace to a single space,
+matching the whitespace-normalization default every `=` rule shares.
+"""
+
+solitary     = 1

--- a/tests/fixtures/align_equals/with_comments.input.py
+++ b/tests/fixtures/align_equals/with_comments.input.py
@@ -1,0 +1,9 @@
+"""
+A comment between two runs splits them into independent groups.
+"""
+
+alpha = 1
+beta = 2
+# break
+long_name = 3
+short = 4

--- a/tests/fixtures/align_equals_drop/shift_limit_drop.input.py
+++ b/tests/fixtures/align_equals_drop/shift_limit_drop.input.py
@@ -1,0 +1,12 @@
+"""
+Under the `drop` policy, an outlier is excluded from padding math
+but the group stays logically intact. Members above and below the
+outlier align against one shared `=` column, as if the outlier were
+invisible. The outlier itself keeps its original spacing.
+"""
+
+short = 1
+medium_size = 2
+really_really_long_target = 3
+longer = 4
+tiny = 5

--- a/tests/fixtures/align_equals_skip/shift_limit_skip.input.py
+++ b/tests/fixtures/align_equals_skip/shift_limit_skip.input.py
@@ -1,0 +1,11 @@
+"""
+Under the `skip` policy, a group whose widest padding would exceed
+`max-align-shift` stays entirely untouched, outlier and neighbors
+alike. No member's whitespace changes.
+"""
+
+short = 1
+medium_size = 2
+really_really_long_target = 3
+longer = 4
+tiny = 5

--- a/tests/fixtures/identity/basic.input.py
+++ b/tests/fixtures/identity/basic.input.py
@@ -1,1 +1,5 @@
+"""
+Seed harness proof that the empty pipeline is the identity transform.
+"""
+
 x = 1

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,8 +2,9 @@
 //!
 //! Each rule owns a subdirectory under `tests/fixtures/<rule>/`
 //! containing one or more `<case>.input.py` files. The expected
-//! transform output is an `insta` snapshot under `tests/snapshots/`
-//! that `cargo insta review` manages.
+//! transform output is an `insta` snapshot under the mirrored path
+//! `tests/snapshots/<rule>/<case>.input.py.snap` that `cargo insta
+//! review` manages.
 //!
 //! The `apply` dispatch below maps a fixture directory name to the
 //! transform to run. `identity` exists as the seed no-op used to prove
@@ -11,14 +12,33 @@
 //! merges.
 
 use std::ffi::OsStr;
+use std::path::PathBuf;
 
+use prose::config::{Config, MaxAlignShiftPolicy};
+use prose::pipeline::{Pipeline, Rule};
+use prose::rules::align_equals::AlignEquals;
 use prose::source::Source;
 
-fn apply(rule: &str, source: &Source) -> String {
-    match rule {
-        "identity" => source.text().to_owned(),
+fn align_equals_with(policy: MaxAlignShiftPolicy) -> AlignEquals {
+    let config = Config {
+        max_align_shift_policy: policy,
+        ..Config::default()
+    };
+    AlignEquals::from_config(&config)
+}
+
+fn apply(rule: &str, source: Source) -> String {
+    let rules: Vec<Box<dyn Rule>> = match rule {
+        "align_equals" => vec![Box::new(AlignEquals::default())],
+        "align_equals_drop" => vec![Box::new(align_equals_with(MaxAlignShiftPolicy::Drop))],
+        "align_equals_skip" => vec![Box::new(align_equals_with(MaxAlignShiftPolicy::Skip))],
+        "identity" => Vec::new(),
         other => panic!("no transform wired for fixture directory `{other}`"),
-    }
+    };
+    let (formatted, _) = Pipeline::from_rules(rules)
+        .run(source)
+        .expect("pipeline run succeeds on fixture input");
+    formatted.text().to_owned()
 }
 
 #[test]
@@ -29,9 +49,19 @@ fn fixtures() {
             .and_then(Path::file_name)
             .and_then(OsStr::to_str)
             .expect("fixture path has a parent directory name");
+        let case = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("fixture path has a file name");
 
         let source = Source::from_path(path).expect("fixture input reads and parses as Python");
 
-        insta::assert_snapshot!(apply(rule, &source));
+        insta::with_settings!({
+            snapshot_path => PathBuf::from("snapshots").join(rule),
+            prepend_module_to_snapshot => false,
+            snapshot_suffix => "",
+        }, {
+            insta::assert_snapshot!(case, apply(rule, source));
+        });
     });
 }

--- a/tests/snapshots/align_equals/annotated.input.py.snap
+++ b/tests/snapshots/align_equals/annotated.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/annotated.input.py
+---
+"""
+Annotated assignment with an initializer (`x: int = 1`) participates
+in the group. The effective left-hand-side width extends through the
+annotation, so the `=` of `beta: int` aligns with the `=` of plain
+assignments alongside.
+"""
+
+alpha      = 1
+beta: int  = 2
+gamma_long = 3

--- a/tests/snapshots/align_equals/augmented.input.py.snap
+++ b/tests/snapshots/align_equals/augmented.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/augmented.input.py
+---
+"""
+Augmented assignment (`+=`) participates in the group. Its `=`
+character aligns with neighboring `=` operators, meaning the `+`
+sits one column before the shared `=` column.
+"""
+
+alpha      = 1
+beta      += 2
+gamma_long = 3

--- a/tests/snapshots/align_equals/basic.input.py.snap
+++ b/tests/snapshots/align_equals/basic.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/basic.input.py
+---
+"""
+Three consecutive single-target assignments with varying LHS widths.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3

--- a/tests/snapshots/align_equals/blank_line.input.py.snap
+++ b/tests/snapshots/align_equals/blank_line.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/blank_line.input.py
+---
+"""
+A blank line between two runs splits them into independent groups.
+"""
+
+alpha = 1
+beta  = 2
+
+long_name = 3
+short     = 4

--- a/tests/snapshots/align_equals/chained.input.py.snap
+++ b/tests/snapshots/align_equals/chained.input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/chained.input.py
+---
+"""
+Chained assignment (`a = b = 1`) carries two equals signs and is skipped.
+"""
+
+a = b = 1
+xx = 2

--- a/tests/snapshots/align_equals/cjk_target.input.py.snap
+++ b/tests/snapshots/align_equals/cjk_target.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/cjk_target.input.py
+---
+"""
+CJK identifiers count as two display columns per character. Padding
+math uses display columns, not bytes, so a two-character CJK target
+sits four columns wide and the rule lines up its `=` with ASCII
+neighbors by display position rather than by byte length.
+"""
+
+alpha  = 1
+名前   = 2
+longer = 3

--- a/tests/snapshots/align_equals/continuation_before_equals.input.py.snap
+++ b/tests/snapshots/align_equals/continuation_before_equals.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/continuation_before_equals.input.py
+---
+"""
+A backslash continuation between the target and the `=` sits out the
+group, leaving neighboring assignments unaligned.
+"""
+
+foo \
+    = 1
+bar = 2

--- a/tests/snapshots/align_equals/idempotent.input.py.snap
+++ b/tests/snapshots/align_equals/idempotent.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/idempotent.input.py
+---
+"""
+An already-aligned group that the rule leaves untouched.
+"""
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/snapshots/align_equals/multi_line_target.input.py.snap
+++ b/tests/snapshots/align_equals/multi_line_target.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/multi_line_target.input.py
+---
+"""
+A target that spans multiple lines leaves the group intact but the
+multi-line entry does not participate.
+"""
+
+alpha = 1
+(
+    x,
+    y,
+) = 2, 3
+beta = 4

--- a/tests/snapshots/align_equals/nested_blocks.input.py.snap
+++ b/tests/snapshots/align_equals/nested_blocks.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/nested_blocks.input.py
+---
+"""
+Independent groups at module, function-body, and class-body scope.
+"""
+
+outer  = 1
+answer = 42
+
+
+def foo():
+    x    = 1
+    quux = 2
+    return x
+
+
+class Bar:
+    a   = 1
+    bb  = 2
+    ccc = 3

--- a/tests/snapshots/align_equals/shift_limit_split.input.py.snap
+++ b/tests/snapshots/align_equals/shift_limit_split.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/shift_limit_split.input.py
+---
+"""
+An outlier target partitions the group under the default `split`
+policy. Members above the outlier align among themselves, members
+below align among themselves, and the outlier falls to a singleton
+that collapses to one space. The two sub-groups settle on different
+`=` columns because each one's widest target is different.
+"""
+
+short       = 1
+medium_size = 2
+really_really_long_target = 3
+longer = 4
+tiny   = 5

--- a/tests/snapshots/align_equals/single_assignment.input.py.snap
+++ b/tests/snapshots/align_equals/single_assignment.input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/single_assignment.input.py
+---
+"""
+A lone assignment collapses its pre-`=` whitespace to a single space,
+matching the whitespace-normalization default every `=` rule shares.
+"""
+
+solitary = 1

--- a/tests/snapshots/align_equals/with_comments.input.py.snap
+++ b/tests/snapshots/align_equals/with_comments.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals/with_comments.input.py
+---
+"""
+A comment between two runs splits them into independent groups.
+"""
+
+alpha = 1
+beta  = 2
+# break
+long_name = 3
+short     = 4

--- a/tests/snapshots/align_equals_drop/shift_limit_drop.input.py.snap
+++ b/tests/snapshots/align_equals_drop/shift_limit_drop.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals_drop/shift_limit_drop.input.py
+---
+"""
+Under the `drop` policy, an outlier is excluded from padding math
+but the group stays logically intact. Members above and below the
+outlier align against one shared `=` column, as if the outlier were
+invisible. The outlier itself keeps its original spacing.
+"""
+
+short       = 1
+medium_size = 2
+really_really_long_target = 3
+longer      = 4
+tiny        = 5

--- a/tests/snapshots/align_equals_skip/shift_limit_skip.input.py.snap
+++ b/tests/snapshots/align_equals_skip/shift_limit_skip.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/align_equals_skip/shift_limit_skip.input.py
+---
+"""
+Under the `skip` policy, a group whose widest padding would exceed
+`max-align-shift` stays entirely untouched, outlier and neighbors
+alike. No member's whitespace changes.
+"""
+
+short = 1
+medium_size = 2
+really_really_long_target = 3
+longer = 4
+tiny = 5

--- a/tests/snapshots/identity/basic.input.py.snap
+++ b/tests/snapshots/identity/basic.input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: "apply(rule, source)"
+input_file: tests/fixtures/identity/basic.input.py
+---
+"""
+Seed harness proof that the empty pipeline is the identity transform.
+"""
+
+x = 1

--- a/tests/snapshots/integration__fixtures.snap
+++ b/tests/snapshots/integration__fixtures.snap
@@ -1,6 +1,0 @@
----
-source: tests/integration.rs
-expression: "apply(rule, &source)"
-input_file: tests/fixtures/identity/basic.input.py
----
-x = 1


### PR DESCRIPTION
### 🪻 Quick Summary

`AlignEquals` groups consecutive single-target, augmented, and annotated assignments at matching block indentation, then aligns their `=` columns via token-stream splicing. A `max-align-shift` cap gates the alignment math and falls through to `split`, `drop`, or `skip` behavior when a group's widest padding would exceed the threshold, preventing a single long target from pulling shorter neighbors across the line. The rule establishes the detect-group-compute-padding-splice pattern that every downstream alignment rule (#9, #10, #12) will reuse, and `Pipeline::run` gains a `changed` flag threaded through its fold so the pre-run buffer clone falls out.

---

### 🗞️ Key Changes

- Adds `AlignEquals` as an AST visitor that qualifies `Stmt::Assign` (*single-target*), `Stmt::AugAssign`, and `Stmt::AnnAssign` (*with an initializer*) statements at matching block indentation, groups adjacent-line members, and emits `Edit::range_replacement` on the pre-`=` gap after locating the `=` character through `Source`'s token stream

- Computes each row's effective left-hand-side width from `target.start()` to the `=` character via [`UnicodeWidthStr::width`](https://docs.rs/unicode-width/latest/unicode_width/trait.UnicodeWidthStr.html#tymethod.width), covering augmented-operator prefixes (*`+` for `+=`, `//` for `//=`*) and annotation spans (*`: int ` for `x: int = 1`*) so `+=` rows place their `+` one column before the shared `=` column rather than pushing it right

- Caps group padding at `max-align-shift` (*default `8`, roughly two Python indents*) and dispatches on `max-align-shift-policy` when the cap is exceeded. `split` greedily partitions the group so each contiguous sub-group satisfies the cap, `drop` excludes the widest members from padding math and leaves their spacing untouched, and `skip` leaves the whole group unaligned

- Refuses alignment when a line break sits between the target and the `=`, returning `None` from the per-statement qualifier so multi-line targets and backslash continuations break the enclosing group rather than flattening the author's layout

- Extends `Config` with `max_align_shift: NonZeroUsize` and `max_align_shift_policy: MaxAlignShiftPolicy` at the top level (*alignment policy is general, not align-equals-specific*), plus a `RuleToggles::align_equals` flag so users can opt the rule out under `[tool.prose.rules]`

- Registers `AlignEquals` at the final alignment slot in `Pipeline::with_defaults`, matching the execution-order comment that has `align_equals` running last so earlier rewrites settle before padding widths are computed

- Threads `changed` through `Pipeline::run`'s `try_fold` accumulator, replacing the upfront `source.text().to_owned()` clone and trailing string-equality check with a single boolean that flips to `true` when any rule's reparse succeeds, with a debug-only assertion catching any future rule that emits non-empty edits producing identical text

- Tightens `aligner::compute` to take `&[usize]` instead of `&[&str]`, moving width measurement to the caller so rules that already track widths can skip the re-measurement, with `align_colons`, `align_imports`, and `match_case_align` measuring via `UnicodeWidthStr::width` at their own call sites when they land

- Moves integration-test snapshots from one concatenated `.snap` file at the top of `tests/snapshots/` to per-case `<case>.input.py.snap` files under mirrored subdirectories (*`tests/snapshots/align_equals/`, `align_equals_drop/`, `align_equals_skip/`*) via `insta::with_settings!`, so each fixture's golden is independently diffable

- Lands fifteen fixtures under `align_equals/` covering basic grouping, idempotency, nested blocks, interleaved comments, blank-line breaks, chained-assignment skips, singleton normalization, augmented and annotated variants, multi-line targets, backslash continuations, split-policy outliers, and `cjk_target` for unicode-width coverage, plus one fixture each under `align_equals_drop/` and `align_equals_skip/` that the integration harness routes through `MaxAlignShiftPolicy` via the directory name

---

### ☕ Implementation Notes

#### Singleton Whitespace Normalization

The implementation normalizes the pre-`=` gap on every lone `=` row to a single space rather than skipping singletons as requirements 4 and 5 describe. Full rationale and the size-1 sub-group corollary under `split` policy in [this issue comment](https://github.com/Jybbs/prose/issues/8#issuecomment-4309765169).

#### `aligner::compute` Signature Change

The #7 landing shipped `aligner::compute(befores: &[&str]) -> Vec<usize>`, owning width measurement inside the primitive via `UnicodeWidthStr::width`. This PR tightens the signature to `aligner::compute(widths: &[usize]) -> Vec<usize>`, moving measurement to the caller. The trigger comes from `align_equals`'s shift-limit path. The rule already needs min and max effective widths to decide whether the cap is breached, so forcing it to hand `&[&str]` back to the primitive would just duplicate the max scan inside `compute`. The remaining three alignment rules (*`align_colons`, `align_imports`, `match_case_align`*) will measure via `UnicodeWidthStr::width` at their own call sites when they land, matching the primitive's one-pass math. `align_equals` itself does not end up calling `compute` in this PR, because the same inlining win applies inside `emit_group` and `emit_drop`. The primitive stays on the shelf for the three rules that will use it cleanly.

#### Snapshot Layout Reorganization

The prior layout emitted every fixture's golden into one concatenated `.snap` file at the top of `tests/snapshots/`. Drift on any one case forced a review of the whole file. This PR routes snapshots through `insta::with_settings!` with `snapshot_path => PathBuf::from("snapshots").join(rule)` and `snapshot_suffix => ""`, producing one `.snap` file per fixture under a subdirectory mirroring the fixture layout. `cargo insta review` now walks fixture-by-fixture pending diffs, and each golden is independently greppable.

---

### 🧵 Related Issues

- Closes #8
