### PR TITLE
[14] Implement `strip_trailing_commas` rule

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -17,6 +17,7 @@ use crate::rules::align_imports::AlignImports;
 use crate::rules::collection_layout::CollectionLayout;
 use crate::rules::match_case_align::MatchCaseAlign;
 use crate::rules::singleton_rule::SingletonRule;
+use crate::rules::strip_trailing_commas::StripTrailingCommas;
 use crate::source::Source;
 
 /// Every rule in `prose` implements this trait and nothing more.
@@ -61,8 +62,9 @@ impl Pipeline {
     /// Returns `None` when `name` does not match any registered rule.
     /// Bypasses each rule's `enabled` flag. Names are snake_case
     /// (`align_colons`, `align_equals`, `align_imports`,
-    /// `collection_layout`, `singleton_rule`), not the kebab-case form
-    /// returned by [`Rule::name`].
+    /// `collection_layout`, `match_case_align`, `singleton_rule`,
+    /// `strip_trailing_commas`), not the kebab-case form returned
+    /// by [`Rule::name`].
     pub fn for_rule(name: &str, config: &Config) -> Option<Self> {
         let rule: Box<dyn Rule> = match name {
             "align_colons" => Box::new(AlignColons::from_config(config)),
@@ -71,6 +73,7 @@ impl Pipeline {
             "collection_layout" => Box::new(CollectionLayout::from_config(config)),
             "match_case_align" => Box::new(MatchCaseAlign::from_config(config)),
             "singleton_rule" => Box::new(SingletonRule::from_config(config)),
+            "strip_trailing_commas" => Box::new(StripTrailingCommas::from_config(config)),
             _ => return None,
         };
         Some(Self::from_rules(vec![rule]))
@@ -96,7 +99,9 @@ impl Pipeline {
             rules.push(Box::new(CollectionLayout::from_config(config)));
         }
         // if config.rules.alphabetize.enabled { rules.push(Box::new(Alphabetize)); }
-        // if config.rules.strip_trailing_commas.enabled { rules.push(Box::new(StripTrailingCommas)); }
+        if config.rules.strip_trailing_commas.enabled {
+            rules.push(Box::new(StripTrailingCommas::from_config(config)));
+        }
         if config.rules.match_case_align.enabled {
             rules.push(Box::new(MatchCaseAlign::from_config(config)));
         }
@@ -404,7 +409,7 @@ mod tests {
     fn with_defaults_registers_enabled_rules() {
         let config = Config::default();
         let pipeline = Pipeline::with_defaults(&config);
-        assert_eq!(pipeline.len(), 6);
+        assert_eq!(pipeline.len(), 7);
     }
 
     #[test]
@@ -416,6 +421,7 @@ mod tests {
         config.rules.collection_layout.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.singleton_rule.enabled = false;
+        config.rules.strip_trailing_commas.enabled = false;
         let pipeline = Pipeline::with_defaults(&config);
         assert!(pipeline.is_empty());
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -9,3 +9,4 @@ pub mod align_imports;
 pub mod collection_layout;
 pub mod match_case_align;
 pub mod singleton_rule;
+pub mod strip_trailing_commas;

--- a/src/rules/strip_trailing_commas.rs
+++ b/src/rules/strip_trailing_commas.rs
@@ -1,0 +1,89 @@
+//! Removes the trailing comma after the last element of any
+//! bracketed container: function calls, function signatures, class
+//! base lists, generic-syntax type-parameter lists on `def` /
+//! `class` / `type`, dict literals, list literals, and set literals.
+//! Tuples and any container whose final non-trivia token is not a
+//! comma are left unchanged.
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::visitor::{walk_arguments, walk_expr, walk_stmt, walk_type_params, Visitor};
+use ruff_python_ast::{Arguments, Expr, Stmt, TypeParams};
+use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
+use ruff_text_size::{Ranged, TextRange, TextSize};
+
+use crate::config::Config;
+use crate::pipeline::Rule;
+use crate::source::Source;
+
+pub struct StripTrailingCommas;
+
+impl StripTrailingCommas {
+    pub fn from_config(_config: &Config) -> Self {
+        Self
+    }
+}
+
+impl Rule for StripTrailingCommas {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let mut visitor = Stripper {
+            edits: Vec::new(),
+            source,
+        };
+        visitor.visit_body(&source.ast().body);
+        visitor.edits
+    }
+
+    fn name(&self) -> &'static str {
+        "strip-trailing-commas"
+    }
+}
+
+struct Stripper<'a> {
+    edits: Vec<Edit>,
+    source: &'a Source,
+}
+
+impl Stripper<'_> {
+    /// Pushes a deletion edit for the trailing comma in `container`
+    /// when its final non-trivia token before the closing bracket
+    /// is a comma.
+    fn process_container(&mut self, container: TextRange) {
+        self.edits.extend(
+            BackwardsTokenizer::up_to(
+                container.end() - TextSize::from(1u32),
+                self.source.text(),
+                self.source.comment_ranges(),
+            )
+            .skip_trivia()
+            .next()
+            .filter(|t| t.kind() == SimpleTokenKind::Comma)
+            .map(|t| Edit::range_deletion(t.range)),
+        );
+    }
+}
+
+impl<'a> Visitor<'a> for Stripper<'a> {
+    fn visit_arguments(&mut self, arguments: &'a Arguments) {
+        self.process_container(arguments.range());
+        walk_arguments(self, arguments);
+    }
+
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if matches!(expr, Expr::Dict(_) | Expr::List(_) | Expr::Set(_)) {
+            self.process_container(expr.range());
+        }
+        walk_expr(self, expr);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if let Stmt::FunctionDef(fd) = stmt {
+            self.process_container(fd.parameters.range());
+        }
+        walk_stmt(self, stmt);
+    }
+
+    fn visit_type_params(&mut self, type_params: &'a TypeParams) {
+        self.process_container(type_params.range());
+        walk_type_params(self, type_params);
+    }
+}

