### PR TITLE
[18] Add end-to-end idempotency and ruff-coexistence assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ run-name : 🪻 CI · ${{ github.head_ref || github.ref_name }}
 on:
   pull_request:
   push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "attribute-derive"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +140,24 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "castaway"
@@ -134,6 +173,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "clap"
@@ -214,6 +264,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,10 +307,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "derive-where"
@@ -248,6 +379,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "drop_bomb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -310,6 +453,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "get-size-derive2"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +529,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -387,10 +555,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -407,6 +583,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +602,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
@@ -477,6 +668,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +719,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,7 +751,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -538,6 +759,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -569,10 +799,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -594,6 +839,41 @@ checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
  "indexmap",
 ]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "phf"
@@ -621,7 +901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -634,10 +914,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -691,12 +983,14 @@ dependencies = [
  "rayon",
  "ruff_diagnostics",
  "ruff_python_ast",
+ "ruff_python_formatter",
  "ruff_python_parser",
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
  "serde",
  "serde_ignored",
+ "similar",
  "tempfile",
  "thiserror",
  "toml",
@@ -748,7 +1042,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -758,7 +1063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -769,6 +1074,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -788,6 +1099,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -829,6 +1149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ruff_annotate_snippets"
+version = "0.1.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "ruff_cache"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
@@ -842,6 +1172,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_db"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "anstyle",
+ "arc-swap",
+ "camino",
+ "dashmap",
+ "dunce",
+ "filetime",
+ "get-size2",
+ "matchit",
+ "path-slash",
+ "pathdiff",
+ "ruff_annotate_snippets",
+ "ruff_diagnostics",
+ "ruff_memory_usage",
+ "ruff_notebook",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "salsa",
+ "similar",
+ "supports-hyperlinks",
+ "thiserror",
+ "tracing",
+ "ty_static",
+ "web-time",
+ "zip",
+]
+
+[[package]]
 name = "ruff_diagnostics"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
@@ -849,6 +1214,62 @@ dependencies = [
  "get-size2",
  "is-macro",
  "ruff_text_size",
+]
+
+[[package]]
+name = "ruff_formatter"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "drop_bomb",
+ "ruff_cache",
+ "ruff_macros",
+ "ruff_text_size",
+ "rustc-hash",
+ "serde",
+ "static_assertions",
+ "tracing",
+ "unicode-width",
+]
+
+[[package]]
+name = "ruff_macros"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "heck",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "ruff_python_trivia",
+ "syn",
+]
+
+[[package]]
+name = "ruff_memory_usage"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "get-size2",
+]
+
+[[package]]
+name = "ruff_notebook"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "rand 0.10.1",
+ "ruff_diagnostics",
+ "ruff_source_file",
+ "ruff_text_size",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -869,6 +1290,35 @@ dependencies = [
  "rustc-hash",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "ruff_python_formatter"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "anyhow",
+ "clap",
+ "countme",
+ "itertools",
+ "memchr",
+ "regex",
+ "ruff_cache",
+ "ruff_db",
+ "ruff_formatter",
+ "ruff_macros",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
+ "rustc-hash",
+ "salsa",
+ "serde",
+ "smallvec",
+ "static_assertions",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -907,8 +1357,10 @@ name = "ruff_source_file"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
 dependencies = [
+ "get-size2",
  "memchr",
  "ruff_text_size",
+ "serde",
 ]
 
 [[package]]
@@ -952,6 +1404,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa"
+version = "0.26.1"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2f687a17ceea8ec7aaa605561ccbde938ccef086#2f687a17ceea8ec7aaa605561ccbde938ccef086"
+dependencies = [
+ "boxcar",
+ "compact_str",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "intrusive-collections",
+ "inventory",
+ "parking_lot",
+ "portable-atomic",
+ "rustc-hash",
+ "salsa-macro-rules",
+ "salsa-macros",
+ "smallvec",
+ "thin-vec",
+ "tracing",
+]
+
+[[package]]
+name = "salsa-macro-rules"
+version = "0.26.1"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2f687a17ceea8ec7aaa605561ccbde938ccef086#2f687a17ceea8ec7aaa605561ccbde938ccef086"
+
+[[package]]
+name = "salsa-macros"
+version = "0.26.1"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2f687a17ceea8ec7aaa605561ccbde938ccef086#2f687a17ceea8ec7aaa605561ccbde938ccef086"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1451,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
@@ -1035,6 +1533,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "serde_core",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1565,12 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1065,6 +1591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1605,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1087,6 +1630,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
@@ -1163,6 +1712,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "ty_static"
+version = "0.0.1"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.10#252f76102a618bff6537b6c53c316ca3837f4abf"
+dependencies = [
+ "ruff_macros",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,7 +1796,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1216,6 +1804,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "rand 0.10.1",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "walkdir"
@@ -1252,6 +1852,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1928,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1433,6 +2088,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,11 @@ toml               = "0.9"
 unicode-width      = "0.2"
 
 [dev-dependencies]
-indoc    = "2"
-insta    = { version = "1.39", features = ["glob", "yaml"] }
-tempfile = "3"
+indoc                 = "2"
+insta                 = { version = "1.39", features = ["glob", "yaml"] }
+ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
+similar               = "2"
+tempfile              = "3"
 
 [profile.release]
 codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,6 @@ pub mod pipeline;
 mod primitives;
 mod rules;
 pub mod source;
+#[cfg(test)]
+mod test_support;
 mod walker;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -40,13 +40,13 @@ impl Pipeline {
     /// Builds a pipeline registering exactly one rule by name.
     ///
     /// Returns `None` when `name` does not match any registered rule.
-    /// Bypasses each rule's `enabled` flag. Names are the kebab-case
-    /// form returned by [`Rule::name`] (`align-colons`,
+    /// Bypasses each rule's `enabled` flag. Names accept either the
+    /// kebab-case form returned by [`Rule::name`] (`align-colons`,
     /// `align-equals`, `align-imports`, `alphabetize`,
     /// `collection-layout`, `match-case-align`, `singleton-rule`,
-    /// `strip-trailing-commas`).
+    /// `strip-trailing-commas`) or the snake-case equivalent.
     pub fn for_rule(name: &str, config: &Config) -> Option<Self> {
-        let rule: Box<dyn Rule> = match name {
+        let rule: Box<dyn Rule> = match name.replace('_', "-").as_str() {
             "align-colons" => Box::new(AlignColons::from_config(config)),
             "align-equals" => Box::new(AlignEquals::from_config(config)),
             "align-imports" => Box::new(AlignImports::from_config(config)),
@@ -201,12 +201,10 @@ fn apply_edits(text: &str, mut edits: Vec<Edit>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 
-    use ruff_text_size::TextRange;
-
     use super::*;
+    use crate::test_support::{assert_send_sync, parse, range};
 
     /// Test-only rule that records its own name into a shared log and
     /// returns the edit list supplied at construction time.
@@ -244,10 +242,6 @@ mod tests {
         fn name(&self) -> &'static str {
             self.name
         }
-    }
-
-    fn range(start: u32, end: u32) -> TextRange {
-        TextRange::new(start.into(), end.into())
     }
 
     #[test]
@@ -317,7 +311,7 @@ mod tests {
                 seen: seen.clone(),
             }),
         ]);
-        let source = Source::from_str("x = 1\n").expect("parses");
+        let source = parse("x = 1\n");
 
         pipeline.run(source).expect("both stages succeed");
 
@@ -327,7 +321,7 @@ mod tests {
     #[test]
     fn empty_pipeline_returns_identical_source() {
         let pipeline = Pipeline::from_rules(Vec::new());
-        let source = Source::from_str("x = 1\n").expect("parses");
+        let source = parse("x = 1\n");
 
         let (result, changed) = pipeline.run(source).expect("identity run succeeds");
 
@@ -337,7 +331,6 @@ mod tests {
 
     #[test]
     fn pipeline_is_send_and_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Pipeline>();
     }
 
@@ -349,7 +342,7 @@ mod tests {
             log: log.clone(),
             name: "breaks-parse",
         })]);
-        let source = Source::from_str("x = 1\n").expect("parses");
+        let source = parse("x = 1\n");
 
         let err = pipeline.run(source).expect_err("reparse should fail");
 
@@ -378,7 +371,7 @@ mod tests {
                 name: "third",
             }),
         ]);
-        let source = Source::from_str("x = 1\n").expect("parses");
+        let source = parse("x = 1\n");
 
         pipeline.run(source).expect("all rules succeed");
 
@@ -392,7 +385,7 @@ mod tests {
             log: Arc::new(Mutex::new(Vec::new())),
             name: "rewrite-x-to-y",
         })]);
-        let source = Source::from_str("x = 1\n").expect("parses");
+        let source = parse("x = 1\n");
 
         let (result, changed) = pipeline.run(source).expect("rewrite succeeds");
 

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -327,11 +327,10 @@ fn range_anchored_member(
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use ruff_text_size::TextSize;
 
     use super::*;
+    use crate::test_support::parse;
 
     /// Builds the expected summary tuple for an `Edit::range_deletion`
     /// over a member's gap.
@@ -378,10 +377,7 @@ mod tests {
                 width,
             });
         }
-        (
-            Source::from_str(&text).expect("test source parses"),
-            members,
-        )
+        (parse(&text), members)
     }
 
     /// Builds a `Settings` carrying the test's cap and policy with
