### PR TITLE
[22] Configure GitHub auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  categories:
+    - title: ✨ Features
+      labels:
+        - 🦉 engine
+        - 🪜 alignment
+        - 🪉 ordering
+        - 🪶 formatting
+        - 🪄 cli
+    - title: 📰 Docs
+      labels:
+        - 📰 docs
+    - title: 🗜️ Build
+      labels:
+        - 🗜️ build
+    - title: 🧱 Internals
+      labels:
+        - ⚖️ tests
+        - 🗺️ architecture
+    - title: Other
+      labels:
+        - "*"


### PR DESCRIPTION
### 🪻 Quick Summary

Adds `.github/release.yml` shaping *Prose*'s GitHub Releases page into five label-routed categories: ✨ Features, 📰 Docs, 🗜️ Build, 🧱 Internals, and Other. Multi-label PRs land in the first matching category top-down through the config.

---

### 🗞️ Key Changes

- Routes the five rule-domain labels (*🦉 engine, 🪜 alignment, 🪉 ordering, 🪶 formatting, 🪄 cli*) under ✨ Features, with ⚖️ tests and 🗺️ architecture paired under 🧱 Internals

- Catches issue-less PRs (*Renovate, bot-driven*) under Other via the `"*"` wildcard

- Copies labels byte-for-byte from `gh label list` to preserve emoji variation selectors

---

### 🧵 Related Issues

- Closes #22