--- a/tests/fixtures/strip_trailing_commas/class_bases.input.py
+++ b/tests/fixtures/strip_trailing_commas/class_bases.input.py
@@ -1,0 +1,13 @@
+"""
+A multi-line class base list drops its trailing comma. The class's
+argument list shares the `Arguments` shape with function calls, and
+the backward scan from before the closing `)` lands on the comma
+after the last base.
+"""
+
+
+class Loader(
+    BaseLoader,
+    CacheMixin,
+):
+    pass

--- a/tests/fixtures/strip_trailing_commas/dict_literal.input.py
+++ b/tests/fixtures/strip_trailing_commas/dict_literal.input.py
@@ -1,0 +1,12 @@
+"""
+A multi-line dict literal drops its trailing comma. The dict's
+range covers `{...}`, and the backward scan from before the closing
+`}` lands on the comma after the last value.
+"""
+
+config = {
+    "linkage": "ward",
+    "metric": "euclidean",
+    "n_clusters": None,
+    "threshold": 0.7,
+}

--- a/tests/fixtures/strip_trailing_commas/function_call.input.py
+++ b/tests/fixtures/strip_trailing_commas/function_call.input.py
@@ -1,0 +1,11 @@
+"""
+A multi-line function call drops its trailing comma. The argument
+list's range covers `(...)`, and the backward scan from before the
+closing `)` lands on the comma after the last argument.
+"""
+
+posting = Posting(
+    company="Cianbro",
+    date_posted=None,
+    title="Electrician",
+)

--- a/tests/fixtures/strip_trailing_commas/function_signature.input.py
+++ b/tests/fixtures/strip_trailing_commas/function_signature.input.py
@@ -1,0 +1,13 @@
+"""
+A multi-line function signature drops its trailing comma. The
+parameter list's range covers `(...)`, and the backward scan from
+before the closing `)` lands on the comma after the last parameter.
+"""
+
+
+def load_lexicon(
+    path: Path,
+    encoding: str,
+    fallback: dict[str, str],
+) -> LexiconLoader:
+    return LexiconLoader(path, encoding, fallback)

--- a/tests/fixtures/strip_trailing_commas/idempotent.input.py
+++ b/tests/fixtures/strip_trailing_commas/idempotent.input.py
@@ -1,0 +1,10 @@
+"""
+A container that already lacks a trailing comma round-trips
+unchanged. The backward scan finds the last element rather than a
+comma and emits no edit.
+"""
+
+posting = Posting(
+    company="Cianbro",
+    title="Electrician"
+)

--- a/tests/fixtures/strip_trailing_commas/list_literal.input.py
+++ b/tests/fixtures/strip_trailing_commas/list_literal.input.py
@@ -1,0 +1,11 @@
+"""
+A multi-line list literal drops its trailing comma. The list's
+range covers `[...]`, and the backward scan from before the closing
+`]` lands on the comma after the last element.
+"""
+
+retired = [
+    "INST_2014_0007",
+    "INST_2018_0033",
+    "INST_2021_0044",
+]