@@ -487,7 +483,7 @@ mod tests {
 
     #[test]
     fn emit_group_handles_empty_member_slice() {
-        let source = Source::from_str("x = 0\n").expect("parses");
+        let source = parse("x = 0\n");
         let mut edits = Vec::new();
 
         emit_group(
@@ -592,7 +588,7 @@ mod tests {
 
     #[test]
     fn keyed_line_adjacent_groups_flushes_trailing_active_run() {
-        let source = Source::from_str("x = 1\ny = 2\n").expect("parses");
+        let source = parse("x = 1\ny = 2\n");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             s.as_assign_stmt().map(|_| ((), ()))
         });
@@ -603,7 +599,7 @@ mod tests {
 
     #[test]
     fn keyed_line_adjacent_groups_merges_same_key_adjacent_stmts() {
-        let source = Source::from_str("x = 1\ny = 2\nz = 3\n").expect("parses");
+        let source = parse("x = 1\ny = 2\nz = 3\n");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             s.as_assign_stmt().map(|_| ((), ()))
         });
@@ -614,7 +610,7 @@ mod tests {
 
     #[test]
     fn keyed_line_adjacent_groups_non_qualifier_closes_active_run() {
-        let source = Source::from_str("x = 1\npass\ny = 2\n").expect("parses");
+        let source = parse("x = 1\npass\ny = 2\n");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             s.as_assign_stmt().map(|_| ((), ()))
         });
@@ -624,7 +620,7 @@ mod tests {
 
     #[test]
     fn keyed_line_adjacent_groups_returns_empty_for_empty_body() {
-        let source = Source::from_str("").expect("parses");
+        let source = parse("");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             s.as_assign_stmt().map(|_| ((), ()))
         });
@@ -634,7 +630,7 @@ mod tests {
 
     #[test]
     fn keyed_line_adjacent_groups_splits_on_blank_line() {
-        let source = Source::from_str("x = 1\n\ny = 2\n").expect("parses");
+        let source = parse("x = 1\n\ny = 2\n");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             s.as_assign_stmt().map(|_| ((), ()))
         });
@@ -644,7 +640,7 @@ mod tests {
 
     #[test]
     fn keyed_line_adjacent_groups_splits_on_comment_in_gap() {
-        let source = Source::from_str("x = 1\n# comment\ny = 2\n").expect("parses");
+        let source = parse("x = 1\n# comment\ny = 2\n");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             s.as_assign_stmt().map(|_| ((), ()))
         });
@@ -657,7 +653,7 @@ mod tests {
         // Two assigns flanking an aug-assign, all line-adjacent. The
         // distinct keys force the run to split even though no whitespace
         // breaks the adjacency, exercising the `keyed`-only invariant.
-        let source = Source::from_str("x = 1\ny += 2\nz = 3\n").expect("parses");
+        let source = parse("x = 1\ny += 2\nz = 3\n");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             if s.is_assign_stmt() {
                 Some(("assign", ()))
@@ -676,7 +672,7 @@ mod tests {
 
     #[test]
     fn keyed_line_adjacent_groups_yields_singleton_for_lone_qualifier() {
-        let source = Source::from_str("x = 1\n").expect("parses");
+        let source = parse("x = 1\n");
         let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
             s.as_assign_stmt().map(|_| ((), ()))
         });
@@ -687,7 +683,7 @@ mod tests {
 
     #[test]
     fn line_anchored_member_collapses_gap_at_line_start() {
-        let source = Source::from_str("xy\n").expect("parses");
+        let source = parse("xy\n");
         let member = line_anchored_member(&source, TextSize::new(0));
 
         // anchor sits at line start, with empty gap and zero width.
@@ -697,7 +693,7 @@ mod tests {
 
     #[test]
     fn space_padding_edit_inserts_when_range_empty_and_n_positive() {
-        let source = Source::from_str("xy\n").expect("parses");
+        let source = parse("xy\n");
         let range = TextRange::new(TextSize::new(1), TextSize::new(1));
         let edit = space_padding_edit(&source, range, 2).expect("0-vs-2 spaces emits");
         assert_eq!(summary(&edit), (1, 1, "  ".to_owned()));
@@ -705,7 +701,7 @@ mod tests {
 
     #[test]
     fn space_padding_edit_replaces_when_text_has_non_space_chars() {
-        let source = Source::from_str("a:b\n").expect("parses");
+        let source = parse("a:b\n");
         let range = TextRange::new(TextSize::new(1), TextSize::new(2));
         let edit = space_padding_edit(&source, range, 1).expect("non-space content emits");
         assert_eq!(summary(&edit), (1, 2, " ".to_owned()));
@@ -713,7 +709,7 @@ mod tests {
 
     #[test]
     fn space_padding_edit_returns_none_for_empty_range_at_zero() {
-        let source = Source::from_str("xy\n").expect("parses");
+        let source = parse("xy\n");
         let range = TextRange::new(TextSize::new(1), TextSize::new(1));
         assert!(space_padding_edit(&source, range, 0).is_none());
     }

--- a/src/primitives/colon_targets.rs
+++ b/src/primitives/colon_targets.rs
@@ -6,8 +6,6 @@
 //! them to strip pre-colon padding from groups that have no column to
 //! align to.
 
-use std::cmp::Ordering;
-
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor::{walk_expr, walk_parameters, walk_stmt, Visitor as AstVisitor};
 use ruff_python_ast::{
@@ -60,7 +58,9 @@ struct ContextVisitor<'a, E> {
 impl<'a, E: ColonEmitter> AstVisitor<'a> for ContextVisitor<'a, E> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         if let Expr::Dict(d) = expr {
-            self.emitter.dict(d, &dict_members(self.source, d));
+            for group in dict_member_groups(self.source, &d.items) {
+                self.emitter.dict(d, &group);
+            }
         }
         walk_expr(self, expr);
     }
@@ -134,12 +134,32 @@ fn dict_item(source: &Source, item: &DictItem) -> Option<aligner::Member> {
     colon_member(source, key.end(), item.value.start())
 }
 
-/// Returns one alignment member per `key: value` entry in `d`.
-/// `**spread` entries (no key) contribute nothing.
-fn dict_members(source: &Source, d: &ExprDict) -> Vec<aligner::Member> {
-    d.iter()
-        .filter_map(|item| dict_item(source, item))
-        .collect()
+/// Returns one group per run of line-adjacent `key: value` entries in
+/// `d`. A blank line between two entries closes the active run and
+/// starts a fresh one, so each contiguous-line group aligns
+/// independently. `**spread` entries skip the colon scan but do not
+/// break the run, matching the long-standing rule that an unpacking
+/// passes alignment through.
+fn dict_member_groups(source: &Source, items: &[DictItem]) -> Vec<Vec<aligner::Member>> {
+    let mut groups: Vec<Vec<aligner::Member>> = Vec::new();
+    let mut last_keyed_end: Option<TextSize> = None;
+    for item in items {
+        let Some(member) = dict_item(source, item) else {
+            continue;
+        };
+        let extends = last_keyed_end
+            .is_some_and(|prev| source.is_line_adjacent(TextRange::new(prev, item.start())));
+        if extends {
+            groups
+                .last_mut()
+                .expect("active run implies non-empty groups")
+                .push(member);
+        } else {
+            groups.push(vec![member]);
+        }
+        last_keyed_end = Some(item.end());
+    }
+    groups
 }
 
 /// Returns one alignment member per entry in the body's leading
@@ -158,8 +178,7 @@ fn docstring_args(source: &Source, body: &[Stmt]) -> Vec<aligner::Member> {
     else {
         return Vec::new();
     };
-    let ds_range = string_literal.range();
-    let text = source.slice(ds_range);
+    let text = source.slice(string_literal);
     let mut lines = text.universal_newlines();
     let Some(header_indent_len) = lines.find_map(|line| {
         let stripped = line.trim_whitespace_start();
@@ -167,7 +186,7 @@ fn docstring_args(source: &Source, body: &[Stmt]) -> Vec<aligner::Member> {
         after
             .trim_whitespace()
             .is_empty()
-            .then(|| line.len() - stripped.len())
+            .then_some(line.len() - stripped.len())
     }) else {
         return Vec::new();
     };
@@ -183,16 +202,17 @@ fn docstring_args(source: &Source, body: &[Stmt]) -> Vec<aligner::Member> {
         }
 
         let expected = *entry_indent_len.get_or_insert(line_indent_len);
-        match line_indent_len.cmp(&expected) {
-            Ordering::Greater => continue,
-            Ordering::Less => break,
-            Ordering::Equal => {}
+        if line_indent_len > expected {
+            continue;
+        }
+        if line_indent_len < expected {
+            break;
         }
 
         if let Some(colon_rel) = find_entry_colon(stripped) {
-            let line_offset = TextSize::try_from(line_indent_len + colon_rel)
-                .expect("docstring colon offset fits in TextSize");
-            let colon_start = ds_range.start() + line.start() + line_offset;
+            let colon_start = string_literal.start()
+                + line.start()
+                + TextSize::of(&line[..line_indent_len + colon_rel]);
             members.push(aligner::line_anchored_member(source, colon_start));
         }
     }
@@ -204,13 +224,12 @@ fn docstring_args(source: &Source, body: &[Stmt]) -> Vec<aligner::Member> {
 /// name and an optional parenthesized type (e.g. `x (int)`). Returns
 /// `None` when the line does not look like an entry.
 fn find_entry_colon(stripped: &str) -> Option<usize> {
-    let bytes = stripped.as_bytes();
-    let &first = bytes.first()?;
+    let first = stripped.bytes().next()?;
     if !(first.is_ascii_alphabetic() || first == b'_' || first == b'*') {
         return None;
     }
     let mut paren_depth = 0usize;
-    for (cursor, &b) in bytes.iter().enumerate() {
+    for (cursor, b) in stripped.bytes().enumerate() {
         match b {
             b'(' | b'[' => paren_depth += 1,
             b')' | b']' => paren_depth = paren_depth.saturating_sub(1),
@@ -238,19 +257,15 @@ fn parameter(source: &Source, param: AnyParameterRef<'_>) -> Option<aligner::Mem
 /// contiguous annotated parameters, splitting at every unannotated
 /// parameter.
 fn parameter_groups(source: &Source, params: &Parameters) -> Vec<Vec<aligner::Member>> {
-    let mut groups: Vec<Vec<aligner::Member>> = Vec::new();
-    let mut current: Vec<aligner::Member> = Vec::new();
-    for p in params.iter_source_order() {
-        match parameter(source, p) {
-            Some(m) => current.push(m),
-            None if !current.is_empty() => groups.push(std::mem::take(&mut current)),
-            None => {}
-        }
-    }
-    if !current.is_empty() {
-        groups.push(current);
-    }
-    groups
+    let members: Vec<_> = params
+        .iter_source_order()
+        .map(|p| parameter(source, p))
+        .collect();
+    members
+        .split(Option::is_none)
+        .filter(|chunk| !chunk.is_empty())
+        .map(|chunk| chunk.iter().copied().flatten().collect())
+        .collect()
 }
 
 #[cfg(test)]
@@ -261,6 +276,12 @@ mod tests {
     fn find_entry_colon_accepts_star_and_double_star() {
         assert_eq!(find_entry_colon("*args: list"), Some(5));
         assert_eq!(find_entry_colon("**kwargs: dict"), Some(8));
+    }
+
+    #[test]
+    fn find_entry_colon_accepts_underscore_led_name() {
+        assert_eq!(find_entry_colon("_arg: int"), Some(4));
+        assert_eq!(find_entry_colon("_: int"), Some(1));
     }
 
     #[test]

--- a/src/primitives/edit.rs
+++ b/src/primitives/edit.rs
@@ -75,76 +75,88 @@ pub(crate) fn narrow_edit(
     Some((span.add_start(prefix_len).sub_end(suffix_len), text))
 }
 
+/// Narrows `text` against the source slice covered by `span` and
+/// shapes the result as either a deletion or replacement Edit.
+/// Returns `None` when the text already matches the source slice.
+pub(crate) fn narrowed_replacement(source: &Source, span: TextRange, text: String) -> Option<Edit> {
+    let (narrowed_span, narrowed_text) = narrow_edit(text, span, source.slice(span))?;
+    Some(if narrowed_text.is_empty() {
+        Edit::range_deletion(narrowed_span)
+    } else {
+        Edit::range_replacement(narrowed_text, narrowed_span)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::range;
 
     #[test]
     fn narrow_edit_handles_multibyte_codepoint_at_divergence() {
-        let span = TextRange::new(0u32.into(), 7u32.into());
-        let (range, text) = narrow_edit("α = 1\n".to_owned(), span, "β = 1\n").expect("differs");
-        assert_eq!(range.start().to_u32(), 0);
-        assert_eq!(range.end().to_u32(), 2);
+        let span = range(0, 7);
+        let (r, text) = narrow_edit("α = 1\n".to_owned(), span, "β = 1\n").expect("differs");
+        assert_eq!(r.start().to_u32(), 0);
+        assert_eq!(r.end().to_u32(), 2);
         assert_eq!(text, "α");
     }
 
     #[test]
     fn narrow_edit_handles_pure_deletion() {
-        let span = TextRange::new(0u32.into(), 3u32.into());
-        let (range, text) = narrow_edit("ab".to_owned(), span, "abc").expect("differs");
-        assert_eq!(range.start().to_u32(), 2);
-        assert_eq!(range.end().to_u32(), 3);
+        let span = range(0, 3);
+        let (r, text) = narrow_edit("ab".to_owned(), span, "abc").expect("differs");
+        assert_eq!(r.start().to_u32(), 2);
+        assert_eq!(r.end().to_u32(), 3);
         assert_eq!(text, "");
     }
 
     #[test]
     fn narrow_edit_handles_pure_insertion() {
-        let span = TextRange::new(0u32.into(), 3u32.into());
-        let (range, text) = narrow_edit("abxc".to_owned(), span, "abc").expect("differs");
-        assert_eq!(range.start().to_u32(), 2);
-        assert_eq!(range.end().to_u32(), 2);
+        let span = range(0, 3);
+        let (r, text) = narrow_edit("abxc".to_owned(), span, "abc").expect("differs");
+        assert_eq!(r.start().to_u32(), 2);
+        assert_eq!(r.end().to_u32(), 2);
         assert_eq!(text, "x");
     }
 
     #[test]
     fn narrow_edit_returns_none_when_text_equals_source() {
-        let span = TextRange::new(0u32.into(), 5u32.into());
-        assert!(narrow_edit("hello".to_owned(), span, "hello").is_none());
+        assert!(narrow_edit("hello".to_owned(), range(0, 5), "hello").is_none());
     }
 
     #[test]
     fn narrow_edit_returns_whole_input_when_no_common_prefix_or_suffix() {
-        let span = TextRange::new(0u32.into(), 3u32.into());
-        let (range, text) = narrow_edit("abc".to_owned(), span, "xyz").expect("differs");
-        assert_eq!(range.start().to_u32(), 0);
-        assert_eq!(range.end().to_u32(), 3);
+        let span = range(0, 3);
+        let (r, text) = narrow_edit("abc".to_owned(), span, "xyz").expect("differs");
+        assert_eq!(r.start().to_u32(), 0);
+        assert_eq!(r.end().to_u32(), 3);
         assert_eq!(text, "abc");
     }
 
     #[test]
     fn narrow_edit_trims_common_prefix() {
-        let span = TextRange::new(0u32.into(), 3u32.into());
-        let (range, text) = narrow_edit("abc".to_owned(), span, "abd").expect("differs");
-        assert_eq!(range.start().to_u32(), 2);
-        assert_eq!(range.end().to_u32(), 3);
+        let span = range(0, 3);
+        let (r, text) = narrow_edit("abc".to_owned(), span, "abd").expect("differs");
+        assert_eq!(r.start().to_u32(), 2);
+        assert_eq!(r.end().to_u32(), 3);
         assert_eq!(text, "c");
     }
 
     #[test]
     fn narrow_edit_trims_common_prefix_and_suffix() {
-        let span = TextRange::new(0u32.into(), 7u32.into());
-        let (range, text) = narrow_edit("ab1cdef".to_owned(), span, "ab2cdef").expect("differs");
-        assert_eq!(range.start().to_u32(), 2);
-        assert_eq!(range.end().to_u32(), 3);
+        let span = range(0, 7);
+        let (r, text) = narrow_edit("ab1cdef".to_owned(), span, "ab2cdef").expect("differs");
+        assert_eq!(r.start().to_u32(), 2);
+        assert_eq!(r.end().to_u32(), 3);
         assert_eq!(text, "1");
     }
 
     #[test]
     fn narrow_edit_trims_common_suffix() {
-        let span = TextRange::new(0u32.into(), 3u32.into());
-        let (range, text) = narrow_edit("abc".to_owned(), span, "xbc").expect("differs");
-        assert_eq!(range.start().to_u32(), 0);
-        assert_eq!(range.end().to_u32(), 1);
+        let span = range(0, 3);
+        let (r, text) = narrow_edit("abc".to_owned(), span, "xbc").expect("differs");
+        assert_eq!(r.start().to_u32(), 0);
+        assert_eq!(r.end().to_u32(), 1);
         assert_eq!(text, "a");
     }
 }

--- a/src/primitives/orderer.rs
+++ b/src/primitives/orderer.rs
@@ -14,22 +14,26 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::source::Source;
 
-/// Splices each rendered child at its sorted position, copying the
-/// source text between adjacent blocks verbatim. `blocks` must be
-/// non-empty and in source order; `rendered` and `order` must have
-/// the same length as `blocks`.
+/// Splices each rendered child at its sorted position. `gap_override`
+/// returning `Some(text)` for new-order slot `i` substitutes that
+/// text for the source gap between slot `i` and slot `i + 1`. A
+/// `None` return copies the source gap verbatim. `blocks` must be
+/// non-empty and in source order, with `rendered` and `order` the
+/// same length as `blocks`.
 pub(crate) fn assemble_blocks<'src>(
     source: &'src Source,
     blocks: &[TextRange],
     rendered: &[Cow<'src, str>],
     order: &[usize],
+    mut gap_override: impl FnMut(usize) -> Option<&'src str>,
 ) -> String {
-    let span = blocks[0].cover(*blocks.last().expect("non-empty blocks"));
-    let mut out = String::with_capacity(span.len().to_usize());
-    for (i, &idx) in order.iter().enumerate() {
+    let mut out = String::with_capacity(blocks_span(blocks).len().to_usize());
+    for (i, (&idx, block)) in order.iter().zip(blocks).enumerate() {
         out.push_str(&rendered[idx]);
         if let Some(next) = blocks.get(i + 1) {
-            out.push_str(source.slice(TextRange::new(blocks[i].end(), next.start())));
+            let gap = gap_override(i)
+                .unwrap_or_else(|| source.slice(TextRange::new(block.end(), next.start())));
+            out.push_str(gap);
         }
     }
     out
@@ -48,12 +52,31 @@ pub(crate) fn block_range<T: Ranged>(
     outer: TextRange,
 ) -> TextRange {
     let item = items[i].range();
-    let lower = items[..i].last().map_or(outer.start(), |t| t.range().end());
-    let upper = items.get(i + 1).map_or(outer.end(), |t| t.range().start());
+    let lower = items[..i].last().map_or(outer.start(), |t| t.end());
+    let upper = items.get(i + 1).map_or(outer.end(), |t| t.start());
     TextRange::new(
         leading_attached_start(source, item.start(), lower),
         source.text().line_end(item.end()).min(upper),
     )
+}
+
+/// Total source extent covered by `blocks`. Requires non-empty input.
+pub(crate) fn blocks_span(blocks: &[TextRange]) -> TextRange {
+    blocks[0].cover(*blocks.last().expect("non-empty blocks"))
+}
+
+/// Convenience wrapper for `permute_in_place` over the full `items`
+/// span. Shared by every caller that sorts the entire slice rather
+/// than a sub-run.
+pub(crate) fn permute_full<'a, T, K>(
+    order: &mut [usize],
+    items: &'a [T],
+    classify: impl FnMut(&'a T) -> Option<K>,
+) -> bool
+where
+    K: Ord,
+{
+    permute_in_place(order, items, 0..items.len(), classify)
 }
 
 /// Permutes the slots of `order` within `range` in place by sorting
@@ -70,7 +93,10 @@ where
     K: Ord,
 {
     let (slots, mut keyed): (Vec<usize>, Vec<(K, usize)>) = range
-        .filter_map(|slot| classify(&items[order[slot]]).map(|k| (slot, (k, order[slot]))))
+        .filter_map(|slot| {
+            let src = order[slot];
+            classify(&items[src]).map(|k| (slot, (k, src)))
+        })
         .unzip();
     if keyed.is_sorted_by_key(|x| &x.0) {
         return false;
@@ -105,20 +131,22 @@ where
     if items.is_empty() {
         return Cow::Borrowed("");
     }
-    let blocks: Vec<TextRange> = items.iter().map(|t| t.range()).collect();
-    let rendered: Vec<Cow<'src, str>> = blocks
+    let (blocks, rendered): (Vec<TextRange>, Vec<Cow<'src, str>>) = items
         .iter()
         .enumerate()
-        .map(|(i, &block)| render_block(i, source.slice(block)))
-        .collect();
+        .map(|(i, t)| {
+            let block = t.range();
+            (block, render_block(i, source.slice(block)))
+        })
+        .unzip();
     let mut order: Vec<usize> = (0..items.len()).collect();
-    let permuted = permute_in_place(&mut order, items, 0..items.len(), classify);
-    let any_owned = rendered.iter().any(|c| matches!(c, Cow::Owned(_)));
-    let span = blocks[0].cover(*blocks.last().expect("non-empty blocks"));
-    if !permuted && !any_owned {
-        return Cow::Borrowed(source.slice(span));
+    let permuted = permute_full(&mut order, items, classify);
+    if !permuted && rendered.iter().all(|c| matches!(c, Cow::Borrowed(_))) {
+        return Cow::Borrowed(source.slice(blocks_span(&blocks)));
     }
-    Cow::Owned(assemble_blocks(source, &blocks, &rendered, &order))
+    Cow::Owned(assemble_blocks(source, &blocks, &rendered, &order, |_| {
+        None
+    }))
 }
 
 /// Walks backward through own-line comments preceding `item_start`,
@@ -148,55 +176,114 @@ fn leading_attached_start(source: &Source, item_start: TextSize, lower: TextSize
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use indoc::indoc;
     use ruff_text_size::TextLen;
 
     use super::*;
+    use crate::test_support::parse;
 
     fn body_range(source: &Source) -> TextRange {
         TextRange::up_to(source.text().text_len())
     }
 
+    fn borrow<'a>(_: usize, slice: &'a str) -> Cow<'a, str> {
+        Cow::Borrowed(slice)
+    }
+
+    #[test]
+    fn assemble_blocks_mixes_overridden_and_source_gaps() {
+        let source = parse("def a(): pass\ndef b(): pass\ndef c(): pass\n");
+        let blocks: Vec<TextRange> = source.ast().body.iter().map(|s| s.range()).collect();
+        let rendered: Vec<Cow<str>> = blocks
+            .iter()
+            .map(|&b| Cow::Borrowed(source.slice(b)))
+            .collect();
+        let order = vec![0, 1, 2];
+        let assembled = assemble_blocks(&source, &blocks, &rendered, &order, |i| {
+            (i == 0).then_some(" ; ")
+        });
+        assert_eq!(assembled, "def a(): pass ; def b(): pass\ndef c(): pass");
+    }
+
+    #[test]
+    fn assemble_blocks_substitutes_gap_when_override_returns_some() {
+        let source = parse("def a(): pass\ndef b(): pass\n");
+        let blocks: Vec<TextRange> = source.ast().body.iter().map(|s| s.range()).collect();
+        let rendered: Vec<Cow<str>> = blocks
+            .iter()
+            .map(|&b| Cow::Borrowed(source.slice(b)))
+            .collect();
+        let order = vec![0, 1];
+        let assembled = assemble_blocks(&source, &blocks, &rendered, &order, |_| Some(" ; "));
+        assert_eq!(assembled, "def a(): pass ; def b(): pass");
+    }
+
     #[test]
     fn block_range_excludes_detached_comment_above_blank_line() {
-        let src = indoc! {"
+        let source = parse(indoc! {"
             # detached
 
             def a(): pass
-        "};
-        let source = Source::from_str(src).expect("parses");
+        "});
         let block = block_range(&source, &source.ast().body, 0, body_range(&source));
         assert_eq!(source.slice(block), "def a(): pass");
     }
 
     #[test]
     fn block_range_extends_back_through_attached_comments() {
-        let src = indoc! {"
+        let source = parse(indoc! {"
             # one
             # two
             def a(): pass
-        "};
-        let source = Source::from_str(src).expect("parses");
+        "});
         let block = block_range(&source, &source.ast().body, 0, body_range(&source));
         assert_eq!(source.slice(block), "# one\n# two\ndef a(): pass");
     }
 
     #[test]
     fn block_range_extends_forward_through_inline_trailing_comment() {
-        let src = "def a(): pass  # trailing\n";
-        let source = Source::from_str(src).expect("parses");
+        let source = parse("def a(): pass  # trailing\n");
         let block = block_range(&source, &source.ast().body, 0, body_range(&source));
         assert_eq!(source.slice(block), "def a(): pass  # trailing");
     }
 
     #[test]
+    fn block_range_extends_to_end_of_final_line_for_multi_line_item() {
+        let source = parse(indoc! {"
+            def a(
+                x,
+                y,
+            ): pass  # trailing
+        "});
+        let block = block_range(&source, &source.ast().body, 0, body_range(&source));
+        assert_eq!(
+            source.slice(block),
+            "def a(\n    x,\n    y,\n): pass  # trailing"
+        );
+    }
+
+    #[test]
+    fn block_range_last_item_uses_outer_end_as_upper_bound() {
+        let source = parse("def a(): pass\ndef b(): pass  # trailing\n");
+        let body = &source.ast().body;
+        let block = block_range(&source, body, body.len() - 1, body_range(&source));
+        assert_eq!(source.slice(block), "def b(): pass  # trailing");
+    }
+
+    #[test]
     fn block_range_lower_bound_blocks_back_extension_into_prior_item() {
-        let src = "def a(): pass\ndef b(): pass\n";
-        let source = Source::from_str(src).expect("parses");
+        let source = parse("def a(): pass\ndef b(): pass\n");
         let block = block_range(&source, &source.ast().body, 1, body_range(&source));
         assert_eq!(source.slice(block), "def b(): pass");
+    }
+
+    #[test]
+    fn permute_in_place_leaves_slots_outside_range_untouched() {
+        let mut order = vec![0, 1, 2, 3];
+        let items = ["d", "c", "b", "a"];
+        let permuted = permute_in_place(&mut order, &items, 1..3, |s: &&str| Some(*s));
+        assert!(permuted);
+        assert_eq!(order, vec![0, 2, 1, 3]);
     }
 
     #[test]
@@ -208,6 +295,15 @@ mod tests {
         });
         assert!(permuted);
         assert_eq!(order, vec![2, 1, 0]);
+    }
+
+    #[test]
+    fn permute_in_place_preserves_relative_order_of_equal_keys() {
+        let mut order = vec![0, 1, 2, 3];
+        let items = [(2, 'a'), (1, 'b'), (1, 'c'), (1, 'd')];
+        let permuted = permute_in_place(&mut order, &items, 0..4, |t: &(u8, char)| Some(t.0));
+        assert!(permuted);
+        assert_eq!(order, vec![1, 2, 3, 0]);
     }
 
     #[test]
@@ -232,15 +328,14 @@ mod tests {
 
     #[test]
     fn reorder_text_inline_swaps_two_items() {
-        let src = "def f(b, a): pass\n";
-        let source = Source::from_str(src).expect("parses");
+        let source = parse("def f(b, a): pass\n");
         let func = source.ast().body[0].as_function_def_stmt().expect("def");
         let params = &func.parameters;
         let cow = reorder_text(
             &source,
             &params.args,
             |p| Some(p.parameter.name.as_str()),
-            |_, slice| Cow::Borrowed(slice),
+            borrow,
         );
         assert!(matches!(cow, Cow::Owned(_)));
         assert_eq!(&*cow, "a, b");
@@ -248,52 +343,49 @@ mod tests {
 
     #[test]
     fn reorder_text_pins_non_classified() {
-        let src = indoc! {"
+        let source = parse(indoc! {"
             def b(): pass
             CONST = 1
             def a(): pass
-        "};
-        let source = Source::from_str(src).expect("parses");
+        "});
         let body = &source.ast().body;
         let cow = reorder_text(
             &source,
             body,
             |stmt| stmt.as_function_def_stmt().map(|f| f.name.as_str()),
-            |_, slice| Cow::Borrowed(slice),
+            borrow,
         );
         assert_eq!(&*cow, "def a(): pass\nCONST = 1\ndef b(): pass");
     }
 
     #[test]
     fn reorder_text_returns_borrowed_when_already_sorted_and_no_render_change() {
-        let src = "def a(): pass\ndef b(): pass\n";
-        let source = Source::from_str(src).expect("parses");
+        let source = parse("def a(): pass\ndef b(): pass\n");
         let cow = reorder_text(
             &source,
             &source.ast().body,
             |stmt| stmt.as_function_def_stmt().map(|f| f.name.as_str()),
-            |_, slice| Cow::Borrowed(slice),
+            borrow,
         );
         assert!(matches!(cow, Cow::Borrowed(_)));
     }
 
     #[test]
     fn reorder_text_returns_empty_borrowed_for_empty_items() {
-        let source = Source::from_str("").expect("parses");
+        let source = parse("");
         let body = &source.ast().body;
         let cow = reorder_text(
             &source,
             body.as_slice(),
             |stmt: &ruff_python_ast::Stmt| stmt.as_function_def_stmt().map(|f| f.name.as_str()),
-            |_, slice| Cow::Borrowed(slice),
+            borrow,
         );
         assert!(matches!(cow, Cow::Borrowed("")));
     }
 
     #[test]
     fn reorder_text_returns_owned_when_render_block_owns_even_without_sort() {
-        let src = "def a(): pass\ndef b(): pass\n";
-        let source = Source::from_str(src).expect("parses");
+        let source = parse("def a(): pass\ndef b(): pass\n");
         let cow = reorder_text(
             &source,
             &source.ast().body,
@@ -308,5 +400,18 @@ mod tests {
         );
         assert!(matches!(cow, Cow::Owned(_)));
         assert!((*cow).contains("def A"));
+    }
+
+    #[test]
+    fn reorder_text_returns_owned_when_sort_and_render_owned_combine() {
+        let source = parse("def b(): pass\ndef a(): pass\n");
+        let cow = reorder_text(
+            &source,
+            &source.ast().body,
+            |stmt| stmt.as_function_def_stmt().map(|f| f.name.as_str()),
+            |_, slice| Cow::Owned(slice.replace("def ", "DEF ")),
+        );
+        assert!(matches!(cow, Cow::Owned(_)));
+        assert_eq!(&*cow, "DEF a(): pass\nDEF b(): pass");
     }
 }

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -17,18 +17,22 @@ use std::borrow::Cow;
 use std::ops::Range;
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::helpers::{any_over_expr, is_dunder, map_callable};
+use ruff_python_ast::helpers::{any_over_expr, is_compound_statement, is_dunder, map_callable};
 use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor as AstVisitor};
 use ruff_python_ast::{
-    Alias, Decorator, ExceptHandler, Expr, ExprCall, ExprLambda, ExprSet, Identifier,
-    ParameterWithDefault, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtDelete, StmtFunctionDef,
+    Alias, Decorator, DictItem, ExceptHandler, Expr, ExprCall, ExprDict, ExprLambda, ExprSet,
+    Identifier, ParameterWithDefault, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtDelete,
+    StmtFunctionDef,
 };
+use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::config::Config;
 use crate::pipeline::Rule;
-use crate::primitives::edit::{apply_inline_edits, narrow_edit};
-use crate::primitives::orderer::{assemble_blocks, block_range, permute_in_place, reorder_text};
+use crate::primitives::edit::{apply_inline_edits, narrowed_replacement};
+use crate::primitives::orderer::{
+    assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
+};
 use crate::source::Source;
 
 pub(crate) struct Alphabetize;
@@ -46,12 +50,18 @@ impl Rule for Alphabetize {
             return Vec::new();
         }
         let leaf_edits = collect_leaf_edits(source);
-        let outer = TextRange::up_to(source.text().text_len());
-        let (body_text, body_span) =
-            rewrite_body(source, body, outer, BodyScope::Module, &leaf_edits);
+        let (body_text, body_span) = rewrite_body(
+            source,
+            body,
+            TextRange::up_to(source.text().text_len()),
+            BodyScope::Module,
+            &leaf_edits,
+        );
         match body_text {
             Cow::Borrowed(_) => leaf_edits,
-            Cow::Owned(text) => emit_narrowed(source, body_span, text),
+            Cow::Owned(text) => narrowed_replacement(source, body_span, text)
+                .into_iter()
+                .collect(),
         }
     }
 
@@ -68,6 +78,7 @@ enum BodyScope {
 }
 
 struct LeafCollector<'a> {
+    dict_depth: u32,
     edits: Vec<Edit>,
     source: &'a Source,
 }
@@ -85,6 +96,13 @@ impl<'a> LeafCollector<'a> {
 
     fn emit_delete(&mut self, d: &'a StmtDelete) {
         self.try_emit_inline_reorder(&d.targets, |t| Some(self.source.slice(t)));
+    }
+
+    fn emit_dict(&mut self, d: &'a ExprDict) {
+        if let Some((span, text)) = rewrite_dict_text(self.source, d) {
+            self.edits
+                .push(Edit::range_replacement(text.into_owned(), span));
+        }
     }
 
     fn emit_dunder_list(&mut self, assign: &'a StmtAssign) {
@@ -149,6 +167,15 @@ impl<'a> LeafCollector<'a> {
 
 impl<'a> AstVisitor<'a> for LeafCollector<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
+        if let Expr::Dict(d) = expr {
+            if self.dict_depth == 0 {
+                self.emit_dict(d);
+            }
+            self.dict_depth += 1;
+            walk_expr(self, expr);
+            self.dict_depth -= 1;
+            return;
+        }
         match expr {
             Expr::Call(c) => self.emit_call(c),
             Expr::Lambda(l) => self.emit_lambda(l),
@@ -164,9 +191,9 @@ impl<'a> AstVisitor<'a> for LeafCollector<'a> {
             Stmt::Delete(d) => self.emit_delete(d),
             Stmt::FunctionDef(f) => self.emit_parameters(&f.parameters, pins_positional_params(f)),
             Stmt::Global(g) => self.emit_id_run(&g.names),
-            Stmt::Nonlocal(n) => self.emit_id_run(&n.names),
             Stmt::Import(i) => self.emit_alias_run(&i.names),
             Stmt::ImportFrom(i) => self.emit_alias_run(&i.names),
+            Stmt::Nonlocal(n) => self.emit_id_run(&n.names),
             _ => {}
         }
         walk_stmt(self, stmt);
@@ -178,6 +205,34 @@ impl<'a> AstVisitor<'a> for LeafCollector<'a> {
 fn ann_assign_with_named_field(stmt: &Stmt) -> Option<(&StmtAnnAssign, &str)> {
     let ann = stmt.as_ann_assign_stmt()?;
     Some((ann, ann.target.as_name_expr()?.id.as_str()))
+}
+
+/// Concatenates dict-item block texts in `order`, normalizing trailing
+/// commas so non-last slots always have one and the new-last slot
+/// matches `source_last_has_comma`. Inserts a blank line at every
+/// slot listed in `divider_slots`.
+fn assemble_dict_items_multiline(
+    block_texts: &[Cow<'_, str>],
+    order: &[usize],
+    divider_slots: &[usize],
+    source_last_has_comma: bool,
+) -> String {
+    let mut out = String::new();
+    for (slot, &idx) in order.iter().enumerate() {
+        let text = block_texts[idx].trim_end_matches(',');
+        out.push_str(text);
+        let is_last = slot + 1 == order.len();
+        if !is_last || source_last_has_comma {
+            out.push(',');
+        }
+        if !is_last {
+            out.push('\n');
+            if divider_slots.contains(&slot) {
+                out.push('\n');
+            }
+        }
+    }
+    out
 }
 
 /// True when a class body has at least two `Stmt::AnnAssign` field
@@ -199,7 +254,7 @@ fn class_pins_methods(body: &[Stmt]) -> bool {
 /// name. `self` and `cls` pin in place.
 fn classify_param(p: &ParameterWithDefault) -> Option<(u8, &str)> {
     let name = p.name().as_str();
-    if matches!(name, "self" | "cls") {
+    if matches!(name, "cls" | "self") {
         return None;
     }
     Some((u8::from(p.default.is_some()), name))
@@ -210,6 +265,7 @@ fn classify_param(p: &ParameterWithDefault) -> Option<(u8, &str)> {
 /// the resulting edits are non-overlapping with each other.
 fn collect_leaf_edits(source: &Source) -> Vec<Edit> {
     let mut collector = LeafCollector {
+        dict_depth: 0,
         edits: Vec::new(),
         source,
     };
@@ -223,6 +279,7 @@ fn collect_leaf_edits(source: &Source) -> Vec<Edit> {
 /// Empty sub-bodies are returned as-is and skipped by the caller.
 fn compound_sub_bodies(stmt: &Stmt) -> Vec<(&[Stmt], TextRange)> {
     match stmt {
+        Stmt::For(s) => vec![(s.body.as_slice(), s.range), (s.orelse.as_slice(), s.range)],
         Stmt::If(s) => std::iter::once((s.body.as_slice(), s.range))
             .chain(
                 s.elif_else_clauses
@@ -230,9 +287,11 @@ fn compound_sub_bodies(stmt: &Stmt) -> Vec<(&[Stmt], TextRange)> {
                     .map(|c| (c.body.as_slice(), c.range)),
             )
             .collect(),
-        Stmt::For(s) => vec![(s.body.as_slice(), s.range), (s.orelse.as_slice(), s.range)],
-        Stmt::While(s) => vec![(s.body.as_slice(), s.range), (s.orelse.as_slice(), s.range)],
-        Stmt::With(s) => vec![(s.body.as_slice(), s.range)],
+        Stmt::Match(s) => s
+            .cases
+            .iter()
+            .map(|c| (c.body.as_slice(), c.range))
+            .collect(),
         Stmt::Try(s) => std::iter::once((s.body.as_slice(), s.range))
             .chain(
                 s.handlers
@@ -244,18 +303,15 @@ fn compound_sub_bodies(stmt: &Stmt) -> Vec<(&[Stmt], TextRange)> {
                 (s.finalbody.as_slice(), s.range),
             ])
             .collect(),
-        Stmt::Match(s) => s
-            .cases
-            .iter()
-            .map(|c| (c.body.as_slice(), c.range))
-            .collect(),
+        Stmt::While(s) => vec![(s.body.as_slice(), s.range), (s.orelse.as_slice(), s.range)],
+        Stmt::With(s) => vec![(s.body.as_slice(), s.range)],
         _ => Vec::new(),
     }
 }
 
 /// Returns `Cow::Borrowed` of `source.slice(span)` when every part
 /// is still a borrow of source, signalling no descendant rewrite
-/// fired; otherwise concatenates the parts into a single owned
+/// fired. Otherwise concatenates the parts into a single owned
 /// string covering the same span.
 fn concat_or_borrow<'src>(
     parts: &[Cow<'src, str>],
@@ -270,21 +326,20 @@ fn concat_or_borrow<'src>(
 
 fn decorator_simple_name(decorator: &Decorator) -> Option<&str> {
     match map_callable(&decorator.expression) {
-        Expr::Name(name) => Some(name.id.as_str()),
         Expr::Attribute(attr) => Some(attr.attr.as_str()),
+        Expr::Name(name) => Some(name.id.as_str()),
         _ => None,
     }
 }
 
-fn emit_narrowed(source: &Source, span: TextRange, text: String) -> Vec<Edit> {
-    let Some((narrowed_span, narrowed_text)) = narrow_edit(text, span, source.slice(span)) else {
-        return Vec::new();
-    };
-    vec![if narrowed_text.is_empty() {
-        Edit::range_deletion(narrowed_span)
-    } else {
-        Edit::range_replacement(narrowed_text, narrowed_span)
-    }]
+/// Composite dict-item sort key. `**unpacked` items return `None` and
+/// pin in source position. Keyed items sort single-line entries before
+/// multi-line entries and alphabetize within each partition by the
+/// key's source slice.
+fn dict_sort_key<'a>(source: &'a Source, item: &'a DictItem) -> Option<(u8, &'a str)> {
+    let key = item.key.as_ref()?;
+    let group = u8::from(source.contains_line_break(item.range()));
+    Some((group, source.slice(key)))
 }
 
 /// True when an annotated assignment carries a default, either
@@ -302,6 +357,17 @@ fn has_default(ann: &StmtAnnAssign) -> bool {
         })
 }
 
+/// True when the line containing the dict's opening `{` carries a
+/// trailing `# prose: keep` comment.
+fn has_keep_marker(source: &Source, dict: &ExprDict) -> bool {
+    let line = source.text().full_line_range(dict.range().start());
+    source
+        .comment_ranges()
+        .comments_in_range(line)
+        .iter()
+        .any(|c| source.slice(c).trim_start_matches('#').trim() == "prose: keep")
+}
+
 /// Returns the method-group index. `0` for dunders, `1` for
 /// `@property` / `@cached_property` (decided by the first decorator),
 /// `2` for single-leading-underscore privates, `3` for public.
@@ -313,7 +379,7 @@ fn method_group(f: &StmtFunctionDef) -> u8 {
         .decorator_list
         .first()
         .and_then(decorator_simple_name)
-        .is_some_and(|n| matches!(n, "property" | "cached_property"))
+        .is_some_and(|n| matches!(n, "cached_property" | "property"))
     {
         1
     } else if name.starts_with('_') {
@@ -321,6 +387,18 @@ fn method_group(f: &StmtFunctionDef) -> u8 {
     } else {
         3
     }
+}
+
+/// Returns the new-order slot indices after which a blank-line
+/// divider should sit. A divider goes on either side of every keyed
+/// multi-line entry, isolating it from its neighbors so each
+/// multi-line entry forms its own alignment group downstream.
+fn partition_divider_slots(source: &Source, order: &[usize], items: &[DictItem]) -> Vec<usize> {
+    let is_multiline =
+        |i: usize| items[i].key.is_some() && source.contains_line_break(items[i].range());
+    (0..order.len() - 1)
+        .filter(|&s| is_multiline(order[s]) || is_multiline(order[s + 1]))
+        .collect()
 }
 
 /// True when any of `f`'s decorators is a `Call` carrying positional
@@ -337,8 +415,9 @@ fn pins_positional_params(f: &StmtFunctionDef) -> bool {
 /// Rewrites a non-empty body, returning the rewritten text alongside
 /// the block-extent span it covers. The text is `Cow::Owned` when any
 /// sibling reorder fires, any descendant rewrite produces owned
-/// content, or any leaf edit lands inside; otherwise `Cow::Borrowed`
-/// over `source.slice(span)`. `scope` selects which family sorts apply.
+/// content, or any leaf edit lands inside, falling back to
+/// `Cow::Borrowed` over `source.slice(span)`. `scope` selects which
+/// family sorts apply.
 fn rewrite_body<'src>(
     source: &'src Source,
     body: &[Stmt],
@@ -354,46 +433,55 @@ fn rewrite_body<'src>(
             (block, rewrite_stmt(source, stmt, block, scope, leaf_edits))
         })
         .unzip();
-    let blocks_span = blocks[0].cover(*blocks.last().expect("non-empty"));
-    let mut order: Vec<usize> = (0..body.len()).collect();
+    let body_span = blocks_span(&blocks);
+    let n = body.len();
+    let mut order: Vec<usize> = (0..n).collect();
     let in_class = scope == BodyScope::Class;
     if scope != BodyScope::Function {
-        permute_in_place(&mut order, body, 0..body.len(), |s| {
+        permute_full(&mut order, body, |s| {
             s.as_class_def_stmt().map(|c| c.name.as_str())
         });
         if in_class {
-            permute_in_place(&mut order, body, 0..body.len(), |s| {
+            permute_full(&mut order, body, |s| {
                 ann_assign_with_named_field(s).map(|(ann, name)| (u8::from(has_default(ann)), name))
             });
-            permute_in_place(&mut order, body, 0..body.len(), simple_name_assign);
+            permute_full(&mut order, body, simple_name_assign);
         }
         if !(in_class && class_pins_methods(body)) {
-            permute_in_place(&mut order, body, 0..body.len(), |s| {
+            permute_full(&mut order, body, |s| {
                 s.as_function_def_stmt()
                     .map(|f| (method_group(f), f.name.as_str()))
             });
         }
     }
-    for run in statement_run_ranges(source, body, Stmt::is_import_from_stmt) {
-        permute_in_place(&mut order, body, run, |s| {
+    let mut import_run_slots: Vec<usize> = Vec::new();
+    for Range { start, end } in statement_run_ranges(body, Stmt::is_import_from_stmt) {
+        permute_in_place(&mut order, body, start..end, |s| {
             let i = s.as_import_from_stmt()?;
             Some((i.level, i.module.as_deref().unwrap_or_default()))
         });
+        import_run_slots.extend(start..end - 1);
     }
-    for run in statement_run_ranges(source, body, Stmt::is_import_stmt) {
-        permute_in_place(&mut order, body, run, |s| {
-            Some(s.as_import_stmt()?.names.first()?.name.as_str())
+    for Range { start, end } in statement_run_ranges(body, Stmt::is_import_stmt) {
+        permute_in_place(&mut order, body, start..end, |s| {
+            s.as_import_stmt()?
+                .names
+                .iter()
+                .map(|a| a.name.as_str())
+                .min()
         });
+        import_run_slots.extend(start..end - 1);
     }
+    import_run_slots.sort_unstable();
     let any_owned = rendered.iter().any(|c| matches!(c, Cow::Owned(_)));
-    let identity = order.iter().copied().eq(0..body.len());
-    if !any_owned && identity {
-        return (Cow::Borrowed(source.slice(blocks_span)), blocks_span);
+    let identity = order.iter().copied().eq(0..n);
+    if !any_owned && identity && import_run_slots.is_empty() {
+        return (Cow::Borrowed(source.slice(body_span)), body_span);
     }
-    (
-        Cow::Owned(assemble_blocks(source, &blocks, &rendered, &order)),
-        blocks_span,
-    )
+    let assembled = assemble_blocks(source, &blocks, &rendered, &order, |i| {
+        import_run_slots.binary_search(&i).ok().map(|_| "\n")
+    });
+    (Cow::Owned(assembled), body_span)
 }
 
 /// Recurses into each sub-body of a compound statement, splicing
@@ -413,6 +501,76 @@ fn rewrite_compound<'src>(
     splice_bodies(source, block, bodies, leaf_edits)
 }
 
+/// Rewrites a dict literal's items span. Returns `Some((span, text))`
+/// when reordering, partition, or any nested-dict rewrite produces
+/// text different from the source slice. Returns `None` for empty
+/// dicts, dicts marked `# prose: keep`, single-item dicts, and any
+/// already-canonical case. Recurses into nested dicts that sit
+/// directly as item values.
+fn rewrite_dict_text<'src>(
+    source: &'src Source,
+    d: &ExprDict,
+) -> Option<(TextRange, Cow<'src, str>)> {
+    if d.items.is_empty() || has_keep_marker(source, d) {
+        return None;
+    }
+    let [first, .., last] = d.items.as_slice() else {
+        return None;
+    };
+    let multi_line = source.contains_line_break(first.range().cover(last.range()));
+    let blocks: Vec<TextRange> = if multi_line {
+        (0..d.items.len())
+            .map(|i| block_range(source, &d.items, i, d.range()))
+            .collect()
+    } else {
+        d.items.iter().map(|item| item.range()).collect()
+    };
+    let span = blocks_span(&blocks);
+    let block_texts: Vec<Cow<'src, str>> = d
+        .items
+        .iter()
+        .enumerate()
+        .map(|(i, item)| rewrite_item_block(source, blocks[i], item))
+        .collect();
+    let any_nested_rewrite = block_texts.iter().any(|c| matches!(c, Cow::Owned(_)));
+    let mut order: Vec<usize> = (0..d.items.len()).collect();
+    let permuted = permute_full(&mut order, &d.items, |item| dict_sort_key(source, item));
+    let assembled = if multi_line {
+        let divider_slots = partition_divider_slots(source, &order, &d.items);
+        let source_last_has_comma = source
+            .slice(*blocks.last().expect("non-empty"))
+            .trim_end()
+            .ends_with(',');
+        assemble_dict_items_multiline(&block_texts, &order, &divider_slots, source_last_has_comma)
+    } else {
+        assemble_blocks(source, &blocks, &block_texts, &order, |_| None)
+    };
+    if !permuted && !any_nested_rewrite && assembled == source.slice(span) {
+        return None;
+    }
+    Some((span, Cow::Owned(assembled)))
+}
+
+/// Returns the block text for a dict item, recursively rewriting a
+/// nested dict that sits directly as the item's value. Returns
+/// `Cow::Borrowed` of `source.slice(block)` when no recursion fires or
+/// the recursive call leaves the inner dict unchanged.
+fn rewrite_item_block<'src>(
+    source: &'src Source,
+    block: TextRange,
+    item: &DictItem,
+) -> Cow<'src, str> {
+    let Expr::Dict(inner) = &item.value else {
+        return Cow::Borrowed(source.slice(block));
+    };
+    let Some((inner_span, inner_text)) = rewrite_dict_text(source, inner) else {
+        return Cow::Borrowed(source.slice(block));
+    };
+    let prefix = source.slice(TextRange::new(block.start(), inner_span.start()));
+    let suffix = source.slice(TextRange::new(inner_span.end(), block.end()));
+    Cow::Owned(format!("{prefix}{inner_text}{suffix}"))
+}
+
 /// Rewrites a single statement. Classes and functions fold their body
 /// via `rewrite_body` and splice the result. Compound statements
 /// (`if`, `for`, `while`, `with`, `try`, `match`) recurse into each
@@ -429,12 +587,9 @@ fn rewrite_stmt<'src>(
     let (body, body_outer, scope): (&[Stmt], TextRange, BodyScope) = match stmt {
         Stmt::ClassDef(c) => (&c.body, c.range(), BodyScope::Class),
         Stmt::FunctionDef(f) => (&f.body, f.range(), BodyScope::Function),
-        Stmt::If(_)
-        | Stmt::For(_)
-        | Stmt::While(_)
-        | Stmt::With(_)
-        | Stmt::Try(_)
-        | Stmt::Match(_) => return rewrite_compound(source, stmt, block, parent_scope, leaf_edits),
+        s if is_compound_statement(s) => {
+            return rewrite_compound(source, stmt, block, parent_scope, leaf_edits)
+        }
         _ => return apply_inline_edits(source, block, leaf_edits),
     };
     if body.is_empty() {
@@ -495,38 +650,32 @@ where
     concat_or_borrow(&parts, source, block)
 }
 
-/// Builds a `Vec<Range<usize>>` of contiguous body slots whose
-/// statements all match `predicate` and are line-adjacent to their
-/// neighbors. Singleton runs drop.
+/// Builds a `Vec<Range<usize>>` of body slots whose statements all
+/// match `predicate`. Adjacent matching statements stay in the same
+/// run regardless of any blank lines between them, so all imports
+/// of the same form collapse into one block at the top of the body.
+/// Non-matching statements break the run. Singleton runs drop.
 fn statement_run_ranges(
-    source: &Source,
     body: &[Stmt],
     mut predicate: impl FnMut(&Stmt) -> bool,
 ) -> Vec<Range<usize>> {
     let mut start = 0;
-    body.chunk_by(|a, b| {
-        predicate(a) && predicate(b) && source.is_line_adjacent(TextRange::new(a.end(), b.start()))
-    })
-    .filter_map(|chunk| {
-        let end = start + chunk.len();
-        let range = (chunk.len() >= 2).then_some(start..end);
-        start = end;
-        range
-    })
-    .collect()
+    body.chunk_by(|a, b| predicate(a) && predicate(b))
+        .filter_map(|chunk| {
+            let end = start + chunk.len();
+            let range = (chunk.len() >= 2).then_some(start..end);
+            start = end;
+            range
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use indoc::indoc;
 
     use super::*;
-
-    fn parse(src: &str) -> Source {
-        Source::from_str(src).expect("test source parses")
-    }
+    use crate::test_support::parse;
 
     #[test]
     fn ann_assign_with_named_field_filters_to_name_targets() {
@@ -550,12 +699,9 @@ mod tests {
             def f(b, a): foo(b=2, a=1)
         "};
         let edits = collect_leaf_edits(&parse(src));
-        let starts: Vec<u32> = edits.iter().map(|e| e.start().to_u32()).collect();
-        assert!(starts.len() >= 5, "fixture must trigger multiple producers");
-        let mut sorted = starts.clone();
-        sorted.sort_unstable();
-        assert_eq!(
-            starts, sorted,
+        assert!(edits.len() >= 5, "fixture must trigger multiple producers");
+        assert!(
+            edits.is_sorted(),
             "leaf edits must be emitted in source order; partition_point in apply_inline_edits relies on this",
         );
     }
@@ -588,6 +734,27 @@ mod tests {
         let f = s.ast().body[0].as_function_def_stmt().expect("def");
         let decorator = f.decorator_list.first().expect("one decorator");
         assert_eq!(decorator_simple_name(decorator), None);
+    }
+
+    #[test]
+    fn method_group_orders_dunder_property_private_public() {
+        let src = indoc! {"
+            class C:
+                def __init__(self): pass
+                @property
+                def name(self): pass
+                def _helper(self): pass
+                def public(self): pass
+        "};
+        let s = parse(src);
+        let class = s.ast().body[0].as_class_def_stmt().expect("class");
+        let groups: Vec<u8> = class
+            .body
+            .iter()
+            .filter_map(Stmt::as_function_def_stmt)
+            .map(method_group)
+            .collect();
+        assert_eq!(groups, vec![0, 1, 2, 3]);
     }
 
     #[test]

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -396,8 +396,11 @@ fn method_group(f: &StmtFunctionDef) -> u8 {
 fn partition_divider_slots(source: &Source, order: &[usize], items: &[DictItem]) -> Vec<usize> {
     let is_multiline =
         |i: usize| items[i].key.is_some() && source.contains_line_break(items[i].range());
-    (0..order.len() - 1)
-        .filter(|&s| is_multiline(order[s]) || is_multiline(order[s + 1]))
+    order
+        .windows(2)
+        .enumerate()
+        .filter(|(_, w)| is_multiline(w[0]) || is_multiline(w[1]))
+        .map(|(i, _)| i)
         .collect()
 }
 
@@ -511,7 +514,7 @@ fn rewrite_dict_text<'src>(
     source: &'src Source,
     d: &ExprDict,
 ) -> Option<(TextRange, Cow<'src, str>)> {
-    if d.items.is_empty() || has_keep_marker(source, d) {
+    if d.is_empty() || has_keep_marker(source, d) {
         return None;
     }
     let [first, .., last] = d.items.as_slice() else {
@@ -519,21 +522,20 @@ fn rewrite_dict_text<'src>(
     };
     let multi_line = source.contains_line_break(first.range().cover(last.range()));
     let blocks: Vec<TextRange> = if multi_line {
-        (0..d.items.len())
+        (0..d.len())
             .map(|i| block_range(source, &d.items, i, d.range()))
             .collect()
     } else {
-        d.items.iter().map(|item| item.range()).collect()
+        d.iter().map(Ranged::range).collect()
     };
     let span = blocks_span(&blocks);
-    let block_texts: Vec<Cow<'src, str>> = d
-        .items
+    let block_texts: Vec<Cow<'src, str>> = blocks
         .iter()
-        .enumerate()
-        .map(|(i, item)| rewrite_item_block(source, blocks[i], item))
+        .zip(d)
+        .map(|(&block, item)| rewrite_item_block(source, block, item))
         .collect();
     let any_nested_rewrite = block_texts.iter().any(|c| matches!(c, Cow::Owned(_)));
-    let mut order: Vec<usize> = (0..d.items.len()).collect();
+    let mut order: Vec<usize> = (0..d.len()).collect();
     let permuted = permute_full(&mut order, &d.items, |item| dict_sort_key(source, item));
     let assembled = if multi_line {
         let divider_slots = partition_divider_slots(source, &order, &d.items);
@@ -560,7 +562,7 @@ fn rewrite_item_block<'src>(
     block: TextRange,
     item: &DictItem,
 ) -> Cow<'src, str> {
-    let Expr::Dict(inner) = &item.value else {
+    let Some(inner) = item.value.as_dict_expr() else {
         return Cow::Borrowed(source.slice(block));
     };
     let Some((inner_span, inner_text)) = rewrite_dict_text(source, inner) else {

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -12,12 +12,12 @@ use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::visitor::{walk_expr, Visitor};
 use ruff_python_ast::{AnyNodeRef, DictItem, Expr};
-use ruff_source_file::{find_newline, LineEnding};
 use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
 use crate::pipeline::Rule;
+use crate::primitives::edit::narrowed_replacement;
 use crate::source::Source;
 
 const DEFAULT_LINE_LENGTH: usize = 88;
@@ -46,14 +46,11 @@ impl CollectionLayout {
 
 impl Rule for CollectionLayout {
     fn apply(&self, source: &Source) -> Vec<Edit> {
-        let newline = find_newline(source.text())
-            .map_or(LineEnding::Lf, |(_, ending)| ending)
-            .as_str();
         let mut visitor = Expander {
             edits: Vec::new(),
             line_length: self.line_length,
             max_atomics_per_line: self.max_atomics_per_line,
-            newline,
+            newline: source.newline_str(),
             source,
         };
         visitor.visit_body(&source.ast().body);
@@ -75,14 +72,18 @@ struct Expander<'a> {
 
 impl<'a> Expander<'a> {
     /// Builds the expanded form of `expr` as a string, recursively
-    /// expanding any qualifying child collections so the caller's
-    /// single `range_replacement` covers every descendant rewrite.
+    /// expanding any qualifying child collections.
     fn expand(&self, expr: &Expr, indent: usize) -> String {
         let item_indent = indent + INDENT_STEP;
-        let (open, close, texts, atomics) = self.gather_items(expr, item_indent);
+        let GatheredItems {
+            atomics,
+            close,
+            open,
+            ranges,
+            texts,
+        } = self.gather_items(expr, item_indent);
         let total = texts.len();
         let item_prefix = " ".repeat(item_indent);
-        let close_prefix = " ".repeat(indent);
         let available = self.line_length.saturating_sub(item_indent);
         let mut out = String::new();
         out.push(open);
@@ -97,65 +98,78 @@ impl<'a> Expander<'a> {
                             out.push(',');
                         }
                         out.push_str(self.newline);
+                        if idx + 1 < total
+                            && self.source.has_blank_line_before(ranges[idx + 1].start())
+                        {
+                            out.push_str(self.newline);
+                        }
                     }
                 }
                 Segment::Flow(range) => {
                     let run_start = range.start;
                     let widths: Vec<usize> = range.map(|i| texts[i].width()).collect();
                     for line_range in flow_lines(&widths, available, self.max_atomics_per_line) {
+                        let line_start = run_start + line_range.start;
+                        let line_end = run_start + line_range.end;
+                        let parts: Vec<&str> =
+                            (line_start..line_end).map(|i| texts[i].as_ref()).collect();
                         out.push_str(&item_prefix);
-                        let line_size = line_range.len();
-                        let absolute = (run_start + line_range.start)..(run_start + line_range.end);
-                        for (line_pos, idx) in absolute.enumerate() {
-                            out.push_str(&texts[idx]);
-                            if idx + 1 != total {
-                                out.push(',');
-                                if line_pos + 1 != line_size {
-                                    out.push(' ');
-                                }
-                            }
+                        out.push_str(&parts.join(", "));
+                        if line_end < total {
+                            out.push(',');
                         }
                         out.push_str(self.newline);
                     }
                 }
             }
         }
-        out.push_str(&close_prefix);
+        out.push_str(&" ".repeat(indent));
         out.push(close);
         out
     }
 
-    /// Collects the bracket pair, per-item serialized text, and
-    /// per-item atomicity for the collection at `expr`. The text is
-    /// produced via `serialize_expr` / `serialize_dict_item` at
-    /// `indent`, so nested qualifying children are already recursively
-    /// expanded in the returned strings. Items that need no expansion
-    /// pass through as `Cow::Borrowed` of their source slice.
-    fn gather_items(
-        &self,
-        expr: &Expr,
-        indent: usize,
-    ) -> (char, char, Vec<Cow<'a, str>>, Vec<bool>) {
+    /// Collects the bracket pair, per-item serialized text, per-item
+    /// atomicity, and per-item source range for the collection at
+    /// `expr`. The text is produced via `serialize_expr` /
+    /// `serialize_dict_item` at `indent`, so nested qualifying
+    /// children are already recursively expanded in the returned
+    /// strings. Items that need no expansion pass through as
+    /// `Cow::Borrowed` of their source slice.
+    fn gather_items(&self, expr: &Expr, indent: usize) -> GatheredItems<'a> {
         let parent = AnyNodeRef::from(expr);
         if let Expr::Dict(d) = expr {
-            let texts: Vec<Cow<'a, str>> = d
-                .items
+            let (texts, ranges): (Vec<Cow<'a, str>>, Vec<TextRange>) = d
                 .iter()
-                .map(|item| self.serialize_dict_item(item, parent, indent))
-                .collect();
-            let atomics = vec![false; d.items.len()];
-            return ('{', '}', texts, atomics);
+                .map(|item| (self.serialize_dict_item(item, parent, indent), item.range()))
+                .unzip();
+            return GatheredItems {
+                atomics: vec![false; d.len()],
+                close: '}',
+                open: '{',
+                ranges,
+                texts,
+            };
         }
         let (open, close, elts) = match expr {
             Expr::List(l) => ('[', ']', &l.elts),
             Expr::Set(s) => ('{', '}', &s.elts),
             _ => unreachable!("gather_items called on non-collection expr"),
         };
-        let (texts, atomics): (Vec<Cow<'a, str>>, Vec<bool>) = elts
-            .iter()
-            .map(|e| (self.serialize_expr(e, parent, indent, indent), is_atomic(e)))
-            .unzip();
-        (open, close, texts, atomics)
+        let mut texts = Vec::with_capacity(elts.len());
+        let mut atomics = Vec::with_capacity(elts.len());
+        let mut ranges = Vec::with_capacity(elts.len());
+        for e in elts {
+            texts.push(self.serialize_expr(e, parent, indent, indent));
+            atomics.push(is_atomic(e));
+            ranges.push(e.range());
+        }
+        GatheredItems {
+            atomics,
+            close,
+            open,
+            ranges,
+            texts,
+        }
     }
 
     /// Serializes a dict item as `key: value` or `**value`.
@@ -166,9 +180,9 @@ impl<'a> Expander<'a> {
     /// long key that pushes its value past the budget correctly
     /// triggers expansion of the value. When the value does expand,
     /// its closing bracket still lands at `indent`. When the value
-    /// passes through borrowed and the source already carries the
-    /// canonical `": "` gap, the item's source slice is returned
-    /// borrowed.
+    /// passes through borrowed and the source carries an
+    /// `align-colons`-shaped gap (`[ ]*: `), the item's source slice
+    /// is returned borrowed so the alignment padding round-trips.
     fn serialize_dict_item(
         &self,
         item: &DictItem,
@@ -179,13 +193,14 @@ impl<'a> Expander<'a> {
             let key_text = self.source.slice(key);
             let value_column = indent + key_text.width() + 2;
             let value_text = self.serialize_expr(&item.value, parent, value_column, indent);
-            let canonical = matches!(value_text, Cow::Borrowed(_))
-                && self
-                    .source
-                    .slice(TextRange::new(key.end(), item.value.start()))
-                    == ": ";
-            if canonical {
+            let gap = self
+                .source
+                .slice(TextRange::new(key.end(), item.value.start()));
+            let aligned = is_align_colons_gap(gap);
+            if aligned && matches!(value_text, Cow::Borrowed(_)) {
                 Cow::Borrowed(self.source.slice(item))
+            } else if aligned {
+                Cow::Owned(format!("{key_text}{gap}{value_text}"))
             } else {
                 Cow::Owned(format!("{key_text}: {value_text}"))
             }
@@ -224,46 +239,50 @@ impl<'a> Expander<'a> {
 
     /// Returns `true` when `expr` is a qualifying collection whose
     /// inline form would overflow the line-length budget at `column`.
-    ///
-    /// Multi-line input always returns `true` so that oddball layouts
-    /// canonicalize through `expand`. Single-line input only returns
-    /// `true` when `column + inline_length > line_length`.
+    /// Multi-line input always returns `true`. Single-line input
+    /// returns `true` only when `column + inline_length > line_length`.
     fn should_expand(&self, expr: &Expr, column: usize) -> bool {
-        let count = match expr {
-            Expr::Dict(d) => d.items.len(),
-            Expr::List(l) => l.elts.len(),
-            Expr::Set(s) => s.elts.len(),
+        let multi_item = match expr {
+            Expr::Dict(d) => d.len() > 1,
+            Expr::List(l) => l.len() > 1,
+            Expr::Set(s) => s.len() > 1,
             _ => return false,
         };
-        if count <= 1 {
-            return false;
-        }
         let range = expr.range();
-        if self.source.intersects_comment(range) {
-            return false;
-        }
-        self.source.contains_line_break(range)
-            || column + self.source.slice(range).width() > self.line_length
+        multi_item
+            && !self.source.intersects_comment(range)
+            && (self.source.contains_line_break(range)
+                || column + self.source.slice(range).width() > self.line_length)
     }
 }
 
 impl<'a> Visitor<'a> for Expander<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
-        let column = self.source.column_of(expr.start());
-        if self.should_expand(expr, column) {
-            let indent = self.source.line_indent_width(expr.start());
-            let replacement = self.expand(expr, indent);
-            if replacement != self.source.slice(expr.range()) {
-                self.edits
-                    .push(Edit::range_replacement(replacement, expr.range()));
-            }
+        let range = expr.range();
+        if !self.should_expand(expr, self.source.column_of(range.start())) {
+            walk_expr(self, expr);
             return;
         }
-        walk_expr(self, expr);
+        let indent = self.source.line_indent_width(range.start());
+        let replacement = self.expand(expr, indent);
+        self.edits
+            .extend(narrowed_replacement(self.source, range, replacement));
     }
 }
 
+/// Per-item state collected from a dict, list, or set literal:
+/// serialized text, atomicity for layout dispatch, and source range
+/// for blank-line-preservation lookups.
+struct GatheredItems<'src> {
+    atomics: Vec<bool>,
+    close: char,
+    open: char,
+    ranges: Vec<TextRange>,
+    texts: Vec<Cow<'src, str>>,
+}
+
 /// Describes how a contiguous slice of items should lay out.
+#[derive(Debug, PartialEq)]
 enum Segment {
     /// Items in the range flow across as few balanced lines as fit.
     Flow(Range<usize>),
@@ -273,9 +292,9 @@ enum Segment {
 
 /// Distributes items into the smallest number of lines such that no
 /// line exceeds `available` characters and no line carries more than
-/// `max_atomics` items, giving roughly equal item counts per line for
-/// visual balance. Escalates to more lines if the even split at the
-/// minimum line count would still overflow either cap.
+/// `max_atomics` items, giving roughly equal item counts per line.
+/// Escalates to more lines if the even split at the minimum line
+/// count would still overflow either cap.
 fn flow_lines(widths: &[usize], available: usize, max_atomics: usize) -> Vec<Range<usize>> {
     if widths.is_empty() {
         return Vec::new();
@@ -297,22 +316,24 @@ fn flow_lines(widths: &[usize], available: usize, max_atomics: usize) -> Vec<Ran
         .unwrap_or_else(|| (0..n).map(|i| i..(i + 1)).collect())
 }
 
-/// Returns `true` for expressions that render as a single compact
-/// token and therefore do not benefit from a dedicated line.
-///
-/// Covers literal values, dotted names (`pkg`, `cls.name.upper`,
-/// reached via `ruff_python_ast::helpers::is_dotted_name`), and unary
-/// operations over atomic operands (`-1`, `not flag`). Starred
-/// expressions (`*name`, `**name`) are intentionally non-atomic so a
-/// spread in the middle of a list or set splits its surrounding
-/// atomics into two independent runs that each flow on their own.
-/// Everything else (calls, comparisons, arithmetic, nested
-/// collections, comprehensions) is considered structured and earns a
-/// line of its own in the output.
+/// Returns `true` when `gap` is zero or more ASCII spaces, then
+/// `:`, then one ASCII space.
+fn is_align_colons_gap(gap: &str) -> bool {
+    gap.strip_suffix(": ")
+        .is_some_and(|prefix| prefix.bytes().all(|b| b == b' '))
+}
+
+/// True for expressions that render as a single compact token and
+/// therefore do not benefit from a dedicated line. Covers literals,
+/// dotted names, and unary operations over atomic operands. Starred
+/// expressions are non-atomic so a spread splits surrounding atomics
+/// into independent runs.
 fn is_atomic(expr: &Expr) -> bool {
     expr.is_literal_expr()
         || is_dotted_name(expr)
-        || matches!(expr, Expr::UnaryOp(u) if is_atomic(&u.operand))
+        || expr
+            .as_unary_op_expr()
+            .is_some_and(|u| is_atomic(&u.operand))
 }
 
 /// Partitions `atomics` into segments. Every contiguous run of
@@ -376,6 +397,40 @@ mod tests {
     use super::*;
 
     #[test]
+    fn align_colons_gap_accepts_canonical_and_padded_forms() {
+        assert!(is_align_colons_gap(": "));
+        assert!(is_align_colons_gap(" : "));
+        assert!(is_align_colons_gap("    : "));
+    }
+
+    #[test]
+    fn align_colons_gap_rejects_non_padding_shapes() {
+        assert!(!is_align_colons_gap(":"));
+        assert!(!is_align_colons_gap(":  "));
+        assert!(!is_align_colons_gap(" :"));
+        assert!(!is_align_colons_gap("\t: "));
+        assert!(!is_align_colons_gap(""));
+    }
+
+    #[test]
+    fn flow_lines_escalates_when_initial_split_overflows() {
+        // Total width forces an initial guess of 2 lines, but the
+        // only even 2-line split puts three 10-wide items on one line
+        // and overflows. The find_map must escalate to 3 lines.
+        let lines = flow_lines(&[10, 10, 10, 1, 1, 1], 23, 8);
+        assert_eq!(lines, vec![0..2, 2..4, 4..6]);
+    }
+
+    #[test]
+    fn flow_lines_falls_back_to_one_per_line_when_no_split_fits() {
+        // The lone 100-wide item exceeds available=10, pushing initial
+        // above n=1 so the find_map range is empty. The fallback
+        // emits one item per line.
+        let lines = flow_lines(&[100], 10, 8);
+        assert_eq!(lines, vec![0..1]);
+    }
+
+    #[test]
     fn flow_lines_packs_into_one_line_when_budget_allows() {
         let lines = flow_lines(&[1, 1, 1, 1], 80, 8);
         assert_eq!(lines, vec![0..4]);
@@ -396,6 +451,25 @@ mod tests {
     fn flow_lines_splits_when_max_atomics_forces_it() {
         let lines = flow_lines(&[1; 6], 80, 3);
         assert_eq!(lines, vec![0..3, 3..6]);
+    }
+
+    #[test]
+    fn segments_partitions_alternating_atomic_runs() {
+        let result = segments(&[true, true, false, true, false, false]);
+        assert_eq!(
+            result,
+            vec![
+                Segment::Flow(0..2),
+                Segment::OnePerLine(2..3),
+                Segment::Flow(3..4),
+                Segment::OnePerLine(4..6),
+            ],
+        );
+    }
+
+    #[test]
+    fn segments_returns_empty_for_empty_input() {
+        assert!(segments(&[]).is_empty());
     }
 
     #[test]

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -113,15 +113,13 @@ impl<'a> StatementVisitor<'a> for Visitor<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
+    use crate::test_support::parse;
 
     /// Parses `src` as a module and tests whether its first top-level
     /// statement would qualify a `match` arm.
     fn collapsible(src: &str) -> bool {
-        let s = Source::from_str(src).expect("test source parses");
-        !is_compound_statement(&s.ast().body[0])
+        !is_compound_statement(&parse(src).ast().body[0])
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -11,7 +11,9 @@ use ruff_python_ast::token::{Token, Tokens};
 use ruff_python_ast::ModModule;
 use ruff_python_parser::{parse_module, ParseError, Parsed};
 use ruff_python_trivia::{leading_indentation, lines_before, CommentRanges};
-use ruff_source_file::{LineColumn, LineRanges, SourceFile, SourceFileBuilder};
+use ruff_source_file::{
+    find_newline, LineColumn, LineEnding, LineRanges, SourceFile, SourceFileBuilder,
+};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use thiserror::Error;
 
@@ -104,6 +106,12 @@ impl Source {
             .map(Token::start)
     }
 
+    /// Returns `true` when at least one blank line separates the
+    /// source ahead of `offset` from the preceding non-whitespace.
+    pub fn has_blank_line_before(&self, offset: TextSize) -> bool {
+        lines_before(offset, self.text()) >= 2
+    }
+
     /// Returns `true` when at least one comment lies within `ranged`.
     pub fn intersects_comment<R: Ranged>(&self, ranged: R) -> bool {
         self.comment_ranges.intersects(ranged.range())
@@ -124,6 +132,14 @@ impl Source {
         leading_indentation(self.text().line_str(offset))
             .chars()
             .count()
+    }
+
+    /// Returns the line-ending sequence used in this source, or
+    /// `"\n"` when the source carries no line break.
+    pub fn newline_str(&self) -> &'static str {
+        find_newline(self.text())
+            .map_or(LineEnding::Lf, |(_, ending)| ending)
+            .as_str()
     }
 
     /// Reparses with replacement source text, preserving the original name.
@@ -192,6 +208,7 @@ mod tests {
     use ruff_text_size::TextRange;
 
     use super::*;
+    use crate::test_support::{assert_send_sync, range};
 
     fn line_col(line: usize, column: usize) -> LineColumn {
         LineColumn {
@@ -204,8 +221,8 @@ mod tests {
     fn comment_ranges_indexes_each_comment_in_the_source() {
         let s = Source::from_str("# top\nx = 1  # trail\n").expect("parses");
         let ranges = s.comment_ranges();
-        assert!(ranges.intersects(TextRange::new(TextSize::new(0), TextSize::new(1))));
-        assert!(ranges.intersects(TextRange::new(TextSize::new(13), TextSize::new(14))));
+        assert!(ranges.intersects(range(0, 1)));
+        assert!(ranges.intersects(range(13, 14)));
     }
 
     #[test]
@@ -349,13 +366,12 @@ mod tests {
     fn slice_at_multibyte_boundary_returns_full_codepoint() {
         let src = "α = 1";
         let s = Source::from_str(src).expect("multibyte source parses");
-        let alpha = s.slice(TextRange::new(TextSize::new(0), TextSize::new(2)));
+        let alpha = s.slice(range(0, 2));
         assert_eq!(alpha, "α");
     }
 
     #[test]
     fn source_is_send_and_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<Source>();
     }
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,15 @@
+//! Helpers shared across `#[cfg(test)] mod tests` blocks.
+
+use ruff_text_size::TextRange;
+
+use crate::source::Source;
+
+pub(crate) fn assert_send_sync<T: Send + Sync>() {}
+
+pub(crate) fn parse(src: &str) -> Source {
+    src.parse().expect("test source parses")
+}
+
+pub(crate) fn range(start: u32, end: u32) -> TextRange {
+    TextRange::new(start.into(), end.into())
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,26 @@
 //! Shared snapshot harness for integration test binaries.
 
+#![allow(dead_code)]
+
 use std::ffi::OsStr;
 use std::path::Path;
 
+use serde::Deserialize;
 use similar::TextDiff;
+
+/// Per-fixture flags read from the sidecar TOML's `[harness]` table,
+/// independent of the `[tool.prose]` config the rule itself consumes.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct HarnessOptions {
+    pub skip_ruff_coexistence: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct Sidecar {
+    harness: HarnessOptions,
+}
 
 pub fn case_stem(path: &Path) -> &str {
     path.file_stem()
@@ -19,6 +36,12 @@ pub fn in_snapshot_dir(directory: &str, f: impl FnOnce()) {
     }, {
         f();
     });
+}
+
+pub fn parse_harness_options(contents: &str) -> HarnessOptions {
+    toml::from_str::<Sidecar>(contents)
+        .unwrap_or_else(|e| panic!("parse sidecar harness section: {e}"))
+        .harness
 }
 
 pub fn unified_diff(expected: &str, actual: &str) -> String {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,29 @@
+//! Shared snapshot harness for integration test binaries.
+
+use std::ffi::OsStr;
+use std::path::Path;
+
+use similar::TextDiff;
+
+pub fn case_stem(path: &Path) -> &str {
+    path.file_stem()
+        .and_then(OsStr::to_str)
+        .expect("fixture path has a stem")
+}
+
+pub fn in_snapshot_dir(directory: &str, f: impl FnOnce()) {
+    insta::with_settings!({
+        snapshot_path => format!("snapshots/{directory}"),
+        prepend_module_to_snapshot => false,
+        snapshot_suffix => "",
+    }, {
+        f();
+    });
+}
+
+pub fn unified_diff(expected: &str, actual: &str) -> String {
+    TextDiff::from_lines(expected, actual)
+        .unified_diff()
+        .header("expected", "actual")
+        .to_string()
+}

--- a/tests/config_parsing.rs
+++ b/tests/config_parsing.rs
@@ -7,26 +7,26 @@
 //! field addition surfaces as a snapshot diff rather than slipping
 //! past spot-checked assertions.
 
-use std::ffi::OsStr;
-use std::path::PathBuf;
+mod common;
 
 use prose::config::Config;
 
 #[test]
 fn fixtures() {
     insta::glob!("fixtures/config/*.toml", |path| {
-        let case = path
-            .file_stem()
-            .and_then(OsStr::to_str)
-            .expect("fixture path has a stem");
+        let case = common::case_stem(path);
         let toml = fs_err::read_to_string(path).expect("fixture reads");
         let config = Config::from_pyproject_str(&toml).expect("fixture parses");
 
-        insta::with_settings!({
-            snapshot_path => PathBuf::from("snapshots").join("config"),
-            prepend_module_to_snapshot => false,
-            snapshot_suffix => "",
-        }, {
+        let reparsed = Config::from_pyproject_str(&toml).expect("fixture re-parses");
+        let (a, b) = (format!("{config:#?}"), format!("{reparsed:#?}"));
+        assert!(
+            a == b,
+            "config parsing not deterministic for `{case}`:\n{}",
+            common::unified_diff(&a, &b),
+        );
+
+        common::in_snapshot_dir("config", || {
             insta::assert_debug_snapshot!(case, config);
         });
     });

--- a/tests/fixtures/align_colons/docstring_args_bracketed_types.input.py
+++ b/tests/fixtures/align_colons/docstring_args_bracketed_types.input.py
@@ -2,7 +2,7 @@
 `Args:` entries whose parenthesized types contain bracketed
 generics. The colon detector tracks both `()` and `[]` nesting, so
 colons inside `Dict[str, int]` and `List[Tuple[int, str]]` do not
-fool the parser; alignment anchors on the entry's outer colon.
+fool the parser. Alignment anchors on the entry's outer colon.
 """
 
 def index(records: list, schema: dict, options: dict) -> None:

--- a/tests/fixtures/align_colons/docstring_args_inline_phrase.input.py
+++ b/tests/fixtures/align_colons/docstring_args_inline_phrase.input.py
@@ -1,7 +1,7 @@
 """
 The phrase `Args:` appears once in the docstring's body prose and
 again as the section header. Only the real header triggers
-alignment; the inline phrase is left as-is.
+alignment, leaving the inline phrase as-is.
 """
 
 def emit(channel: str, severity: str, payload: str) -> None:

--- a/tests/fixtures/align_imports/aliased_shift_limit_drop.config.toml
+++ b/tests/fixtures/align_imports/aliased_shift_limit_drop.config.toml
@@ -1,0 +1,2 @@
+[tool.prose.rules.align-imports]
+max-shift-policy = "drop"

--- a/tests/fixtures/align_imports/aliased_shift_limit_drop.input.py
+++ b/tests/fixtures/align_imports/aliased_shift_limit_drop.input.py
@@ -1,0 +1,12 @@
+"""
+Same shape as `aliased_shift_limit_split` under the `drop` policy.
+The widest module sorts to the top of the kept set on width, the
+remaining modules align at their tightened column, and the outlier
+itself keeps its original spacing untouched.
+"""
+
+import datetime as dt
+import os as o
+import re as r
+import collections_with_a_very_long_module_name as long
+import json as j

--- a/tests/fixtures/align_imports/aliased_shift_limit_skip.config.toml
+++ b/tests/fixtures/align_imports/aliased_shift_limit_skip.config.toml
@@ -1,0 +1,2 @@
+[tool.prose.rules.align-imports]
+max-shift-policy = "skip"

--- a/tests/fixtures/align_imports/aliased_shift_limit_skip.input.py
+++ b/tests/fixtures/align_imports/aliased_shift_limit_skip.input.py
@@ -1,0 +1,11 @@
+"""
+Same shape as `aliased_shift_limit_split` under the `skip` policy.
+A run whose widest module overshoots the cap leaves the entire run
+untouched.
+"""
+
+import datetime as dt
+import os as o
+import re as r
+import collections_with_a_very_long_module_name as long
+import json as j

--- a/tests/fixtures/align_imports/aliased_shift_limit_split.input.py
+++ b/tests/fixtures/align_imports/aliased_shift_limit_split.input.py
@@ -1,0 +1,13 @@
+"""
+The shift-limit policy applies to `import M as A` runs by the same
+distance rules used for `from`-import runs. A widest module that
+overshoots `max-shift = 8` greedily partitions the run into
+sub-groups, each aligning at its own tightened column independently
+of the others.
+"""
+
+import datetime as dt
+import os as o
+import re as r
+import collections_with_a_very_long_module_name as long
+import json as j

--- a/tests/fixtures/alphabetize/bare_imports.input.py
+++ b/tests/fixtures/alphabetize/bare_imports.input.py
@@ -1,8 +1,8 @@
 """
-Bare `import` statement runs alphabetize within blank-line bounds,
-mirroring the `from`-import-run pass on the `Stmt::Import` shape.
-Bare imports sit above `from`-imports as their own group, and the
-two run families never interleave.
+Every bare `import` statement at a body's top level collapses into
+a single alphabetized block. Blank lines that the user wrote between
+imports are removed so the form reads as one paragraph regardless
+of how the source was originally arranged.
 """
 
 import zlib

--- a/tests/fixtures/alphabetize/dict_keep_marker.input.py
+++ b/tests/fixtures/alphabetize/dict_keep_marker.input.py
@@ -1,0 +1,24 @@
+"""
+A trailing `# prose: keep` comment on the opening `{` line preserves
+source order for that single dict. The unmarked sibling alphabetizes
+and partitions through the same machinery, so the contrast lands side
+by side: same scrambled input, two different outputs.
+"""
+
+unmarked = {
+    "version"  : "0.1.0",
+    "config"   : {
+        "strict"  : True,
+        "verbose" : False,
+    },
+    "name"     : "prose",
+}
+
+marked = {  # prose: keep
+    "version"  : "0.1.0",
+    "config"   : {
+        "strict"  : True,
+        "verbose" : False,
+    },
+    "name"     : "prose",
+}

--- a/tests/fixtures/alphabetize/dict_keys.input.py
+++ b/tests/fixtures/alphabetize/dict_keys.input.py
@@ -1,0 +1,61 @@
+"""
+Multi-line dict literals partition entries by rendered line count.
+Single-line entries (key + value fit on one source line) sort first,
+followed by a blank-line divider, followed by multi-line entries
+(value spans multiple source lines). `**unpacked` items pin in source
+position. The partition fires recursively at every level of nesting.
+"""
+
+mixed = {
+    "version"  : "0.1.0",
+    "tags"     : ["staging", "ingest"],
+    "name"     : "prose",
+    "config": {
+        "verbose"    : False,
+        "strict"     : True,
+        "tracebacks" : "short",
+    },
+    "author"   : "jibbs",
+    "metadata" : load_metadata(),
+    "deps"     : ["ruff_python_parser", "clap"],
+}
+
+inline = {"version": "0.1.0", "config": {"strict": True}, "name": "prose"}
+
+with_spread = {
+    "version" : "0.1.0",
+    **defaults,
+    "name"    : "prose",
+    "config": {
+        "strict"  : True,
+        "verbose" : False,
+        "tracing" : "off",
+    },
+}
+
+single_line_only = {
+    "config"   : {"strict": True},
+    "metadata" : load_metadata(),
+    "version"  : "0.1.0",
+    "deps"     : ["ruff_python_parser", "clap"],
+}
+
+deep_nesting = {
+    "delta" : "...",
+    "alpha" : 1,
+    "settings": {
+        "network": {
+            "timeout" : 30,
+            "retries" : 5,
+        },
+        "logging": {
+            "format": {
+                "json"    : True,
+                "compact" : False,
+            },
+            "stderr" : "warn",
+            "stdout" : "info",
+        },
+    },
+    "beta"  : 2,
+}

--- a/tests/fixtures/alphabetize/dunder_all.input.py
+++ b/tests/fixtures/alphabetize/dunder_all.input.py
@@ -1,8 +1,8 @@
 """
 The string-literal items inside `__all__` alphabetize by string
 value. Detection is by target simple name because the dunder-list
-convention is what makes the list documentary; ordinary list
-assignments stay untouched.
+convention is what makes the list documentary, leaving ordinary list
+assignments untouched.
 """
 
 __all__ = [

--- a/tests/fixtures/alphabetize/from_import_aliases.input.py
+++ b/tests/fixtures/alphabetize/from_import_aliases.input.py
@@ -1,7 +1,7 @@
 """
 The alias list inside one `from M import a, b, c` statement
 alphabetizes by alias name. Inline lists run through inline block
-mode; multi-line lists run through line block mode.
+mode and multi-line lists run through line block mode.
 """
 
 from collections import deque, defaultdict, Counter

--- a/tests/fixtures/alphabetize/from_imports.input.py
+++ b/tests/fixtures/alphabetize/from_imports.input.py
@@ -1,7 +1,8 @@
 """
-`from`-import statements alphabetize within each blank-line-bounded
-run by module name. Cross-run reordering does not happen, so a
-stranded run separated by a blank line stays in its own bucket.
+Every `from`-import statement at a body's top level collapses into
+a single alphabetized block. Blank lines that the user wrote between
+imports are removed so the form reads as one paragraph regardless
+of how the source was originally arranged.
 """
 
 from loguru import logger

--- a/tests/fixtures/collection_layout/nested_blocks.input.py
+++ b/tests/fixtures/collection_layout/nested_blocks.input.py
@@ -2,9 +2,9 @@
 Collections inside function and class bodies compute their enclosing
 indent from the opening bracket's line, not from the module top-level.
 Short collections at any indent level stay inline. A long dict at
-any depth expands with each entry on its own line; a long list or
-set of atomic items flow-packs across balanced lines at the item
-indent.
+any depth expands with each entry on its own line, whereas a long
+list or set of atomic items flow-packs across balanced lines at the
+item indent.
 """
 
 

--- a/tests/fixtures/collection_layout/unpacking.input.py
+++ b/tests/fixtures/collection_layout/unpacking.input.py
@@ -3,7 +3,7 @@ Dict `**` unpacking and list or set `*` unpacking survive the
 expansion. Dict items with `key == None` serialize as `**value` via
 an explicit branch and always land on their own line alongside the
 dict's other entries. Starred expressions in list and set elts slice
-through the `Expr::Starred` range verbatim; they are non-atomic, so
+through the `Expr::Starred` range verbatim. They are non-atomic, so
 a spread in the middle of a list splits its surrounding atomics into
 two independent runs that each flow on their own, and a set made
 entirely of spreads goes one entry per line.

--- a/tests/fixtures/composition/class_essentials.input.py
+++ b/tests/fixtures/composition/class_essentials.input.py
@@ -1,0 +1,37 @@
+"""
+Cross-rule composition on a small class: alphabetize reorders methods
+into the canonical dunder / property / private / public groups,
+alphabetizes annotated fields, and sorts both bare and from-import
+runs at the module top. align_colons and align_equals then settle
+the field-declaration columns. The full pipeline running twice on
+this input produces no further change.
+"""
+
+from typing import Any
+from collections import Counter
+
+import sys
+import os
+
+
+class Posting:
+    title: str = "Untitled"
+    description: str = ""
+    company: str = "TBD"
+    salary: float = 0.0
+
+    def __repr__(self):
+        return f"Posting({self.title})"
+
+    def update(self, *, atomic=True, retries=3):
+        return self
+
+    def __init__(self):
+        pass
+
+    @property
+    def name(self):
+        return self.title
+
+    def _internal(self):
+        pass

--- a/tests/fixtures/composition/expanded_collection.input.py
+++ b/tests/fixtures/composition/expanded_collection.input.py
@@ -1,0 +1,12 @@
+"""
+Long dict literal that fits on one line in source but overflows the
+line-length budget once expanded. collection_layout puts each entry on
+its own line and recursively expands the long nested dict, alphabetize
+partitions single-line entries before the multi-line entry and sorts
+within each partition, align_colons aligns the colons across the
+entries, and strip_trailing_commas removes any dangling commas the
+source carried. The full pipeline running twice on this input produces
+no further change.
+"""
+
+CONFIG = {"timeout": 30, "retries": 5, "backoff": 1.5, "verbose": True, "label": "primary-region-default", "tags": ["staging", "ingest"], "limits": {"requests_per_minute": 600, "burst_capacity": 1200, "concurrent_streams": 8, "queue_depth": 256}}

--- a/tests/fixtures/composition/match_dispatch.input.py
+++ b/tests/fixtures/composition/match_dispatch.input.py
@@ -1,0 +1,24 @@
+"""
+Cross-rule composition over a match statement: match_case_align
+collapses single-statement arms onto their pattern lines, alphabetize
+sorts the kwargs inside the dispatched calls, strip_trailing_commas
+removes the dangling commas the source carries, and the singleton
+rule strips the lone-key dict's pre-`:` padding. The full pipeline
+running twice produces no further change.
+"""
+
+def dispatch(event):
+    match event.kind:
+        case "create": return Counter(timestamp=event.ts, source=event.src, action="create")
+        case "update": return Counter(timestamp=event.ts, source=event.src, action="update")
+        case "delete": return Counter(timestamp=event.ts, source=event.src, action="delete")
+        case _      : return None
+
+
+SETTINGS = {
+    "default_action" : "noop",
+}
+
+
+def required_only(name):
+    return {name,}

--- a/tests/fixtures/composition/recursive_partition.input.py
+++ b/tests/fixtures/composition/recursive_partition.input.py
@@ -1,0 +1,16 @@
+"""
+Long single-line dict with multiple levels of nested dicts. The full
+pipeline exercises every dict-handling feature in concert:
+collection_layout expands the outer dict and recurses into any value
+whose inline form overflows, alphabetize sorts and partitions
+single-line entries before multi-line entries with a blank-line
+divider at every level, align_colons aligns colons within each
+line-adjacent group so the divider closes the active alignment run,
+and strip_trailing_commas removes the dangling commas the recursive
+expansion leaves behind. Every level carries multiple siblings of each
+shape, so the sort, partition, and per-group alignment are visible at
+every depth. The full pipeline running twice on this input produces
+no further change.
+"""
+
+DEPLOY = {"region": "us-east", "version": 12, "stage": "prod", "owner": "core", "services": {"api": {"timeout": 30, "retries": 3, "port": 8080, "endpoints": {"health": "/health", "metrics": "/metrics", "readiness": "/ready", "version": "/v"}, "headers": {"trace_id": "x-trace", "user_agent": "deploy/1", "request_id": "x-req"}}, "worker": {"concurrency": 8, "queue": "tasks"}, "gateway": {"timeout": 5, "rate_limit": 1000, "upstream": {"primary": "api.internal", "fallback": "api.backup"}}}, "telemetry": {"sink": "datadog", "interval": 30, "logs": {"level": "info", "format": "json", "destinations": {"file": "/var/log/app", "stdout": True, "syslog": False, "remote_sink": "logserver"}}}}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,87 +1,138 @@
 //! Integration tests exercising each rule against golden-file fixtures.
-//!
-//! Each rule owns a subdirectory under `tests/fixtures/<rule>/`
-//! containing `<case>.input.py` files, each optionally paired with a
-//! sibling `<case>.config.toml` carrying a `[tool.prose]` override
-//! for that single case. The harness reads the sidecar through
-//! `Config::from_pyproject_str` and snapshots the transform output
-//! under `tests/snapshots/<rule>/<case>.input.py.snap`, then reruns
-//! the pipeline on the formatted text and asserts the second pass
-//! produces zero edits and identical bytes.
+
+mod common;
 
 use std::ffi::OsStr;
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::path::Path;
 
 use prose::config::Config;
 use prose::pipeline::Pipeline;
 use prose::source::Source;
+use ruff_python_formatter::{format_module_source, PyFormatOptions};
 
-fn build_pipeline(rule: &str, config: &Config) -> Pipeline {
-    if rule == "identity" {
-        return Pipeline::empty();
+fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
+    match directory {
+        "composition" => Pipeline::with_defaults(config),
+        "identity" => Pipeline::empty(),
+        _ => Pipeline::for_rule(directory, config)
+            .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),
     }
-    let kebab = rule.replace('_', "-");
-    Pipeline::for_rule(&kebab, config)
-        .unwrap_or_else(|| panic!("no rule registered for fixture directory `{rule}`"))
 }
 
-fn fixture_config(input_path: &Path) -> Config {
-    let stem = input_path
-        .file_name()
-        .and_then(OsStr::to_str)
-        .and_then(|f| f.strip_suffix(".input.py"))
-        .expect("fixture path ends in .input.py");
-    let sidecar = input_path.with_file_name(format!("{stem}.config.toml"));
-    match fs_err::read_to_string(&sidecar) {
-        Ok(contents) => Config::from_pyproject_str(&contents)
-            .unwrap_or_else(|e| panic!("parse sidecar {sidecar:?}: {e}")),
-        Err(e) if e.kind() == ErrorKind::NotFound => Config::default(),
-        Err(e) => panic!("read sidecar {sidecar:?}: {e}"),
+struct FixturePath<'a>(&'a Path);
+
+impl<'a> FixturePath<'a> {
+    fn case(&self) -> &'a str {
+        self.0
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("fixture path has a file name")
+    }
+
+    fn directory(&self) -> &'a str {
+        self.0
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(OsStr::to_str)
+            .expect("fixture path has a parent directory name")
+    }
+
+    fn config(&self) -> Config {
+        let stem = common::case_stem(self.0)
+            .strip_suffix(".input")
+            .expect("fixture path ends in .input.py");
+        let sidecar = self.0.with_file_name(format!("{stem}.config.toml"));
+        match fs_err::read_to_string(&sidecar) {
+            Ok(contents) => Config::from_pyproject_str(&contents)
+                .unwrap_or_else(|e| panic!("parse sidecar {sidecar:?}: {e}")),
+            Err(e) if e.kind() == ErrorKind::NotFound => Config::default(),
+            Err(e) => panic!("read sidecar: {e}"),
+        }
     }
 }
 
 #[test]
 fn fixtures() {
     insta::glob!("fixtures/**/*.input.py", |path| {
-        let rule = path
-            .parent()
-            .and_then(Path::file_name)
-            .and_then(OsStr::to_str)
-            .expect("fixture path has a parent directory name");
-        let case = path
-            .file_name()
-            .and_then(OsStr::to_str)
-            .expect("fixture path has a file name");
+        let fixture = FixturePath(path);
+        let directory = fixture.directory();
+        let case = fixture.case();
 
-        let config = fixture_config(path);
-        let pipeline = build_pipeline(rule, &config);
+        let config = fixture.config();
+        let pipeline = build_pipeline(directory, &config);
         let source = Source::from_path(path).expect("fixture input reads and parses as Python");
 
         let (formatted, _) = pipeline
             .run(source)
             .expect("first pass succeeds on fixture input");
-        let output = formatted.text().to_owned();
+        let output = formatted.text();
 
-        insta::with_settings!({
-            snapshot_path => PathBuf::from("snapshots").join(rule),
-            prepend_module_to_snapshot => false,
-            snapshot_suffix => "",
-        }, {
-            insta::assert_snapshot!(case, &output);
+        common::in_snapshot_dir(directory, || {
+            insta::assert_snapshot!(case, output);
         });
 
-        let reparsed = Source::from_str(&output).expect("formatter output reparses as Python");
+        let reparsed = output
+            .parse::<Source>()
+            .expect("formatter output reparses as Python");
         let (second, changed) = pipeline.run(reparsed).expect("second pass succeeds");
         assert!(
             !changed,
-            "rule `{rule}` not idempotent on `{case}`: second pass emitted edits",
+            "fixture `{directory}/{case}` not idempotent: second pass emitted edits",
         );
-        assert_eq!(
-            second.text(),
-            output,
-            "rule `{rule}` not byte-stable on `{case}`",
+        assert!(
+            second.text() == output,
+            "fixture `{directory}/{case}` not byte-stable on second pass:\n{}",
+            common::unified_diff(output, second.text()),
+        );
+
+        let fresh_source =
+            Source::from_path(path).expect("fixture input re-reads for determinism check");
+        let (fresh_formatted, _) = build_pipeline(directory, &config)
+            .run(fresh_source)
+            .expect("fresh pipeline run succeeds");
+        assert!(
+            fresh_formatted.text() == output,
+            "fixture `{directory}/{case}` not deterministic across pipeline instances:\n{}",
+            common::unified_diff(output, fresh_formatted.text()),
+        );
+    });
+}
+
+#[test]
+fn prose_is_stable_after_ruff() {
+    let pipeline = Pipeline::with_defaults(&Config::default());
+    insta::glob!("fixtures/composition/*.input.py", |path| {
+        let case = FixturePath(path).case();
+        let input = fs_err::read_to_string(path)
+            .unwrap_or_else(|e| panic!("read composition fixture: {e}"));
+
+        let post_ruff = format_module_source(&input, PyFormatOptions::default())
+            .unwrap_or_else(|e| panic!("ruff format failed on `{case}`: {e}"))
+            .into_code();
+
+        let format = |text: &str| {
+            pipeline
+                .run(
+                    text.parse::<Source>()
+                        .expect("prose input reparses as Python"),
+                )
+                .expect("prose pipeline succeeds after ruff")
+                .0
+        };
+        let one = format(&post_ruff);
+        let two = format(one.text());
+
+        assert!(
+            one.text() != post_ruff,
+            "prose was a no-op on `{case}` after ruff — composition fixture should require transformation",
+        );
+        assert!(
+            two.text() == one.text(),
+            "prose not stable on `{case}` after ruff:\n\
+             --- post-ruff (input to prose) ---\n{post_ruff}\
+             --- diff between first and second prose pass ---\n{}",
+            common::unified_diff(one.text(), two.text()),
         );
     });
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -39,14 +39,29 @@ impl<'a> FixturePath<'a> {
     }
 
     fn config(&self) -> Config {
+        self.sidecar_contents()
+            .map(|c| {
+                Config::from_pyproject_str(&c)
+                    .unwrap_or_else(|e| panic!("parse sidecar config: {e}"))
+            })
+            .unwrap_or_default()
+    }
+
+    fn harness_options(&self) -> common::HarnessOptions {
+        self.sidecar_contents()
+            .as_deref()
+            .map(common::parse_harness_options)
+            .unwrap_or_default()
+    }
+
+    fn sidecar_contents(&self) -> Option<String> {
         let stem = common::case_stem(self.0)
             .strip_suffix(".input")
             .expect("fixture path ends in .input.py");
         let sidecar = self.0.with_file_name(format!("{stem}.config.toml"));
         match fs_err::read_to_string(&sidecar) {
-            Ok(contents) => Config::from_pyproject_str(&contents)
-                .unwrap_or_else(|e| panic!("parse sidecar {sidecar:?}: {e}")),
-            Err(e) if e.kind() == ErrorKind::NotFound => Config::default(),
+            Ok(c) => Some(c),
+            Err(e) if e.kind() == ErrorKind::NotFound => None,
             Err(e) => panic!("read sidecar: {e}"),
         }
     }
@@ -100,17 +115,60 @@ fn fixtures() {
 }
 
 #[test]
-fn prose_is_stable_after_ruff() {
-    let pipeline = Pipeline::with_defaults(&Config::default());
-    insta::glob!("fixtures/composition/*.input.py", |path| {
-        let case = FixturePath(path).case();
-        let input = fs_err::read_to_string(path)
-            .unwrap_or_else(|e| panic!("read composition fixture: {e}"));
+fn pipeline_is_idempotent() {
+    insta::glob!("fixtures/**/*.input.py", |path| {
+        let fixture = FixturePath(path);
+        let directory = fixture.directory();
+        let case = fixture.case();
+        if directory == "identity" {
+            return;
+        }
 
+        let pipeline = Pipeline::with_defaults(&fixture.config());
+        let source = Source::from_path(path).expect("fixture input reads and parses as Python");
+        let (first, _) = pipeline
+            .run(source)
+            .expect("first full-pipeline pass succeeds");
+        let reparsed = first
+            .text()
+            .parse::<Source>()
+            .expect("full-pipeline output reparses as Python");
+        let (second, changed) = pipeline
+            .run(reparsed)
+            .expect("second full-pipeline pass succeeds");
+        assert!(
+            !changed,
+            "fixture `{directory}/{case}` not idempotent under full pipeline: second pass emitted edits",
+        );
+        assert!(
+            second.text() == first.text(),
+            "fixture `{directory}/{case}` not byte-stable under full pipeline:\n{}",
+            common::unified_diff(first.text(), second.text()),
+        );
+    });
+}
+
+#[test]
+fn prose_is_stable_after_ruff() {
+    insta::glob!("fixtures/**/*.input.py", |path| {
+        let fixture = FixturePath(path);
+        let directory = fixture.directory();
+        let case = fixture.case();
+        if directory == "identity" || fixture.harness_options().skip_ruff_coexistence {
+            return;
+        }
+
+        let input = fs_err::read_to_string(path).unwrap_or_else(|e| panic!("read fixture: {e}"));
         let post_ruff = format_module_source(&input, PyFormatOptions::default())
-            .unwrap_or_else(|e| panic!("ruff format failed on `{case}`: {e}"))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "ruff format failed on `{directory}/{case}`: {e}\n\
+                     set `[harness] skip_ruff_coexistence = true` in the sidecar to opt this fixture out",
+                )
+            })
             .into_code();
 
+        let pipeline = Pipeline::with_defaults(&fixture.config());
         let format = |text: &str| {
             pipeline
                 .run(
@@ -123,13 +181,15 @@ fn prose_is_stable_after_ruff() {
         let one = format(&post_ruff);
         let two = format(one.text());
 
-        assert!(
-            one.text() != post_ruff,
-            "prose was a no-op on `{case}` after ruff — composition fixture should require transformation",
-        );
+        if directory == "composition" {
+            assert!(
+                one.text() != post_ruff,
+                "prose was a no-op on `{case}` after ruff — composition fixture should require transformation",
+            );
+        }
         assert!(
             two.text() == one.text(),
-            "prose not stable on `{case}` after ruff:\n\
+            "prose not stable on `{directory}/{case}` after ruff:\n\
              --- post-ruff (input to prose) ---\n{post_ruff}\
              --- diff between first and second prose pass ---\n{}",
             common::unified_diff(one.text(), two.text()),

--- a/tests/snapshots/align_colons/docstring_args_bracketed_types.input.py.snap
+++ b/tests/snapshots/align_colons/docstring_args_bracketed_types.input.py.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: "&output"
 input_file: tests/fixtures/align_colons/docstring_args_bracketed_types.input.py
 ---
 """
 `Args:` entries whose parenthesized types contain bracketed
 generics. The colon detector tracks both `()` and `[]` nesting, so
 colons inside `Dict[str, int]` and `List[Tuple[int, str]]` do not
-fool the parser; alignment anchors on the entry's outer colon.
+fool the parser. Alignment anchors on the entry's outer colon.
 """
 
 def index(records: list, schema: dict, options: dict) -> None:

--- a/tests/snapshots/align_colons/docstring_args_inline_phrase.input.py.snap
+++ b/tests/snapshots/align_colons/docstring_args_inline_phrase.input.py.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: "&output"
 input_file: tests/fixtures/align_colons/docstring_args_inline_phrase.input.py
 ---
 """
 The phrase `Args:` appears once in the docstring's body prose and
 again as the section header. Only the real header triggers
-alignment; the inline phrase is left as-is.
+alignment, leaving the inline phrase as-is.
 """
 
 def emit(channel: str, severity: str, payload: str) -> None:

--- a/tests/snapshots/align_imports/aliased_shift_limit_drop.input.py.snap
+++ b/tests/snapshots/align_imports/aliased_shift_limit_drop.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/align_imports/aliased_shift_limit_drop.input.py
+---
+"""
+Same shape as `aliased_shift_limit_split` under the `drop` policy.
+The widest module sorts to the top of the kept set on width, the
+remaining modules align at their tightened column, and the outlier
+itself keeps its original spacing untouched.
+"""
+
+import datetime as dt
+import os       as o
+import re       as r
+import collections_with_a_very_long_module_name as long
+import json     as j

--- a/tests/snapshots/align_imports/aliased_shift_limit_skip.input.py.snap
+++ b/tests/snapshots/align_imports/aliased_shift_limit_skip.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/align_imports/aliased_shift_limit_skip.input.py
+---
+"""
+Same shape as `aliased_shift_limit_split` under the `skip` policy.
+A run whose widest module overshoots the cap leaves the entire run
+untouched.
+"""
+
+import datetime as dt
+import os as o
+import re as r
+import collections_with_a_very_long_module_name as long
+import json as j

--- a/tests/snapshots/align_imports/aliased_shift_limit_split.input.py.snap
+++ b/tests/snapshots/align_imports/aliased_shift_limit_split.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/align_imports/aliased_shift_limit.input.py
+---
+"""
+The shift-limit policy applies to `import M as A` runs by the same
+distance rules used for `from`-import runs. A widest module that
+overshoots `max-shift = 8` greedily partitions the run into
+sub-groups, each aligning at its own tightened column independently
+of the others.
+"""
+
+import datetime as dt
+import os       as o
+import re       as r
+import collections_with_a_very_long_module_name as long
+import json as j

--- a/tests/snapshots/alphabetize/annotated_field_default.input.py.snap
+++ b/tests/snapshots/alphabetize/annotated_field_default.input.py.snap
@@ -12,9 +12,8 @@ covering Pydantic, msgspec, attrs, and similar libraries without
 naming the field constructor.
 """
 
-from typing import Annotated
-
 from pydantic import BaseModel, Field
+from typing import Annotated
 
 
 class Posting(BaseModel):

--- a/tests/snapshots/alphabetize/bare_imports.input.py.snap
+++ b/tests/snapshots/alphabetize/bare_imports.input.py.snap
@@ -4,15 +4,14 @@ expression: "&output"
 input_file: tests/fixtures/alphabetize/bare_imports.input.py
 ---
 """
-Bare `import` statement runs alphabetize within blank-line bounds,
-mirroring the `from`-import-run pass on the `Stmt::Import` shape.
-Bare imports sit above `from`-imports as their own group, and the
-two run families never interleave.
+Every bare `import` statement at a body's top level collapses into
+a single alphabetized block. Blank lines that the user wrote between
+imports are removed so the form reads as one paragraph regardless
+of how the source was originally arranged.
 """
 
 import argparse
-import os
-import zlib
-
 import numpy as np
+import os
 import pandas as pd
+import zlib

--- a/tests/snapshots/alphabetize/dict_keep_marker.input.py.snap
+++ b/tests/snapshots/alphabetize/dict_keep_marker.input.py.snap
@@ -1,0 +1,30 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/alphabetize/dict_keep_marker.input.py
+---
+"""
+A trailing `# prose: keep` comment on the opening `{` line preserves
+source order for that single dict. The unmarked sibling alphabetizes
+and partitions through the same machinery, so the contrast lands side
+by side: same scrambled input, two different outputs.
+"""
+
+unmarked = {
+    "name"     : "prose",
+    "version"  : "0.1.0",
+
+    "config"   : {
+        "strict"  : True,
+        "verbose" : False,
+    },
+}
+
+marked = {  # prose: keep
+    "version"  : "0.1.0",
+    "config"   : {
+        "strict"  : True,
+        "verbose" : False,
+    },
+    "name"     : "prose",
+}

--- a/tests/snapshots/alphabetize/dict_keys.input.py.snap
+++ b/tests/snapshots/alphabetize/dict_keys.input.py.snap
@@ -1,0 +1,71 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/alphabetize/dict_keys.input.py
+---
+"""
+Multi-line dict literals partition entries by rendered line count.
+Single-line entries (key + value fit on one source line) sort first,
+followed by a blank-line divider, followed by multi-line entries
+(value spans multiple source lines). `**unpacked` items pin in source
+position. The partition fires recursively at every level of nesting.
+"""
+
+mixed = {
+    "author"   : "jibbs",
+    "deps"     : ["ruff_python_parser", "clap"],
+    "metadata" : load_metadata(),
+    "name"     : "prose",
+    "tags"     : ["staging", "ingest"],
+    "version"  : "0.1.0",
+
+    "config": {
+        "strict"     : True,
+        "tracebacks" : "short",
+        "verbose"    : False,
+    },
+}
+
+inline = {"config": {"strict": True}, "name": "prose", "version": "0.1.0"}
+
+with_spread = {
+    "name"    : "prose",
+    **defaults,
+    "version" : "0.1.0",
+
+    "config": {
+        "strict"  : True,
+        "tracing" : "off",
+        "verbose" : False,
+    },
+}
+
+single_line_only = {
+    "config"   : {"strict": True},
+    "deps"     : ["ruff_python_parser", "clap"],
+    "metadata" : load_metadata(),
+    "version"  : "0.1.0",
+}
+
+deep_nesting = {
+    "alpha" : 1,
+    "beta"  : 2,
+    "delta" : "...",
+
+    "settings": {
+        "logging": {
+            "stderr" : "warn",
+            "stdout" : "info",
+
+            "format": {
+                "compact" : False,
+                "json"    : True,
+            },
+        },
+
+        "network": {
+            "retries" : 5,
+            "timeout" : 30,
+        },
+    },
+}

--- a/tests/snapshots/alphabetize/dunder_all.input.py.snap
+++ b/tests/snapshots/alphabetize/dunder_all.input.py.snap
@@ -6,8 +6,8 @@ input_file: tests/fixtures/alphabetize/dunder_all.input.py
 """
 The string-literal items inside `__all__` alphabetize by string
 value. Detection is by target simple name because the dunder-list
-convention is what makes the list documentary; ordinary list
-assignments stay untouched.
+convention is what makes the list documentary, leaving ordinary list
+assignments untouched.
 """
 
 __all__ = [

--- a/tests/snapshots/alphabetize/from_import_aliases.input.py.snap
+++ b/tests/snapshots/alphabetize/from_import_aliases.input.py.snap
@@ -6,7 +6,7 @@ input_file: tests/fixtures/alphabetize/from_import_aliases.input.py
 """
 The alias list inside one `from M import a, b, c` statement
 alphabetizes by alias name. Inline lists run through inline block
-mode; multi-line lists run through line block mode.
+mode and multi-line lists run through line block mode.
 """
 
 from collections import Counter, defaultdict, deque

--- a/tests/snapshots/alphabetize/from_imports.input.py.snap
+++ b/tests/snapshots/alphabetize/from_imports.input.py.snap
@@ -4,14 +4,14 @@ expression: "&output"
 input_file: tests/fixtures/alphabetize/from_imports.input.py
 ---
 """
-`from`-import statements alphabetize within each blank-line-bounded
-run by module name. Cross-run reordering does not happen, so a
-stranded run separated by a blank line stays in its own bucket.
+Every `from`-import statement at a body's top level collapses into
+a single alphabetized block. Blank lines that the user wrote between
+imports are removed so the form reads as one paragraph regardless
+of how the source was originally arranged.
 """
 
 from collections import Counter
+from enum import StrEnum
 from hamilton.function_modifiers import extract_fields
 from loguru import logger
-
-from enum import StrEnum
 from pydantic import BaseModel

--- a/tests/snapshots/collection_layout/nested_blocks.input.py.snap
+++ b/tests/snapshots/collection_layout/nested_blocks.input.py.snap
@@ -1,15 +1,15 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: "&output"
 input_file: tests/fixtures/collection_layout/nested_blocks.input.py
 ---
 """
 Collections inside function and class bodies compute their enclosing
 indent from the opening bracket's line, not from the module top-level.
 Short collections at any indent level stay inline. A long dict at
-any depth expands with each entry on its own line; a long list or
-set of atomic items flow-packs across balanced lines at the item
-indent.
+any depth expands with each entry on its own line, whereas a long
+list or set of atomic items flow-packs across balanced lines at the
+item indent.
 """
 
 

--- a/tests/snapshots/collection_layout/unpacking.input.py.snap
+++ b/tests/snapshots/collection_layout/unpacking.input.py.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: "&output"
 input_file: tests/fixtures/collection_layout/unpacking.input.py
 ---
 """
@@ -8,7 +8,7 @@ Dict `**` unpacking and list or set `*` unpacking survive the
 expansion. Dict items with `key == None` serialize as `**value` via
 an explicit branch and always land on their own line alongside the
 dict's other entries. Starred expressions in list and set elts slice
-through the `Expr::Starred` range verbatim; they are non-atomic, so
+through the `Expr::Starred` range verbatim. They are non-atomic, so
 a spread in the middle of a list splits its surrounding atomics into
 two independent runs that each flow on their own, and a set made
 entirely of spreads goes one entry per line.

--- a/tests/snapshots/composition/class_essentials.input.py.snap
+++ b/tests/snapshots/composition/class_essentials.input.py.snap
@@ -1,0 +1,42 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/composition/class_essentials.input.py
+---
+"""
+Cross-rule composition on a small class: alphabetize reorders methods
+into the canonical dunder / property / private / public groups,
+alphabetizes annotated fields, and sorts both bare and from-import
+runs at the module top. align_colons and align_equals then settle
+the field-declaration columns. The full pipeline running twice on
+this input produces no further change.
+"""
+
+from collections import Counter
+from typing      import Any
+
+import os
+import sys
+
+
+class Posting:
+    company     : str   = "TBD"
+    description : str   = ""
+    salary      : float = 0.0
+    title       : str   = "Untitled"
+
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return f"Posting({self.title})"
+
+    @property
+    def name(self):
+        return self.title
+
+    def _internal(self):
+        pass
+
+    def update(self, *, atomic=True, retries=3):
+        return self

--- a/tests/snapshots/composition/expanded_collection.input.py.snap
+++ b/tests/snapshots/composition/expanded_collection.input.py.snap
@@ -1,0 +1,31 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/composition/expanded_collection.input.py
+---
+"""
+Long dict literal that fits on one line in source but overflows the
+line-length budget once expanded. collection_layout puts each entry on
+its own line and recursively expands the long nested dict, alphabetize
+partitions single-line entries before the multi-line entry and sorts
+within each partition, align_colons aligns the colons across the
+entries, and strip_trailing_commas removes any dangling commas the
+source carried. The full pipeline running twice on this input produces
+no further change.
+"""
+
+CONFIG = {
+    "backoff" : 1.5,
+    "label"   : "primary-region-default",
+    "retries" : 5,
+    "tags"    : ["staging", "ingest"],
+    "timeout" : 30,
+    "verbose" : True,
+
+    "limits": {
+        "burst_capacity"      : 1200,
+        "concurrent_streams"  : 8,
+        "queue_depth"         : 256,
+        "requests_per_minute" : 600
+    }
+}

--- a/tests/snapshots/composition/match_dispatch.input.py.snap
+++ b/tests/snapshots/composition/match_dispatch.input.py.snap
@@ -1,0 +1,29 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/composition/match_dispatch.input.py
+---
+"""
+Cross-rule composition over a match statement: match_case_align
+collapses single-statement arms onto their pattern lines, alphabetize
+sorts the kwargs inside the dispatched calls, strip_trailing_commas
+removes the dangling commas the source carries, and the singleton
+rule strips the lone-key dict's pre-`:` padding. The full pipeline
+running twice produces no further change.
+"""
+
+def dispatch(event):
+    match event.kind:
+        case "create" : return Counter(action="create", source=event.src, timestamp=event.ts)
+        case "update" : return Counter(action="update", source=event.src, timestamp=event.ts)
+        case "delete" : return Counter(action="delete", source=event.src, timestamp=event.ts)
+        case _        : return None
+
+
+SETTINGS = {
+    "default_action": "noop"
+}
+
+
+def required_only(name):
+    return {name}

--- a/tests/snapshots/composition/recursive_partition.input.py.snap
+++ b/tests/snapshots/composition/recursive_partition.input.py.snap
@@ -1,0 +1,72 @@
+---
+source: tests/integration.rs
+expression: "&output"
+input_file: tests/fixtures/composition/recursive_partition.input.py
+---
+"""
+Long single-line dict with multiple levels of nested dicts. The full
+pipeline exercises every dict-handling feature in concert:
+collection_layout expands the outer dict and recurses into any value
+whose inline form overflows, alphabetize sorts and partitions
+single-line entries before multi-line entries with a blank-line
+divider at every level, align_colons aligns colons within each
+line-adjacent group so the divider closes the active alignment run,
+and strip_trailing_commas removes the dangling commas the recursive
+expansion leaves behind. Every level carries multiple siblings of each
+shape, so the sort, partition, and per-group alignment are visible at
+every depth. The full pipeline running twice on this input produces
+no further change.
+"""
+
+DEPLOY = {
+    "owner"   : "core",
+    "region"  : "us-east",
+    "stage"   : "prod",
+    "version" : 12,
+
+    "services": {
+        "worker": {"concurrency": 8, "queue": "tasks"},
+
+        "api": {
+            "port"    : 8080,
+            "retries" : 3,
+            "timeout" : 30,
+
+            "endpoints": {
+                "health"    : "/health",
+                "metrics"   : "/metrics",
+                "readiness" : "/ready",
+                "version"   : "/v"
+            },
+
+            "headers": {
+                "request_id" : "x-req",
+                "trace_id"   : "x-trace",
+                "user_agent" : "deploy/1"
+            }
+        },
+
+        "gateway": {
+            "rate_limit" : 1000,
+            "timeout"    : 5,
+            "upstream"   : {"fallback": "api.backup", "primary": "api.internal"}
+        }
+    },
+
+    "telemetry": {
+        "interval" : 30,
+        "sink"     : "datadog",
+
+        "logs": {
+            "format" : "json",
+            "level"  : "info",
+
+            "destinations": {
+                "file"        : "/var/log/app",
+                "remote_sink" : "logserver",
+                "stdout"      : True,
+                "syslog"      : False
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🪻 Quick Summary

Adds the universal correctness assertions every Python input must satisfy when fed through the formatter, wired to fire against every fixture under `tests/fixtures/`. The integration harness now checks idempotency at two granularities, the per-rule pipeline (*the existing `fixtures` test*) and the full default pipeline (*the new `pipeline_is_idempotent` test*), alongside determinism across two pipeline instances, syntactic validity through `ruff_python_parser`, and stability after `ruff_python_formatter::format_module_source` runs ahead of *Prose* (*the now-broadened `prose_is_stable_after_ruff` test*). A `[harness]` sidecar table parsed via `HarnessOptions` lets a fixture flag itself out of the ruff-coexistence pass without affecting the rest of the assertion suite. A new `composition/` directory carries `class_essentials`, `expanded_collection`, `match_dispatch`, and `recursive_partition` to exercise rule composition end-to-end.

The scope expanded during implementation to include dict-literal alphabetization, surfacing during composition testing where long config dicts kept source order while every sibling shape canonicalized. Dict literals now alphabetize with line-count partitioning (*single-line entries first, multi-line entries below a blank-line divider that fires on either side of each multi-line entry*), [`**unpacked`](https://peps.python.org/pep-0448/) pin-in-place, recursive descent into nested dicts, and a `# prose: keep` trailing-comment marker that preserves source order for a single dict whose iteration order is observable downstream. The partition fires recursively at every nesting level, with `align_colons` splitting its dict-member groups at blank-line boundaries so each line-adjacent run aligns independently.

---

### 🗞️ Key Changes

- Adds the per-fixture assertion suite to the `fixtures` test, where each fixture under `tests/fixtures/` exercises a snapshot reviewed through [`cargo insta review`](https://insta.rs/docs/cli/), a per-rule second-pass idempotency check (*`changed = false` and byte-stable*), and determinism across two independent `Pipeline` instances

- Adds `pipeline_is_idempotent` running every fixture's input through `Pipeline::with_defaults` twice and asserting the second pass returns `changed = false` and byte-stable text, catching rule-ordering oscillation that the per-rule check inside `fixtures` cannot

- Broadens `prose_is_stable_after_ruff` from `composition/` only to every fixture, gating the existing `prose != no-op` assertion to the composition directory and adding a `[harness] skip_ruff_coexistence = true` sidecar opt-out for fixtures `ruff_python_formatter` cannot format

- Adds `composition/` with four multi-rule fixtures (*`class_essentials`, `expanded_collection`, `match_dispatch`, `recursive_partition`*) running through `Pipeline::with_defaults`, demonstrating sort, partition, divider injection, alignment, and trailing-comma normalization composing across rule boundaries at multiple nesting levels

- Extends `alphabetize` to dict literals through `rewrite_dict_text`, partitioning entries by `Source::contains_line_break` on the item's range, alphabetizing within partitions by the key's source slice, and pinning `**unpacked` items in source position. The visitor tracks `dict_depth` and fires `emit_dict` only at the outermost dict, so a single non-overlapping edit captures every inner reorder

- Adds the `# prose: keep` trailing-comment opt-out detected through `Source::comment_ranges` against the line containing the dict's opening brace, short-circuiting `emit_dict` for that single dict while nested dicts inside continue to alphabetize unless individually marked

- Preserves source blank lines in `collection_layout::expand` so the partition divider survives canonical re-expansion across passes, and reuses the source's `align-colons`-shaped key-value gap in `serialize_dict_item`'s owned branch so recursive expansion of a nested value keeps the outer alignment column intact

- Splits `align_colons` dict-member groups at blank-line boundaries through `colon_targets::dict_member_groups`, mirroring how `class_field_groups` partitions class-body fields, so each contiguous-line run aligns independently and multi-line singletons strip their pre-colon padding via `singleton_rule`

- Adds `similar = "2"` as a dev-dependency for the unified-diff failure output that surfaces the post-ruff buffer and the inter-pass diff in test panic messages, plus `ruff_python_formatter` pinned to the same `0.15.10` tag as the rest of the ruff workspace

---

### ☕ Implementation Notes

Two requirements in the spec did not land in this PR. The structural-preservation assertion was capitulated, with the fixture suite plus the remaining assertions standing in as the practical regression detector. The three-tier stdlib bucketing was prototyped and withdrawn because the category-based grouping imposes a vertical-blocking decision the source itself does not carry, against the project's structurally-bound ordering posture. Rationale for both, plus the dict-literal scope expansion, lives in [this issue comment](https://github.com/Jybbs/prose/issues/18#issuecomment-4361202573).

---

### 🧵 Related Issues

- Closes #18