### PR TITLE
[11] Implement `singleton_rule`

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -15,6 +15,7 @@ use crate::rules::align_colons::AlignColons;
 use crate::rules::align_equals::AlignEquals;
 use crate::rules::align_imports::AlignImports;
 use crate::rules::collection_layout::CollectionLayout;
+use crate::rules::singleton_rule::SingletonRule;
 use crate::source::Source;
 
 /// Every rule in `prose` implements this trait and nothing more.
@@ -59,14 +60,15 @@ impl Pipeline {
     /// Returns `None` when `name` does not match any registered rule.
     /// Bypasses each rule's `enabled` flag. Names are snake_case
     /// (`align_colons`, `align_equals`, `align_imports`,
-    /// `collection_layout`), not the kebab-case form returned by
-    /// [`Rule::name`].
+    /// `collection_layout`, `singleton_rule`), not the kebab-case form
+    /// returned by [`Rule::name`].
     pub fn for_rule(name: &str, config: &Config) -> Option<Self> {
         let rule: Box<dyn Rule> = match name {
             "align_colons" => Box::new(AlignColons::from_config(config)),
             "align_equals" => Box::new(AlignEquals::from_config(config)),
             "align_imports" => Box::new(AlignImports::from_config(config)),
             "collection_layout" => Box::new(CollectionLayout::from_config(config)),
+            "singleton_rule" => Box::new(SingletonRule::from_config(config)),
             _ => return None,
         };
         Some(Self::from_rules(vec![rule]))
@@ -83,8 +85,8 @@ impl Pipeline {
     /// Builds a pipeline registering every rule enabled in `config`.
     ///
     /// Execution order: `collection_layout` → `alphabetize` →
-    /// `strip_trailing_commas` → `match_case_align` → `singleton_rule`
-    /// → `align_imports` → `align_colons` → `align_equals`. Each rule
+    /// `strip_trailing_commas` → `match_case_align` → `align_imports`
+    /// → `align_colons` → `align_equals` → `singleton_rule`. Each rule
     /// PR adds one registration line at its ordered slot below.
     pub fn with_defaults(config: &Config) -> Self {
         let mut rules: Vec<Box<dyn Rule>> = Vec::new();
@@ -94,7 +96,6 @@ impl Pipeline {
         // if config.rules.alphabetize.enabled { rules.push(Box::new(Alphabetize)); }
         // if config.rules.strip_trailing_commas.enabled { rules.push(Box::new(StripTrailingCommas)); }
         // if config.rules.match_case_align.enabled { rules.push(Box::new(MatchCaseAlign)); }
-        // if config.rules.singleton_rule.enabled { rules.push(Box::new(SingletonRule)); }
         if config.rules.align_imports.enabled {
             rules.push(Box::new(AlignImports::from_config(config)));
         }
@@ -103,6 +104,9 @@ impl Pipeline {
         }
         if config.rules.align_equals.enabled {
             rules.push(Box::new(AlignEquals::from_config(config)));
+        }
+        if config.rules.singleton_rule.enabled {
+            rules.push(Box::new(SingletonRule::from_config(config)));
         }
         Self { rules }
     }
@@ -396,7 +400,7 @@ mod tests {
     fn with_defaults_registers_enabled_rules() {
         let config = Config::default();
         let pipeline = Pipeline::with_defaults(&config);
-        assert_eq!(pipeline.len(), 4);
+        assert_eq!(pipeline.len(), 5);
     }
 
     #[test]
@@ -406,6 +410,7 @@ mod tests {
         config.rules.align_equals.enabled = false;
         config.rules.align_imports.enabled = false;
         config.rules.collection_layout.enabled = false;
+        config.rules.singleton_rule.enabled = false;
         let pipeline = Pipeline::with_defaults(&config);
         assert!(pipeline.is_empty());
     }

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -1,6 +1,6 @@
 //! Computes padding widths and emits alignment edits for rules that
 //! align a shared token across a group of lines. `emit_group` is the
-//! entry point. Per-rule knobs travel through `Settings`; both
+//! entry point. Per-rule knobs travel through `Settings`, where both
 //! `align_colons` and `align_equals` use `suffix_len = 1`, leaving a
 //! one-space buffer before the aligned token.
 
@@ -20,10 +20,14 @@ use crate::source::Source;
 /// `width` is the display-column width of the row's left-hand-side
 /// region, from the start of the member to the start of the gap. `gap`
 /// is the whitespace range ending immediately before the aligned
-/// token that the rule will rewrite.
+/// token that the rule will rewrite. `line_start` is the offset of
+/// the start of the source line containing the gap, captured at
+/// construction time so [`distinct_lines`] can compare line identity
+/// without re-scanning the source.
 #[derive(Clone, Copy, Debug)]
 pub struct Member {
     pub gap: TextRange,
+    pub line_start: TextSize,
     pub width: usize,
 }
 
@@ -63,8 +67,7 @@ pub fn emit_group(source: &Source, members: &[Member], settings: Settings, edits
             (mn.min(m.width), mx.max(m.width))
         });
     if max_w - min_w <= settings.max_shift {
-        let paddings: Vec<usize> = members.iter().map(|m| max_w - m.width).collect();
-        emit_with_paddings(source, members, &paddings, settings.suffix_len, edits);
+        emit_with_paddings(source, members, max_w, settings.suffix_len, edits);
         return;
     }
     match settings.policy {
@@ -74,20 +77,20 @@ pub fn emit_group(source: &Source, members: &[Member], settings: Settings, edits
     }
 }
 
-/// Rewrites each member's gap to `suffix_len + paddings[i]` spaces,
-/// skipping members whose gap already carries that exact width of
-/// ASCII spaces. Emits `Edit::deletion` when the target width is
-/// zero and the current gap is non-empty, since `Edit::range_replacement`
-/// rejects empty content. Parallel-slice API: `members.len() == paddings.len()`.
+/// Rewrites each member's gap to `suffix_len + (max_w - m.width)`
+/// spaces, skipping members whose gap already carries that exact
+/// width of ASCII spaces. Emits `Edit::deletion` when the target
+/// width is zero and the current gap is non-empty, because
+/// `Edit::range_replacement` rejects empty content.
 fn emit_with_paddings(
     source: &Source,
     members: &[Member],
-    paddings: &[usize],
+    max_w: usize,
     suffix_len: usize,
     edits: &mut Vec<Edit>,
 ) {
-    edits.extend(members.iter().zip(paddings).filter_map(|(m, &p)| {
-        let target_len = suffix_len + p;
+    edits.extend(members.iter().filter_map(|m| {
+        let target_len = suffix_len + (max_w - m.width);
         let gap_text = source.slice(m.gap);
         let already_correct = gap_text.len() == target_len && gap_text.bytes().all(|b| b == b' ');
         if already_correct {
@@ -120,6 +123,7 @@ pub fn line_anchored_member(source: &Source, anchor: TextSize) -> Member {
     let gap_start = line_start + TextSize::of(trimmed_end);
     Member {
         gap: TextRange::new(gap_start, anchor),
+        line_start,
         width: trimmed_end.trim_whitespace_start().width(),
     }
 }
@@ -127,7 +131,7 @@ pub fn line_anchored_member(source: &Source, anchor: TextSize) -> Member {
 /// Builds a `Member` for a row whose aligned token sits at `anchor`,
 /// with width measured by the display width of `target` plus
 /// `extra_width`. Pass `extra_width = 0` when the LHS is exactly
-/// `target` (e.g. `x = 1`); pass a non-zero value when the LHS
+/// `target` (e.g. `x = 1`), and pass a non-zero value when the LHS
 /// visually extends past `target` by characters not covered by the
 /// slice (e.g. the `+` of `x += 1` widens the LHS by one column
 /// without being part of the target range).
@@ -139,8 +143,19 @@ pub fn range_anchored_member(
 ) -> Member {
     Member {
         gap: TextRange::new(target.end(), anchor),
+        line_start: source.text().line_start(anchor),
         width: source.slice(target).width() + extra_width,
     }
+}
+
+/// Returns `true` when every member's aligned token sits on a
+/// distinct source line. Two `:`-anchored members on the same line
+/// have no column to align to, so rules that align across lines key
+/// off this predicate to decide whether alignment applies.
+pub fn distinct_lines(members: &[Member]) -> bool {
+    members
+        .windows(2)
+        .all(|w| w[0].line_start != w[1].line_start)
 }
 
 /// Builds a `Member` whose anchor is the first token of `kind` within
@@ -153,9 +168,7 @@ pub fn line_anchored_member_at_kind(
     search: TextRange,
     kind: TokenKind,
 ) -> Option<Member> {
-    let anchor = source
-        .first_token_in_range(search, |t| t.kind() == kind)
-        .map(Token::start)?;
+    let anchor = source.first_token_offset_in_range(search, |t| t.kind() == kind)?;
     Some(line_anchored_member(source, anchor))
 }
 
@@ -175,9 +188,7 @@ pub fn range_anchored_member_single_line<F>(
 where
     F: FnMut(&Token) -> bool,
 {
-    let anchor = source
-        .first_token_in_range(search, predicate)
-        .map(Token::start)?;
+    let anchor = source.first_token_offset_in_range(search, predicate)?;
     if source
         .text()
         .contains_line_break(TextRange::new(target.start(), anchor))
@@ -208,13 +219,14 @@ where
 
 /// Generalization of [`line_adjacent_groups`] for rules that admit
 /// more than one member shape. The qualifier returns `Option<(K, M)>`
-/// where `K` tags the shape; a run extends only while the next member
-/// shares both the active key and line-adjacency. A key change at an
-/// otherwise-adjacent boundary closes the active run and starts a
-/// fresh one without losing the boundary statement, which keeps
+/// where `K` tags the shape, and a run extends only while the next
+/// member shares both the active key and line-adjacency. A key change
+/// at an otherwise-adjacent boundary closes the active run and starts
+/// a fresh one without losing the boundary statement, which keeps
 /// `align_imports` from mixing `from`-import members with
 /// `import M as A` members in a single group. Walks `body` exactly
-/// once and calls `is_line_adjacent` at most once per gap.
+/// once and calls `is_line_adjacent` at most once per qualifying
+/// statement.
 pub fn keyed_line_adjacent_groups<'a, K, M, F>(
     source: &'a Source,
     body: &'a [Stmt],
@@ -225,31 +237,24 @@ where
     F: FnMut(&'a Stmt) -> Option<(K, M)>,
 {
     let mut groups: Vec<Vec<M>> = Vec::new();
-    let mut active: Option<(K, Vec<M>, TextSize)> = None;
+    let mut active: Option<(K, TextSize)> = None;
     for stmt in body {
-        let stmt_range = stmt.range();
-        active = match (qualify(stmt), active) {
-            (Some((key, member)), Some((active_key, mut members, last_end))) => {
-                if active_key == key
-                    && is_line_adjacent(source, TextRange::new(last_end, stmt_range.start()))
-                {
-                    members.push(member);
-                    Some((active_key, members, stmt_range.end()))
-                } else {
-                    groups.push(members);
-                    Some((key, vec![member], stmt_range.end()))
-                }
-            }
-            (Some((key, member)), None) => Some((key, vec![member], stmt_range.end())),
-            (None, Some((_, members, _))) => {
-                groups.push(members);
-                None
-            }
-            (None, None) => None,
+        let Some((key, member)) = qualify(stmt) else {
+            active = None;
+            continue;
         };
-    }
-    if let Some((_, members, _)) = active {
-        groups.push(members);
+        let extends = active.as_ref().is_some_and(|(active_key, last_end)| {
+            active_key == &key && is_line_adjacent(source, TextRange::new(*last_end, stmt.start()))
+        });
+        if extends {
+            groups
+                .last_mut()
+                .expect("active implies groups non-empty")
+                .push(member);
+        } else {
+            groups.push(vec![member]);
+        }
+        active = Some((key, stmt.end()));
     }
     groups
 }
@@ -271,8 +276,7 @@ fn emit_drop(source: &Source, members: &[Member], settings: Settings, edits: &mu
         return;
     }
     let max_w = kept.last().expect("kept non-empty").width;
-    let paddings: Vec<usize> = kept.iter().map(|m| max_w - m.width).collect();
-    emit_with_paddings(source, kept, &paddings, settings.suffix_len, edits);
+    emit_with_paddings(source, kept, max_w, settings.suffix_len, edits);
 }
 
 /// Greedy partitioning: extends the current sub-group while its
@@ -297,8 +301,7 @@ fn emit_split(source: &Source, members: &[Member], settings: Settings, edits: &m
             end += 1;
         }
         let sub = &members[cursor..end];
-        let paddings: Vec<usize> = sub.iter().map(|m| max_w - m.width).collect();
-        emit_with_paddings(source, sub, &paddings, settings.suffix_len, edits);
+        emit_with_paddings(source, sub, max_w, settings.suffix_len, edits);
         cursor = end;
     }
 }
@@ -330,6 +333,7 @@ mod tests {
         let mut text = String::new();
         let mut members = Vec::new();
         for &(width, gap_chars) in specs {
+            let line_start = u32::try_from(text.len()).expect("test source fits in u32");
             for _ in 0..width {
                 text.push('x');
             }
@@ -341,6 +345,7 @@ mod tests {
             text.push_str("= 0\n");
             members.push(Member {
                 gap: TextRange::new(TextSize::new(gap_start), TextSize::new(gap_end)),
+                line_start: TextSize::new(line_start),
                 width,
             });
         }
@@ -507,11 +512,10 @@ mod tests {
         let (source, members) = rows(&[(3, 4)]);
         let mut edits = Vec::new();
 
-        emit_with_paddings(&source, &members, &[0], 0, &mut edits);
+        // max_w == m.width → padding = 0, suffix_len = 0 → target_len = 0
+        // → must emit deletion (range_replacement rejects empty content).
+        emit_with_paddings(&source, &members, members[0].width, 0, &mut edits);
 
-        // target_len = 0 + 0 → must emit deletion (range_replacement
-        // rejects empty content). Deletion has no content, so the
-        // summary's content slot is the empty string.
         assert_eq!(edits.len(), 1);
         assert_eq!(
             summary(&edits[0]),
@@ -528,7 +532,9 @@ mod tests {
         let (source, members) = rows(&[(3, 1)]);
         let mut edits = Vec::new();
 
-        emit_with_paddings(&source, &members, &[0], 1, &mut edits);
+        // max_w == m.width → padding = 0, suffix_len = 1 → target_len = 1.
+        // The fabricated gap is one space already, so emit nothing.
+        emit_with_paddings(&source, &members, members[0].width, 1, &mut edits);
 
         assert!(
             edits.is_empty(),

--- a/src/primitives/colon_targets.rs
+++ b/src/primitives/colon_targets.rs
@@ -1,0 +1,173 @@
+//! Member constructors for the four `:` alignment contexts: dict
+//! items, Pydantic-style class fields, annotated function parameters,
+//! and Google/numpy docstring `Args:` entries. `align_colons` consumes
+//! these to align multi-item groups, whereas `singleton_rule` consumes
+//! the same shapes to strip pre-colon padding from singleton groups.
+
+use ruff_python_ast::token::TokenKind;
+use ruff_python_ast::{AnyParameterRef, DictItem, ExprDict, ExprStringLiteral, Parameters, Stmt};
+use ruff_python_trivia::PythonWhitespace;
+use ruff_source_file::UniversalNewlines;
+use ruff_text_size::{Ranged, TextRange, TextSize};
+
+use crate::primitives::aligner;
+use crate::source::Source;
+
+/// Builds an alignment member for a class-body annotated assignment,
+/// anchored on the `:` between target and annotation. Returns `None`
+/// for any other statement shape.
+pub fn class_field(source: &Source, stmt: &Stmt) -> Option<aligner::Member> {
+    let ann = stmt.as_ann_assign_stmt()?;
+    aligner::line_anchored_member_at_kind(
+        source,
+        TextRange::new(ann.target.end(), ann.annotation.start()),
+        TokenKind::Colon,
+    )
+}
+
+/// Walks `body`, qualifying each statement through `class_field`,
+/// and returns one group per run of contiguous line-adjacent
+/// annotated-assignment statements.
+pub fn class_field_groups(source: &Source, body: &[Stmt]) -> Vec<Vec<aligner::Member>> {
+    aligner::line_adjacent_groups(source, body, |s| class_field(source, s))
+}
+
+/// Builds an alignment member for a `key: value` dict entry, anchored
+/// on the `:` between key and value. Returns `None` for `**spread`
+/// entries that have no key.
+pub fn dict_item(source: &Source, item: &DictItem) -> Option<aligner::Member> {
+    let key = item.key.as_ref()?;
+    aligner::line_anchored_member_at_kind(
+        source,
+        TextRange::new(key.end(), item.value.start()),
+        TokenKind::Colon,
+    )
+}
+
+/// Returns one alignment member per `key: value` entry in `d`.
+/// `**spread` entries (no key) contribute nothing.
+pub fn dict_members(source: &Source, d: &ExprDict) -> Vec<aligner::Member> {
+    d.iter()
+        .filter_map(|item| dict_item(source, item))
+        .collect()
+}
+
+/// Returns one alignment member per entry in the body's leading
+/// docstring's `Args:` section. Returns an empty `Vec` when the body
+/// has no leading docstring, when the docstring is implicitly
+/// concatenated, or when the docstring carries no `Args:` header.
+/// An entry is any line whose first non-whitespace content runs up
+/// to a `:` before the line ends. Continuation lines, blank lines,
+/// and the next section header end the block.
+pub fn docstring_args(source: &Source, body: &[Stmt]) -> Vec<aligner::Member> {
+    let Some(string_literal) = body
+        .first()
+        .and_then(Stmt::as_expr_stmt)
+        .and_then(|s| s.value.as_string_literal_expr())
+        .and_then(ExprStringLiteral::as_single_part_string)
+    else {
+        return Vec::new();
+    };
+    let ds_range = string_literal.range();
+    let text = source.slice(ds_range);
+    let Some((header_offset, header_indent_len)) = find_args_header(text) else {
+        return Vec::new();
+    };
+
+    let mut members = Vec::new();
+    let mut entry_indent_len: Option<usize> = None;
+    let after_header = header_offset + "Args:".len();
+    for line in text[after_header..].universal_newlines().skip(1) {
+        let content = line.as_str();
+        let stripped = content.trim_whitespace_start();
+        let line_indent_len = content.len() - stripped.len();
+
+        if stripped.is_empty() || line_indent_len <= header_indent_len {
+            break;
+        }
+
+        let expected = *entry_indent_len.get_or_insert(line_indent_len);
+        if line_indent_len > expected {
+            continue;
+        }
+        if line_indent_len < expected {
+            break;
+        }
+
+        if let Some(colon_rel) = find_entry_colon(stripped) {
+            let line_offset = TextSize::try_from(after_header + line_indent_len + colon_rel)
+                .expect("docstring colon offset fits in TextSize");
+            let colon_start = ds_range.start() + line.start() + line_offset;
+            members.push(aligner::line_anchored_member(source, colon_start));
+        }
+    }
+    members
+}
+
+/// Builds an alignment member for an annotated function parameter,
+/// anchored on the `:` between name and annotation. Returns `None` for
+/// unannotated parameters, signaling a group break to callers.
+pub fn parameter(source: &Source, param: AnyParameterRef<'_>) -> Option<aligner::Member> {
+    let annotation = param.annotation()?;
+    aligner::line_anchored_member_at_kind(
+        source,
+        TextRange::new(param.name().end(), annotation.start()),
+        TokenKind::Colon,
+    )
+}
+
+/// Walks `params` in source order and returns one group per run of
+/// contiguous annotated parameters, splitting at every unannotated
+/// parameter (*the `self`/`cls` boundary, positional-only and
+/// keyword-only separators when bare, anything else without an
+/// annotation*).
+pub fn parameter_groups(source: &Source, params: &Parameters) -> Vec<Vec<aligner::Member>> {
+    let optional: Vec<Option<aligner::Member>> = params
+        .iter_source_order()
+        .map(|p| parameter(source, p))
+        .collect();
+    optional
+        .split(Option::is_none)
+        .map(|run| run.iter().flatten().copied().collect())
+        .collect()
+}
+
+/// Returns `(byte_offset_of_args, line_indent_len)` for the first
+/// `Args:` section header, which means a line whose first
+/// non-whitespace content is exactly `Args:` followed only by
+/// whitespace. The indent length is the byte count of leading
+/// whitespace on the header's line, surfaced so callers can compare
+/// subsequent entry-line indents without recomputing.
+fn find_args_header(body: &str) -> Option<(usize, usize)> {
+    body.universal_newlines().find_map(|line| {
+        let content = line.as_str();
+        let stripped = content.trim_whitespace_start();
+        let after = stripped.strip_prefix("Args:")?;
+        after.trim_whitespace().is_empty().then(|| {
+            let indent_len = content.len() - stripped.len();
+            (line.start().to_usize() + indent_len, indent_len)
+        })
+    })
+}
+
+/// Finds the byte offset of the `:` within a docstring entry line's
+/// post-indent content. The pre-colon region may include the argument
+/// name and an optional parenthesized type (e.g. `x (int)`). Returns
+/// `None` when the line does not look like an entry.
+fn find_entry_colon(stripped: &str) -> Option<usize> {
+    let bytes = stripped.as_bytes();
+    let &first = bytes.first()?;
+    if !(first.is_ascii_alphabetic() || first == b'_' || first == b'*') {
+        return None;
+    }
+    let mut paren_depth = 0usize;
+    for (cursor, &b) in bytes.iter().enumerate() {
+        match b {
+            b'(' | b'[' => paren_depth += 1,
+            b')' | b']' => paren_depth = paren_depth.saturating_sub(1),
+            b':' if paren_depth == 0 => return Some(cursor),
+            _ => {}
+        }
+    }
+    None
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,6 +1,9 @@
 //! Shared primitives used across rule implementations. `aligner`
-//! emits alignment edits for groups sharing a token. `locator` lifts
-//! position helpers over `Source`.
+//! emits alignment edits for groups sharing a token. `colon_targets`
+//! constructs alignment members at every `:` context the alignment
+//! and singleton rules consume. `locator` lifts position helpers over
+//! `Source`.
 
 pub mod aligner;
+pub mod colon_targets;
 pub mod locator;

--- a/src/rules/align_colons.rs
+++ b/src/rules/align_colons.rs
@@ -5,19 +5,15 @@
 //! downstream. Each aligned `:` keeps a one-space buffer before the
 //! colon.
 
-use std::cmp::Ordering;
-
 use ruff_diagnostics::Edit;
-use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::{walk_expr, walk_parameters, walk_stmt, Visitor as AstVisitor};
-use ruff_python_ast::{AnyParameterRef, Expr, ExprDict, Parameters, Stmt};
-use ruff_python_trivia::{CommentRanges, PythonWhitespace};
-use ruff_source_file::{LineRanges, UniversalNewlines};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_python_ast::{Expr, ExprDict, Parameters, Stmt};
+use ruff_python_trivia::CommentRanges;
+use ruff_text_size::Ranged;
 
 use crate::config::Config;
 use crate::pipeline::Rule;
-use crate::primitives::aligner;
+use crate::primitives::{aligner, colon_targets};
 use crate::source::Source;
 
 pub struct AlignColons {
@@ -57,146 +53,33 @@ struct Visitor<'a> {
 }
 
 impl Visitor<'_> {
-    fn class_field_member(&self, stmt: &Stmt) -> Option<aligner::Member> {
-        let ann = stmt.as_ann_assign_stmt()?;
-        aligner::line_anchored_member_at_kind(
-            self.source,
-            TextRange::new(ann.target.end(), ann.annotation.start()),
-            TokenKind::Colon,
-        )
-    }
-
-    /// Returns `true` when every member's colon sits on a distinct
-    /// source line. The `line_start`-anchored width math requires this
-    /// so two members do not share a prefix region. The colon's
-    /// position is recoverable as `gap.end()` because `lhs_info`
-    /// constructs the gap with the colon as its end.
-    fn distinct_lines(&self, members: &[aligner::Member]) -> bool {
-        let text = self.source.text();
-        members
-            .windows(2)
-            .all(|w| text.line_start(w[0].gap.end()) != text.line_start(w[1].gap.end()))
-    }
-
-    /// Walks the source lines spanned by a docstring's text range,
-    /// locates the first `Args:` header, and returns one alignment
-    /// member per entry line in the subsequent indented block. An
-    /// entry is any line whose first non-whitespace content runs up
-    /// to a `:` before the line ends. Continuation lines, blank
-    /// lines, and the next section header end the block.
-    fn docstring_args_members(&self, ds_range: TextRange) -> Vec<aligner::Member> {
-        let body = self.source.slice(ds_range);
-        let Some(header_offset) = find_args_header(body) else {
-            return Vec::new();
-        };
-        let header_indent_len = body[..header_offset]
-            .rsplit_once('\n')
-            .map_or(header_offset, |(_, last)| last.len());
-
-        let mut members = Vec::new();
-        let mut entry_indent_len: Option<usize> = None;
-        let after_header = header_offset + "Args:".len();
-        for line in body[after_header..].universal_newlines().skip(1) {
-            let content = line.as_str();
-            let stripped = content.trim_whitespace_start();
-            let line_indent_len = content.len() - stripped.len();
-
-            if stripped.is_empty() || line_indent_len <= header_indent_len {
-                break;
-            }
-
-            match entry_indent_len {
-                None => entry_indent_len = Some(line_indent_len),
-                Some(expected) => match line_indent_len.cmp(&expected) {
-                    Ordering::Greater => continue,
-                    Ordering::Less => break,
-                    Ordering::Equal => {}
-                },
-            }
-
-            if let Some(colon_rel) = find_entry_colon(stripped) {
-                let line_offset = TextSize::try_from(after_header + line_indent_len + colon_rel)
-                    .expect("docstring colon offset fits in TextSize");
-                let colon_start = ds_range.start() + line.start() + line_offset;
-                members.push(aligner::line_anchored_member(self.source, colon_start));
-            }
-        }
-        members
-    }
-
     /// Emits alignment edits for a qualifying group of members.
     fn emit(&mut self, members: &[aligner::Member]) {
-        if members.len() < 2 || !self.distinct_lines(members) {
+        if members.len() < 2 || !aligner::distinct_lines(members) {
             return;
         }
         aligner::emit_group(self.source, members, self.settings, &mut self.edits);
     }
 
-    /// Builds an alignment member from a single annotated parameter,
-    /// or returns `None` to signal a group break.
-    fn parameter_member(&self, param_ref: AnyParameterRef<'_>) -> Option<aligner::Member> {
-        let annotation = param_ref.annotation()?;
-        aligner::line_anchored_member_at_kind(
-            self.source,
-            TextRange::new(param_ref.name().end(), annotation.start()),
-            TokenKind::Colon,
-        )
-    }
-
-    /// Processes consecutive `AnnAssign` statements in a class body,
-    /// grouping them by line adjacency through the shared
-    /// `aligner::line_adjacent_groups` primitive.
     fn process_class_fields(&mut self, body: &[Stmt]) {
-        for members in
-            aligner::line_adjacent_groups(self.source, body, |s| self.class_field_member(s))
-        {
-            self.emit(&members);
+        for group in colon_targets::class_field_groups(self.source, body) {
+            self.emit(&group);
         }
     }
 
     fn process_dict(&mut self, d: &ExprDict) {
-        if d.items.len() < 2 || self.comment_ranges.intersects(d.range()) {
+        if d.len() < 2 || self.comment_ranges.intersects(d.range()) {
             return;
         }
-        let members: Vec<aligner::Member> = d
-            .items
-            .iter()
-            .filter_map(|item| {
-                let key = item.key.as_ref()?;
-                aligner::line_anchored_member_at_kind(
-                    self.source,
-                    TextRange::new(key.end(), item.value.start()),
-                    TokenKind::Colon,
-                )
-            })
-            .collect();
-        self.emit(&members);
+        self.emit(&colon_targets::dict_members(self.source, d));
     }
 
-    /// Detects and aligns a Google/numpy-style `Args:` section in the
-    /// body's leading docstring. Only the single-part string literal
-    /// case is handled, leaving implicitly concatenated docstrings
-    /// alone.
     fn process_docstring_args(&mut self, body: &[Stmt]) {
-        let Some(lit) = body
-            .first()
-            .and_then(Stmt::as_expr_stmt)
-            .and_then(|s| s.value.as_string_literal_expr())
-            .filter(|lit| !lit.value.is_implicit_concatenated())
-        else {
-            return;
-        };
-        let members = self.docstring_args_members(lit.range());
-        self.emit(&members);
+        self.emit(&colon_targets::docstring_args(self.source, body));
     }
 
     fn process_parameters(&mut self, params: &Parameters) {
-        let optional: Vec<Option<aligner::Member>> = params
-            .iter_source_order()
-            .map(|p| self.parameter_member(p))
-            .collect();
-        for run in optional.split(Option::is_none) {
-            let group: Vec<aligner::Member> = run.iter().flatten().copied().collect();
+        for group in colon_targets::parameter_groups(self.source, params) {
             self.emit(&group);
         }
     }
@@ -228,41 +111,4 @@ impl<'a> AstVisitor<'a> for Visitor<'a> {
         }
         walk_stmt(self, stmt);
     }
-}
-
-/// Returns the byte offset of `Args:` when it appears as a section
-/// header, which means it sits at the start of a line (modulo leading
-/// whitespace) and is followed only by whitespace on that line.
-fn find_args_header(body: &str) -> Option<usize> {
-    body.universal_newlines().find_map(|line| {
-        let content = line.as_str();
-        let stripped = content.trim_whitespace_start();
-        let after = stripped.strip_prefix("Args:")?;
-        after.trim_whitespace().is_empty().then(|| {
-            let indent_len = content.len() - stripped.len();
-            line.start().to_usize() + indent_len
-        })
-    })
-}
-
-/// Finds the byte offset of the `:` within a docstring entry line's
-/// post-indent content. The pre-colon region may include the
-/// argument name and an optional parenthesized type (e.g. `x (int)`).
-/// Returns `None` when the line does not look like an entry.
-fn find_entry_colon(stripped: &str) -> Option<usize> {
-    let bytes = stripped.as_bytes();
-    let &first = bytes.first()?;
-    if !(first.is_ascii_alphabetic() || first == b'_' || first == b'*') {
-        return None;
-    }
-    let mut paren_depth = 0usize;
-    for (cursor, &b) in bytes.iter().enumerate() {
-        match b {
-            b'(' | b'[' => paren_depth += 1,
-            b')' | b']' => paren_depth = paren_depth.saturating_sub(1),
-            b':' if paren_depth == 0 => return Some(cursor),
-            _ => {}
-        }
-    }
-    None
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -7,3 +7,4 @@ pub mod align_colons;
 pub mod align_equals;
 pub mod align_imports;
 pub mod collection_layout;
+pub mod singleton_rule;

--- a/src/rules/singleton_rule.rs
+++ b/src/rules/singleton_rule.rs
@@ -1,0 +1,237 @@
+//! Strips the pre-`:` padding on aligned contexts whose `:`s have no
+//! column to align to. The two cases are a singleton group (one
+//! member, so no neighbor row) and a multi-member group whose `:`s
+//! all share a source line (no column distinction across rows). Both
+//! reduce to "alignment is not happening here," at which point the
+//! pre-`:` gap is visual noise and the rule strips it. Multi-member
+//! groups whose `:`s sit on distinct lines belong to `align_colons`
+//! and pass through this rule untouched. Runs after the alignment
+//! rules in `Pipeline::with_defaults` so it sees their output.
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::visitor::{walk_expr, walk_parameters, walk_stmt, Visitor as AstVisitor};
+use ruff_python_ast::{Expr, ExprDict, Parameters, Stmt};
+
+use crate::config::Config;
+use crate::pipeline::Rule;
+use crate::primitives::{aligner, colon_targets};
+use crate::source::Source;
+
+pub struct SingletonRule;
+
+impl SingletonRule {
+    pub fn from_config(_config: &Config) -> Self {
+        Self
+    }
+}
+
+impl Rule for SingletonRule {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let mut visitor = Visitor {
+            edits: Vec::new(),
+            source,
+        };
+        visitor.visit_body(&source.ast().body);
+        visitor.edits
+    }
+
+    fn name(&self) -> &'static str {
+        "singleton-rule"
+    }
+}
+
+struct Visitor<'a> {
+    edits: Vec<Edit>,
+    source: &'a Source,
+}
+
+impl Visitor<'_> {
+    /// Emits a deletion edit per member when alignment is not
+    /// happening for the group. Singleton groups always qualify, since
+    /// a single row has nothing to align against. Multi-member groups
+    /// qualify when their `:`s share a source line, since no column
+    /// distinguishes the rows. Multi-member groups on distinct lines
+    /// belong to `align_colons` and emit nothing here. The `width > 0`
+    /// guard rejects the edge case where a `:` sits on its own
+    /// indented line and the "gap" is leading indent rather than
+    /// padding.
+    fn emit(&mut self, members: &[aligner::Member]) {
+        if members.is_empty() || (members.len() >= 2 && aligner::distinct_lines(members)) {
+            return;
+        }
+        self.edits.extend(
+            members
+                .iter()
+                .filter(|m| m.width > 0 && !m.gap.is_empty())
+                .map(|m| Edit::range_deletion(m.gap)),
+        );
+    }
+
+    fn process_class_fields(&mut self, body: &[Stmt]) {
+        for group in colon_targets::class_field_groups(self.source, body) {
+            self.emit(&group);
+        }
+    }
+
+    fn process_dict(&mut self, d: &ExprDict) {
+        self.emit(&colon_targets::dict_members(self.source, d));
+    }
+
+    fn process_docstring_args(&mut self, body: &[Stmt]) {
+        self.emit(&colon_targets::docstring_args(self.source, body));
+    }
+
+    fn process_parameters(&mut self, params: &Parameters) {
+        for group in colon_targets::parameter_groups(self.source, params) {
+            self.emit(&group);
+        }
+    }
+}
+
+impl<'a> AstVisitor<'a> for Visitor<'a> {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if let Expr::Dict(d) = expr {
+            self.process_dict(d);
+        }
+        walk_expr(self, expr);
+    }
+
+    fn visit_parameters(&mut self, parameters: &'a Parameters) {
+        self.process_parameters(parameters);
+        walk_parameters(self, parameters);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::ClassDef(cd) => {
+                self.process_class_fields(&cd.body);
+                self.process_docstring_args(&cd.body);
+            }
+            Stmt::FunctionDef(fd) => {
+                self.process_docstring_args(&fd.body);
+            }
+            _ => {}
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use ruff_text_size::{Ranged, TextRange, TextSize};
+
+    use super::*;
+
+    /// Builds a synthetic source carrying `text_len` ASCII bytes, used
+    /// as the backing text for fabricated `Member`s. Tests bypass the
+    /// AST walk and call `emit` directly to pin its gating logic.
+    fn synthetic_source(text_len: usize) -> Source {
+        Source::from_str(&"x".repeat(text_len)).expect("synthetic ASCII source parses")
+    }
+
+    /// Drives `emit` against `members` and returns the resulting edits.
+    fn run_emit(source: &Source, members: &[aligner::Member]) -> Vec<Edit> {
+        let mut visitor = Visitor {
+            edits: Vec::new(),
+            source,
+        };
+        visitor.emit(members);
+        visitor.edits
+    }
+
+    #[test]
+    fn emit_handles_empty_members_slice() {
+        // No members: `emit` returns immediately, no edits.
+        let source = synthetic_source(0);
+        assert!(run_emit(&source, &[]).is_empty());
+    }
+
+    #[test]
+    fn emit_skips_multi_member_groups_on_distinct_lines() {
+        // Two members on different source lines: `distinct_lines` is
+        // true, alignment defers to `align_colons`, this rule emits
+        // nothing.
+        let source = Source::from_str("xx: 1\nyy: 2\n").expect("parses");
+        let members = [
+            aligner::Member {
+                gap: TextRange::new(TextSize::new(2), TextSize::new(2)),
+                line_start: TextSize::new(0),
+                width: 2,
+            },
+            aligner::Member {
+                gap: TextRange::new(TextSize::new(8), TextSize::new(8)),
+                line_start: TextSize::new(6),
+                width: 2,
+            },
+        ];
+        assert!(run_emit(&source, &members).is_empty());
+    }
+
+    #[test]
+    fn emit_skips_zero_width_member_with_empty_gap() {
+        // The "anchor at line start" shape that `line_anchored_member`
+        // produces for any token at column 0. Width and gap both zero,
+        // nothing to delete, no edit emitted.
+        let source = synthetic_source(1);
+        let member = aligner::Member {
+            gap: TextRange::new(TextSize::new(0), TextSize::new(0)),
+            line_start: TextSize::new(0),
+            width: 0,
+        };
+        assert!(run_emit(&source, &[member]).is_empty());
+    }
+
+    #[test]
+    fn emit_skips_zero_width_member_with_indent_gap() {
+        // The "`:` on its own indented line" shape: the line has only
+        // whitespace before the colon, so the line-anchored width is
+        // zero and the "gap" is leading indent rather than padding.
+        let source = synthetic_source(8);
+        let member = aligner::Member {
+            gap: TextRange::new(TextSize::new(0), TextSize::new(4)),
+            line_start: TextSize::new(0),
+            width: 0,
+        };
+        assert!(run_emit(&source, &[member]).is_empty());
+    }
+
+    #[test]
+    fn emit_strips_every_member_when_colons_share_a_line() {
+        // Two members on the same source line: `distinct_lines` is
+        // false, so alignment defers to this rule and every member's
+        // gap is deleted.
+        let source = synthetic_source(20);
+        let members = [
+            aligner::Member {
+                gap: TextRange::new(TextSize::new(3), TextSize::new(5)),
+                line_start: TextSize::new(0),
+                width: 3,
+            },
+            aligner::Member {
+                gap: TextRange::new(TextSize::new(8), TextSize::new(10)),
+                line_start: TextSize::new(0),
+                width: 5,
+            },
+        ];
+        assert_eq!(run_emit(&source, &members).len(), 2);
+    }
+
+    #[test]
+    fn emit_strips_singleton_with_content_and_gap() {
+        // The canonical singleton: content on the same line as the
+        // colon, non-empty pre-colon gap. Both guards pass, the gap
+        // is deleted.
+        let source = synthetic_source(8);
+        let member = aligner::Member {
+            gap: TextRange::new(TextSize::new(3), TextSize::new(5)),
+            line_start: TextSize::new(0),
+            width: 3,
+        };
+        let edits = run_emit(&source, &[member]);
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].start(), TextSize::new(3));
+        assert_eq!(edits[0].end(), TextSize::new(5));
+    }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -49,15 +49,26 @@ impl Source {
         self.parsed.syntax()
     }
 
-    /// Returns the first token in `range` for which `predicate` is
-    /// true. Callers that just need the offset can chain
-    /// `.map(Token::start)`. Used by every rule that anchors alignment
-    /// on a specific keyword or operator token.
-    pub fn first_token_in_range<F>(&self, range: TextRange, mut predicate: F) -> Option<&Token>
+    /// Returns the start offset of the first token in `range` for
+    /// which `predicate` is true. Callers that need the full `&Token`
+    /// (kind, range, flags) should chain
+    /// `tokens().in_range(range).iter().find(...)` directly. This
+    /// helper exists for the dominant case of "find a kind, take its
+    /// start offset," which every alignment-rule member constructor
+    /// reduces to.
+    pub fn first_token_offset_in_range<F>(
+        &self,
+        range: TextRange,
+        mut predicate: F,
+    ) -> Option<TextSize>
     where
         F: FnMut(&Token) -> bool,
     {
-        self.tokens().in_range(range).iter().find(|&t| predicate(t))
+        self.tokens()
+            .in_range(range)
+            .iter()
+            .find(|&t| predicate(t))
+            .map(Token::start)
     }
 
     /// Returns the line and column for a byte offset.
@@ -160,56 +171,56 @@ mod tests {
     }
 
     #[test]
-    fn first_token_in_range_returns_first_match_when_multiple_satisfy() {
-        // Chained assignment carries two `=` tokens; the helper must
-        // return the leftmost one, not just any match.
+    fn first_token_offset_in_range_returns_first_match_when_multiple_satisfy() {
+        // Chained assignment carries two `=` tokens, and the helper
+        // must return the leftmost one, not just any match.
         let s = Source::from_str("a = b = 1\n").expect("parses");
-        let token = s
-            .first_token_in_range(s.ast().body[0].range(), |t| t.kind() == TokenKind::Equal)
+        let offset = s
+            .first_token_offset_in_range(s.ast().body[0].range(), |t| t.kind() == TokenKind::Equal)
             .expect("two `=` tokens, picks first");
 
-        assert_eq!(token.start(), TextSize::new(2));
+        assert_eq!(offset, TextSize::new(2));
     }
 
     #[test]
-    fn first_token_in_range_returns_none_for_empty_range() {
+    fn first_token_offset_in_range_returns_none_for_empty_range() {
         let s = Source::from_str("x = 1\n").expect("parses");
         let empty = TextRange::empty(TextSize::new(0));
 
-        assert!(s.first_token_in_range(empty, |_| true).is_none());
+        assert!(s.first_token_offset_in_range(empty, |_| true).is_none());
     }
 
     #[test]
-    fn first_token_in_range_returns_none_when_no_token_matches() {
+    fn first_token_offset_in_range_returns_none_when_no_token_matches() {
         let s = Source::from_str("x = 1\n").expect("parses");
-        let result =
-            s.first_token_in_range(s.ast().body[0].range(), |t| t.kind() == TokenKind::Colon);
+        let result = s
+            .first_token_offset_in_range(s.ast().body[0].range(), |t| t.kind() == TokenKind::Colon);
 
         assert!(result.is_none());
     }
 
     #[test]
-    fn first_token_in_range_returns_token_for_single_match() {
+    fn first_token_offset_in_range_returns_offset_for_single_match() {
         let s = Source::from_str("x = 1\n").expect("parses");
-        let token = s
-            .first_token_in_range(s.ast().body[0].range(), |t| t.kind() == TokenKind::Equal)
+        let offset = s
+            .first_token_offset_in_range(s.ast().body[0].range(), |t| t.kind() == TokenKind::Equal)
             .expect("one `=` token");
 
-        assert_eq!(token.start(), TextSize::new(2));
+        assert_eq!(offset, TextSize::new(2));
     }
 
     #[test]
-    fn first_token_in_range_supports_predicate_compositions() {
+    fn first_token_offset_in_range_supports_predicate_compositions() {
         // Mirrors how align_equals's aug-assign arm picks any token in
         // the augmented-assign-operator family rather than a specific kind.
         let s = Source::from_str("x += 1\n").expect("parses");
-        let token = s
-            .first_token_in_range(s.ast().body[0].range(), |t| {
+        let offset = s
+            .first_token_offset_in_range(s.ast().body[0].range(), |t| {
                 t.kind().as_augmented_assign_operator().is_some()
             })
             .expect("`+=` is an aug-assign operator");
 
-        assert_eq!(token.start(), TextSize::new(2));
+        assert_eq!(offset, TextSize::new(2));
     }
 
     #[test]

--- a/tests/fixtures/singleton_rule/dict_literal.input.py
+++ b/tests/fixtures/singleton_rule/dict_literal.input.py
@@ -1,0 +1,19 @@
+"""
+A single-entry dict strips its pre-`:` padding because there is no
+sibling key to align against. A two-entry dict has neighbors and so
+the rule leaves its alignment alone for `align_colons` to own. A
+nested singleton inside a multi-entry parent strips through the
+visitor's recursive walk, even though its surrounding dict stays
+padded.
+"""
+
+single = {"only_key"  : compute_value()}
+
+paired = {
+    "first"  : 1,
+    "second" : 2,
+}
+
+nested = {
+    "outer" : {"inner" : "value"},
+}

--- a/tests/fixtures/singleton_rule/docstring_args.input.py
+++ b/tests/fixtures/singleton_rule/docstring_args.input.py
@@ -1,0 +1,21 @@
+"""
+A docstring `Args:` section with one entry strips the pre-`:` padding
+on that entry. A section with two or more entries keeps padding so
+that `align_colons` can align them in a separate pass.
+"""
+
+def fetch(timeout):
+    """Loads the resource over the network.
+
+    Args:
+        timeout : Maximum seconds to wait before giving up.
+    """
+
+
+def render(template, context):
+    """Expands the template with substitutions.
+
+    Args:
+        template : The template string.
+        context  : Substitution dictionary.
+    """

--- a/tests/fixtures/singleton_rule/function_signature.input.py
+++ b/tests/fixtures/singleton_rule/function_signature.input.py
@@ -1,0 +1,19 @@
+"""
+A single-parameter signature with extra padding before its `:` is
+the canonical singleton case, so the rule strips that padding to
+zero. Multi-parameter signatures collapsed onto one line do the same,
+since with every `:` on the same line there is no column to align
+against. A multi-parameter signature spread across multiple lines
+belongs to `align_colons` and stays padded for that pass to align.
+"""
+
+def fetch(timeout : float) -> bytes:
+    return b""
+
+
+def store(record : Record, *, ttl : int = 3600) -> None:
+    pass
+
+
+def render(template : str, context : dict, *, escape : bool = True) -> str:
+    return ""

--- a/tests/fixtures/singleton_rule/idempotent.input.py
+++ b/tests/fixtures/singleton_rule/idempotent.input.py
@@ -1,0 +1,24 @@
+"""
+Input where every singleton context already carries zero pre-`:`
+padding. The rule recognizes each gap as already empty and emits no
+edits, so the output text equals the input text byte-for-byte and
+the pipeline reports no change.
+"""
+
+def fetch(timeout: float) -> bytes:
+    return b""
+
+
+single = {"only_key": compute_value()}
+
+
+class Solo:
+    only_field: str
+
+
+def render(template):
+    """Expands the template with substitutions.
+
+    Args:
+        template: The template string.
+    """

--- a/tests/fixtures/singleton_rule/method_self_and_kwarg.input.py
+++ b/tests/fixtures/singleton_rule/method_self_and_kwarg.input.py
@@ -1,0 +1,19 @@
+"""
+A method's `self` parameter is unannotated, so the parameter walk
+yields a `None` that splits the slice into runs. A method with one
+annotated parameter after `self` produces a singleton run and strips
+the parameter's pre-`:` padding. The same applies to a keyword-only
+parameter introduced by `*`. A method with two annotated parameters
+after `self` lands a size-two run on a single source line, so it
+strips too because same-line `:`s have no column to align against.
+"""
+
+class Service:
+    def fetch(self, timeout : float) -> bytes:
+        return b""
+
+    def store(self, *, ttl : int = 3600) -> None:
+        pass
+
+    def render(self, template : str, context : dict) -> str:
+        return ""

--- a/tests/fixtures/singleton_rule/mixed_singleton_and_group.input.py
+++ b/tests/fixtures/singleton_rule/mixed_singleton_and_group.input.py
@@ -1,0 +1,32 @@
+"""
+Inputs that interleave singleton contexts with multi-item groups
+across all four shapes: class fields, dict literals, function
+parameters. Singletons strip their pre-`:` padding. Multi-line
+multi-item groups stay padded for `align_colons` to align. A
+multi-item group squashed onto a single line strips its padding
+too, because same-line `:`s have no column to align against.
+"""
+
+class Solo:
+    only_field : str
+
+
+class Pair:
+    first  : str
+    second : int
+
+
+single_dict = {"key" : "value"}
+
+paired_dict = {
+    "first"  : 1,
+    "second" : 2,
+}
+
+
+def lone_param(x : int) -> int:
+    return x
+
+
+def two_params(first : int, second : str) -> str:
+    return ""

--- a/tests/fixtures/singleton_rule/multiline_signature.input.py
+++ b/tests/fixtures/singleton_rule/multiline_signature.input.py
@@ -1,0 +1,19 @@
+"""
+A multi-line single-parameter signature strips its pre-`:` padding,
+because the parameter and its `:` sit on the same line and the
+member width is non-zero. A multi-line multi-parameter signature
+qualifies two distinct-line members, so the rule defers to
+`align_colons` and the padding stays for that pass to align.
+"""
+
+def fetch(
+    timeout : float,
+) -> bytes:
+    return b""
+
+
+def render(
+    template : str,
+    context  : dict,
+) -> str:
+    return ""

--- a/tests/fixtures/singleton_rule/pydantic_field.input.py
+++ b/tests/fixtures/singleton_rule/pydantic_field.input.py
@@ -1,0 +1,26 @@
+"""
+A class with a single annotated field strips that field's pre-`:`
+padding. A class with multiple line-adjacent annotated fields keeps
+its padding, since `align_colons` owns the multi-field alignment.
+A class that mixes a single annotated field with method definitions
+still treats the field as a singleton, because the method breaks the
+line-adjacent group rather than joining it.
+"""
+
+from pydantic import BaseModel
+
+
+class Solo(BaseModel):
+    only_field : str
+
+
+class Pair(BaseModel):
+    first  : str
+    second : int
+
+
+class WithMethod(BaseModel):
+    sole_field : str
+
+    def serialize(self) -> dict:
+        return self.model_dump()

--- a/tests/fixtures/singleton_rule/same_line_dict.input.py
+++ b/tests/fixtures/singleton_rule/same_line_dict.input.py
@@ -1,0 +1,13 @@
+"""
+A multi-entry dict squashed onto one line strips every entry's
+pre-`:` padding, since same-line `:`s have no column to align
+against. The same dict spread across multiple lines belongs to
+`align_colons` and stays padded for that pass to handle.
+"""
+
+oneline = {"first" : 1, "second" : 2, "third" : 3}
+
+multiline = {
+    "first"  : 1,
+    "second" : 2,
+}

--- a/tests/fixtures/singleton_rule/with_comments.input.py
+++ b/tests/fixtures/singleton_rule/with_comments.input.py
@@ -1,0 +1,17 @@
+"""
+A singleton dict carrying a leading or trailing comment still strips
+its pre-`:` padding. The rule's edit deletes a small whitespace span
+between key and `:`, which is structurally separate from any comment
+on a different line or trailing the value, so the comment is not at
+risk and the strip lands.
+"""
+
+stays_singleton = {
+    # leading comment lives on its own line
+    "only_key"  : compute_value(),
+}
+
+
+also_stripped = {
+    "only_key"  : compute_value(),  # trailing comment after the value
+}

--- a/tests/snapshots/singleton_rule/dict_literal.input.py.snap
+++ b/tests/snapshots/singleton_rule/dict_literal.input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/dict_literal.input.py
+---
+"""
+A single-entry dict strips its pre-`:` padding because there is no
+sibling key to align against. A two-entry dict has neighbors and so
+the rule leaves its alignment alone for `align_colons` to own. A
+nested singleton inside a multi-entry parent strips through the
+visitor's recursive walk, even though its surrounding dict stays
+padded.
+"""
+
+single = {"only_key": compute_value()}
+
+paired = {
+    "first"  : 1,
+    "second" : 2,
+}
+
+nested = {
+    "outer": {"inner": "value"},
+}

--- a/tests/snapshots/singleton_rule/docstring_args.input.py.snap
+++ b/tests/snapshots/singleton_rule/docstring_args.input.py.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/docstring_args.input.py
+---
+"""
+A docstring `Args:` section with one entry strips the pre-`:` padding
+on that entry. A section with two or more entries keeps padding so
+that `align_colons` can align them in a separate pass.
+"""
+
+def fetch(timeout):
+    """Loads the resource over the network.
+
+    Args:
+        timeout: Maximum seconds to wait before giving up.
+    """
+
+
+def render(template, context):
+    """Expands the template with substitutions.
+
+    Args:
+        template : The template string.
+        context  : Substitution dictionary.
+    """

--- a/tests/snapshots/singleton_rule/function_signature.input.py.snap
+++ b/tests/snapshots/singleton_rule/function_signature.input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/function_signature.input.py
+---
+"""
+A single-parameter signature with extra padding before its `:` is
+the canonical singleton case, so the rule strips that padding to
+zero. Multi-parameter signatures collapsed onto one line do the same,
+since with every `:` on the same line there is no column to align
+against. A multi-parameter signature spread across multiple lines
+belongs to `align_colons` and stays padded for that pass to align.
+"""
+
+def fetch(timeout: float) -> bytes:
+    return b""
+
+
+def store(record: Record, *, ttl: int = 3600) -> None:
+    pass
+
+
+def render(template: str, context: dict, *, escape: bool = True) -> str:
+    return ""

--- a/tests/snapshots/singleton_rule/idempotent.input.py.snap
+++ b/tests/snapshots/singleton_rule/idempotent.input.py.snap
@@ -1,0 +1,29 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/idempotent.input.py
+---
+"""
+Input where every singleton context already carries zero pre-`:`
+padding. The rule recognizes each gap as already empty and emits no
+edits, so the output text equals the input text byte-for-byte and
+the pipeline reports no change.
+"""
+
+def fetch(timeout: float) -> bytes:
+    return b""
+
+
+single = {"only_key": compute_value()}
+
+
+class Solo:
+    only_field: str
+
+
+def render(template):
+    """Expands the template with substitutions.
+
+    Args:
+        template: The template string.
+    """

--- a/tests/snapshots/singleton_rule/method_self_and_kwarg.input.py.snap
+++ b/tests/snapshots/singleton_rule/method_self_and_kwarg.input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/method_self_and_kwarg.input.py
+---
+"""
+A method's `self` parameter is unannotated, so the parameter walk
+yields a `None` that splits the slice into runs. A method with one
+annotated parameter after `self` produces a singleton run and strips
+the parameter's pre-`:` padding. The same applies to a keyword-only
+parameter introduced by `*`. A method with two annotated parameters
+after `self` lands a size-two run on a single source line, so it
+strips too because same-line `:`s have no column to align against.
+"""
+
+class Service:
+    def fetch(self, timeout: float) -> bytes:
+        return b""
+
+    def store(self, *, ttl: int = 3600) -> None:
+        pass
+
+    def render(self, template: str, context: dict) -> str:
+        return ""

--- a/tests/snapshots/singleton_rule/mixed_singleton_and_group.input.py.snap
+++ b/tests/snapshots/singleton_rule/mixed_singleton_and_group.input.py.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/mixed_singleton_and_group.input.py
+---
+"""
+Inputs that interleave singleton contexts with multi-item groups
+across all four shapes: class fields, dict literals, function
+parameters. Singletons strip their pre-`:` padding. Multi-line
+multi-item groups stay padded for `align_colons` to align. A
+multi-item group squashed onto a single line strips its padding
+too, because same-line `:`s have no column to align against.
+"""
+
+class Solo:
+    only_field: str
+
+
+class Pair:
+    first  : str
+    second : int
+
+
+single_dict = {"key": "value"}
+
+paired_dict = {
+    "first"  : 1,
+    "second" : 2,
+}
+
+
+def lone_param(x: int) -> int:
+    return x
+
+
+def two_params(first: int, second: str) -> str:
+    return ""

--- a/tests/snapshots/singleton_rule/multiline_signature.input.py.snap
+++ b/tests/snapshots/singleton_rule/multiline_signature.input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/multiline_signature.input.py
+---
+"""
+A multi-line single-parameter signature strips its pre-`:` padding,
+because the parameter and its `:` sit on the same line and the
+member width is non-zero. A multi-line multi-parameter signature
+qualifies two distinct-line members, so the rule defers to
+`align_colons` and the padding stays for that pass to align.
+"""
+
+def fetch(
+    timeout: float,
+) -> bytes:
+    return b""
+
+
+def render(
+    template : str,
+    context  : dict,
+) -> str:
+    return ""

--- a/tests/snapshots/singleton_rule/pydantic_field.input.py.snap
+++ b/tests/snapshots/singleton_rule/pydantic_field.input.py.snap
@@ -1,0 +1,31 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/pydantic_field.input.py
+---
+"""
+A class with a single annotated field strips that field's pre-`:`
+padding. A class with multiple line-adjacent annotated fields keeps
+its padding, since `align_colons` owns the multi-field alignment.
+A class that mixes a single annotated field with method definitions
+still treats the field as a singleton, because the method breaks the
+line-adjacent group rather than joining it.
+"""
+
+from pydantic import BaseModel
+
+
+class Solo(BaseModel):
+    only_field: str
+
+
+class Pair(BaseModel):
+    first  : str
+    second : int
+
+
+class WithMethod(BaseModel):
+    sole_field: str
+
+    def serialize(self) -> dict:
+        return self.model_dump()

--- a/tests/snapshots/singleton_rule/same_line_dict.input.py.snap
+++ b/tests/snapshots/singleton_rule/same_line_dict.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/same_line_dict.input.py
+---
+"""
+A multi-entry dict squashed onto one line strips every entry's
+pre-`:` padding, since same-line `:`s have no column to align
+against. The same dict spread across multiple lines belongs to
+`align_colons` and stays padded for that pass to handle.
+"""
+
+oneline = {"first": 1, "second": 2, "third": 3}
+
+multiline = {
+    "first"  : 1,
+    "second" : 2,
+}

--- a/tests/snapshots/singleton_rule/with_comments.input.py.snap
+++ b/tests/snapshots/singleton_rule/with_comments.input.py.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/singleton_rule/with_comments.input.py
+---
+"""
+A singleton dict carrying a leading or trailing comment still strips
+its pre-`:` padding. The rule's edit deletes a small whitespace span
+between key and `:`, which is structurally separate from any comment
+on a different line or trailing the value, so the comment is not at
+risk and the strip lands.
+"""
+
+stays_singleton = {
+    # leading comment lives on its own line
+    "only_key": compute_value(),
+}
+
+
+also_stripped = {
+    "only_key": compute_value(),  # trailing comment after the value
+}


### PR DESCRIPTION
### 🪻 Quick Summary

`SingletonRule` strips the pre-`:` padding on aligned contexts whose colons have no column to align to. The two qualifying cases are a singleton group (*one member, so no neighbor row*) and a multi-member group whose colons all share a source line (*no column distinction across rows*). Both reduce to "alignment is not happening here," at which point the pre-`:` gap is visual noise. Multi-member groups whose colons sit on distinct lines belong to `align_colons` and pass through this rule untouched. The rule registers after `align_equals` in `Pipeline::with_defaults` so it sees the alignment rules' output.

A new `primitives/colon_targets` module consolidates the four `:`-context member constructors that `align_colons` already knew about and `singleton_rule` now consumes through the same shapes, plus matching group and collection helpers that leave each rule's `process_*` body as a uniform 2-3 line wrapper. The aligner gains `Member.line_start` (*captured at construction so `distinct_lines` is a pure function over the slice*), a simplified `keyed_line_adjacent_groups` state machine, and an `emit_with_paddings(max_w)` signature that drops three caller-side allocations per `emit_group`.

---

### 🗞️ Key Changes

- Adds `SingletonRule` as an AST visitor that strips pre-`:` padding when alignment is not happening for the group, covering singleton cases (*one member, no row to align against*) and squashed multi-member cases (*colons share a source line, no column to align to*)

- Adopts an `m.width > 0` guard in the rule's `emit` so the rule does not delete the line's leading indent when a `:` sits on its own indented line, treating that pathological-but-parseable shape as a no-op

- Adds `primitives/colon_targets` consolidating the four `:`-context member constructors (*class fields, dict items, annotated parameters, docstring `Args:` entries*) plus their `_groups` and `_members` collector counterparts, shared by `align_colons` and `singleton_rule` at the same call shape

- Stores `line_start: TextSize` on `aligner::Member` at construction time so `aligner::distinct_lines(&[Member])` is a pure function over the slice without a `Source` parameter

- Simplifies `aligner::keyed_line_adjacent_groups` to push each group to the result `Vec` as it opens, replacing the four-arm `match (qualify, active)` with a `let-else` plus an `is_some_and`-driven extends boolean, and dropping the post-loop flush

- Tightens `aligner::emit_with_paddings` to take `max_w: usize` over `paddings: &[usize]`, dropping three caller-side `Vec<usize>` allocations per `emit_group` invocation

- Renames `Source::first_token_in_range` to `first_token_offset_in_range` returning `Option<TextSize>` directly, since every caller chained `.map(Token::start)?` to discard the `&Token`

- Adopts `ExprStringLiteral::as_single_part_string` for the not-implicitly-concatenated check in `colon_targets::docstring_args`, replacing the negated `is_implicit_concatenated()` filter with the upstream typed accessor that returns the inner `&StringLiteral`

- Adopts `ExprDict::len()` and `ExprDict::iter()` over `d.items.len()` and `d.items.iter()`, matching the upstream API surface that `ExprList` and `ExprTuple` already use

- Moves leading-docstring detection into `colon_targets::docstring_args(source, body)` so both rules' `process_docstring_args` collapse to one statement and the docstring-shape detection lives alongside the `Args:` section parsing in one module

- Threads `find_args_header`'s computed indent length out through its return type so `colon_targets::docstring_args` does not recompute via a `body[..header_offset].rsplit_once('\n')` walk

- Registers `SingletonRule` after `align_equals` in `Pipeline::with_defaults` and bumps the default-rule count assertion from 4 to 5

- Lands ten fixtures under `tests/fixtures/singleton_rule/` covering each `:` context plus mixed singleton-and-group, comment-bearing dict, multi-line signature with the width-guard edge, method with `self` and an annotated kwarg, same-line multi-entry dict, and idempotent input

- Adds six inline tests pinning `emit`'s gating truth table across the width and member-count dimensions: width-zero with empty gap, width-zero with indent gap, width-positive singleton, empty members slice, multi-member same-line strip, multi-member distinct-lines skip

---

### ☕ Implementation Notes

Rationale for the two spec departures (*same-line multi-item groups strip alongside singletons, and comment-bearing singleton dicts strip rather than skip*) lives in [this issue comment](https://github.com/Jybbs/prose/issues/11#issuecomment-4322681892).

#### Shared Colon-Context Primitives

`align_colons` previously carried the four `:`-context member constructors as private `Visitor` methods, plus the `find_args_header` and `find_entry_colon` helpers and the `docstring_args_members` walker. With `singleton_rule` consuming the same shapes for a different edit policy, the constructors moved into the new `primitives/colon_targets` module, with `class_field` and `class_field_groups`, `dict_item` and `dict_members`, `parameter` and `parameter_groups`, plus a body-aware `docstring_args(source, body)` that handles the leading-docstring detection internally.

Each rule's four `process_*` methods are now uniform 2-3 line wrappers that call the matching primitive and emit per group, leaving rule-specific gating (*`align_colons`'s `< 2` short-circuit and comment-skip on dicts, `singleton_rule`'s `emit` truth table*) at the rule level where it belongs.

---

### 🧵 Related Issues

- Closes #11