--- a/tests/fixtures/strip_trailing_commas/nested.input.py
+++ b/tests/fixtures/strip_trailing_commas/nested.input.py
@@ -1,0 +1,19 @@
+"""
+Nested multi-line containers each drop their own trailing comma.
+The outer call, the inner dict, and the inner list each emit a
+separate deletion edit, and the edits do not interact.
+"""
+
+posting = Posting(
+    keywords=[
+        "rust",
+        "python",
+    ],
+    metadata={
+        "source": "indeed",
+        "tags": [
+            "remote",
+            "contract",
+        ],
+    },
+)

--- a/tests/fixtures/strip_trailing_commas/parenthesized_args.input.py
+++ b/tests/fixtures/strip_trailing_commas/parenthesized_args.input.py
@@ -1,0 +1,11 @@
+"""
+A parenthesized argument expression has its own closing `)` between
+the inner expression and the trailing comma. The backward scan
+starts from the call's outer `)` and reads the trailing comma
+directly, so the inner `)` does not need to be skipped explicitly.
+"""
+
+result = compute(
+    (a + b),
+    (c * d),
+)

--- a/tests/fixtures/strip_trailing_commas/pos_only_separator.input.py
+++ b/tests/fixtures/strip_trailing_commas/pos_only_separator.input.py
@@ -1,0 +1,20 @@
+"""
+The positional-only `/` and keyword-only `*` separators have no AST
+node of their own, but the backward scan from the closing `)` only
+asks whether the immediate previous non-trivia token is a comma, so
+the separators ride through without any special handling.
+"""
+
+
+def split_pos_only(
+    a,
+    /,
+) -> None:
+    return None
+
+
+def split_kw_only(
+    *,
+    b,
+) -> None:
+    return None

--- a/tests/fixtures/strip_trailing_commas/set_literal.input.py
+++ b/tests/fixtures/strip_trailing_commas/set_literal.input.py
@@ -1,0 +1,11 @@
+"""
+A multi-line set literal drops its trailing comma. The set's range
+covers `{...}`, and the backward scan from before the closing `}`
+lands on the comma after the last element.
+"""
+
+allowed = {
+    "INST_2014_0007",
+    "INST_2018_0033",
+    "INST_2021_0044",
+}

--- a/tests/fixtures/strip_trailing_commas/single_line.input.py
+++ b/tests/fixtures/strip_trailing_commas/single_line.input.py
@@ -1,0 +1,15 @@
+"""
+A container whose opening and closing brackets sit on the same
+source line still drops its trailing comma. Single-line trailing
+commas carry no semantic meaning across the in-scope contexts and
+are stripped on the same backward-scan path that handles multi-line
+input.
+"""
+
+call = f(a, b, c,)
+literal = [1, 2, 3,]
+mapping = {"a": 1, "b": 2,}
+
+
+def signature(a, b, c,):
+    return a + b + c

--- a/tests/fixtures/strip_trailing_commas/tuple_in_call.input.py
+++ b/tests/fixtures/strip_trailing_commas/tuple_in_call.input.py
@@ -1,0 +1,10 @@
+"""
+A tuple literal inside a function call keeps its own trailing
+comma because tuples are out of scope for this rule. The call's
+trailing comma is still stripped.
+"""
+
+singletons = make_pair(
+    (1,),
+    (2,),
+)

--- a/tests/fixtures/strip_trailing_commas/type_params.input.py
+++ b/tests/fixtures/strip_trailing_commas/type_params.input.py
@@ -1,0 +1,27 @@
+"""
+A multi-line generic-syntax type-parameter list drops its trailing
+comma in any of three syntactic homes: function definitions, class
+definitions, and type-alias statements. The list's range covers
+`[...]`, and the backward scan from before the closing `]` lands
+on the comma after the last type parameter.
+"""
+
+
+def transform[
+    T,
+    U,
+](x: T) -> U:
+    raise NotImplementedError
+
+
+class Container[
+    T,
+    U,
+]:
+    pass
+
+
+type Pair[
+    T,
+    U,
+] = tuple[T, U]

--- a/tests/fixtures/strip_trailing_commas/with_comments.input.py
+++ b/tests/fixtures/strip_trailing_commas/with_comments.input.py
@@ -1,0 +1,18 @@
+"""
+A trailing comma followed by a same-line comment loses only the
+comma. A comment that sits between the last element and the closing
+bracket also rides through unchanged because the backward scan
+treats comments as trivia before checking for a comma.
+"""
+
+posting = Posting(
+    company="Cianbro",
+    date_posted=None,
+    title="Electrician",  # primary listing title
+)
+
+retired = [
+    "INST_2014_0007",
+    "INST_2018_0033",
+    # legacy identifier kept for audit history
+]

--- a/tests/snapshots/strip_trailing_commas/class_bases.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/class_bases.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/class_bases.input.py
+---
+"""
+A multi-line class base list drops its trailing comma. The class's
+argument list shares the `Arguments` shape with function calls, and
+the backward scan from before the closing `)` lands on the comma
+after the last base.
+"""
+
+
+class Loader(
+    BaseLoader,
+    CacheMixin
+):
+    pass

--- a/tests/snapshots/strip_trailing_commas/dict_literal.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/dict_literal.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/dict_literal.input.py
+---
+"""
+A multi-line dict literal drops its trailing comma. The dict's
+range covers `{...}`, and the backward scan from before the closing
+`}` lands on the comma after the last value.
+"""
+
+config = {
+    "linkage": "ward",
+    "metric": "euclidean",
+    "n_clusters": None,
+    "threshold": 0.7
+}

--- a/tests/snapshots/strip_trailing_commas/function_call.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/function_call.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/function_call.input.py
+---
+"""
+A multi-line function call drops its trailing comma. The argument
+list's range covers `(...)`, and the backward scan from before the
+closing `)` lands on the comma after the last argument.
+"""
+
+posting = Posting(
+    company="Cianbro",
+    date_posted=None,
+    title="Electrician"
+)

--- a/tests/snapshots/strip_trailing_commas/function_signature.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/function_signature.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/function_signature.input.py
+---
+"""
+A multi-line function signature drops its trailing comma. The
+parameter list's range covers `(...)`, and the backward scan from
+before the closing `)` lands on the comma after the last parameter.
+"""
+
+
+def load_lexicon(
+    path: Path,
+    encoding: str,
+    fallback: dict[str, str]
+) -> LexiconLoader:
+    return LexiconLoader(path, encoding, fallback)

--- a/tests/snapshots/strip_trailing_commas/idempotent.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/idempotent.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/idempotent.input.py
+---
+"""
+A container that already lacks a trailing comma round-trips
+unchanged. The backward scan finds the last element rather than a
+comma and emits no edit.
+"""
+
+posting = Posting(
+    company="Cianbro",
+    title="Electrician"
+)

--- a/tests/snapshots/strip_trailing_commas/list_literal.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/list_literal.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/list_literal.input.py
+---
+"""
+A multi-line list literal drops its trailing comma. The list's
+range covers `[...]`, and the backward scan from before the closing
+`]` lands on the comma after the last element.
+"""
+
+retired = [
+    "INST_2014_0007",
+    "INST_2018_0033",
+    "INST_2021_0044"
+]

--- a/tests/snapshots/strip_trailing_commas/nested.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/nested.input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/nested.input.py
+---
+"""
+Nested multi-line containers each drop their own trailing comma.
+The outer call, the inner dict, and the inner list each emit a
+separate deletion edit, and the edits do not interact.
+"""
+
+posting = Posting(
+    keywords=[
+        "rust",
+        "python"
+    ],
+    metadata={
+        "source": "indeed",
+        "tags": [
+            "remote",
+            "contract"
+        ]
+    }
+)

--- a/tests/snapshots/strip_trailing_commas/parenthesized_args.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/parenthesized_args.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/parenthesized_args.input.py
+---
+"""
+A parenthesized argument expression has its own closing `)` between
+the inner expression and the trailing comma. The backward scan
+starts from the call's outer `)` and reads the trailing comma
+directly, so the inner `)` does not need to be skipped explicitly.
+"""
+
+result = compute(
+    (a + b),
+    (c * d)
+)

--- a/tests/snapshots/strip_trailing_commas/pos_only_separator.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/pos_only_separator.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/pos_only_separator.input.py
+---
+"""
+The positional-only `/` and keyword-only `*` separators have no AST
+node of their own, but the backward scan from the closing `)` only
+asks whether the immediate previous non-trivia token is a comma, so
+the separators ride through without any special handling.
+"""
+
+
+def split_pos_only(
+    a,
+    /
+) -> None:
+    return None
+
+
+def split_kw_only(
+    *,
+    b
+) -> None:
+    return None

--- a/tests/snapshots/strip_trailing_commas/set_literal.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/set_literal.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/set_literal.input.py
+---
+"""
+A multi-line set literal drops its trailing comma. The set's range
+covers `{...}`, and the backward scan from before the closing `}`
+lands on the comma after the last element.
+"""
+
+allowed = {
+    "INST_2014_0007",
+    "INST_2018_0033",
+    "INST_2021_0044"
+}

--- a/tests/snapshots/strip_trailing_commas/single_line.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/single_line.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/single_line.input.py
+---
+"""
+A container whose opening and closing brackets sit on the same
+source line still drops its trailing comma. Single-line trailing
+commas carry no semantic meaning across the in-scope contexts and
+are stripped on the same backward-scan path that handles multi-line
+input.
+"""
+
+call = f(a, b, c)
+literal = [1, 2, 3]
+mapping = {"a": 1, "b": 2}
+
+
+def signature(a, b, c):
+    return a + b + c

--- a/tests/snapshots/strip_trailing_commas/tuple_in_call.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/tuple_in_call.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/tuple_in_call.input.py
+---
+"""
+A tuple literal inside a function call keeps its own trailing
+comma because tuples are out of scope for this rule. The call's
+trailing comma is still stripped.
+"""
+
+singletons = make_pair(
+    (1,),
+    (2,)
+)

--- a/tests/snapshots/strip_trailing_commas/type_params.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/type_params.input.py.snap
@@ -1,0 +1,32 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/type_params.input.py
+---
+"""
+A multi-line generic-syntax type-parameter list drops its trailing
+comma in any of three syntactic homes: function definitions, class
+definitions, and type-alias statements. The list's range covers
+`[...]`, and the backward scan from before the closing `]` lands
+on the comma after the last type parameter.
+"""
+
+
+def transform[
+    T,
+    U
+](x: T) -> U:
+    raise NotImplementedError
+
+
+class Container[
+    T,
+    U
+]:
+    pass
+
+
+type Pair[
+    T,
+    U
+] = tuple[T, U]

--- a/tests/snapshots/strip_trailing_commas/with_comments.input.py.snap
+++ b/tests/snapshots/strip_trailing_commas/with_comments.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/strip_trailing_commas/with_comments.input.py
+---
+"""
+A trailing comma followed by a same-line comment loses only the
+comma. A comment that sits between the last element and the closing
+bracket also rides through unchanged because the backward scan
+treats comments as trivia before checking for a comma.
+"""
+
+posting = Posting(
+    company="Cianbro",
+    date_posted=None,
+    title="Electrician"  # primary listing title
+)
+
+retired = [
+    "INST_2014_0007",
+    "INST_2018_0033"
+    # legacy identifier kept for audit history
+]


### PR DESCRIPTION
### 🪻 Quick Summary

`StripTrailingCommas` deletes the trailing comma after the last element of any bracketed container: function calls, function signatures, class base lists, generic-syntax type-parameter lists on `def` / `class` / `type`, dict literals, list literals, and set literals. Single-line and multi-line containers are stripped on the same path. Tuples are out of scope.

The rule walks backward from the closing-bracket offset via `BackwardsTokenizer::up_to` from `ruff_python_trivia`, takes the first non-trivia token, and emits an `Edit::range_deletion` when its kind is `Comma`. Dispatch routes through ruff's `Visitor` trait hooks: `visit_arguments` for `Call` and `ClassDef`, `visit_type_params` for all three type-param homes, `visit_expr` for `Dict` / `List` / `Set`, and `visit_stmt` for `FunctionDef.parameters`. `visit_parameters` stays unhooked, leaving lambda parameters out of scope.

---

### 🗞️ Key Changes

- Adds `StripTrailingCommas` as a `Visitor` impl with `visit_arguments`, `visit_type_params`, `visit_expr`, and `visit_stmt` hooks. Each hook hands the relevant container range to a single `process_container` method that emits at most one deletion edit per container.

- Implements detection through `BackwardsTokenizer::up_to`, taking the first non-trivia token before the closing bracket and emitting `Edit::range_deletion` on `Comma`. Parenthesized children, `,/` and `,*` parameter separators, and inter-element comments fall through the same scan without per-shape casework.

- Strips single-line and multi-line containers alike. The line-count check the spec calls for is omitted.

- Registers the rule in `Pipeline::with_defaults` between `collection_layout` and `match_case_align`, matching the execution order in `docs/rules.md`. `Pipeline::for_rule` gains a `strip_trailing_commas` arm. The `with_defaults_registers_enabled_rules` assertion bumps from `6` to `7`.

- Lands fourteen fixtures under `tests/fixtures/strip_trailing_commas/`: the seven in-scope shapes (*`function_call`, `function_signature`, `class_bases`, `type_params` covering all three syntactic homes, `dict_literal`, `list_literal`, `set_literal`*), the canonical `idempotent` and `nested` cases, the single-line strip case, the `parenthesized_args` case, the `pos_only_separator` case, the `with_comments` case, and the `tuple_in_call` case pinning the one explicit out-of-scope shape.

---

### 🧵 Related Issues

- Closes #14
