### PR TITLE
[23] Ship `0.1.0` release

### DIFF
--- a/.github/scripts/parse-version.py
+++ b/.github/scripts/parse-version.py
@@ -7,7 +7,7 @@ Validate that pyproject.toml and Cargo.toml agree with the pushed tag.
 
 Reads from the environment:
     GITHUB_REF_TYPE  e.g. tag, branch
-    GITHUB_REF_NAME  e.g. v0.1.0, main
+    GITHUB_REF_NAME  e.g. 0.1.0, main
 
 Exits 0 on a non-tag run, or on a tag whose declared pyproject.toml and
 Cargo.toml versions match. Exits 1 when either file disagrees with the tag.
@@ -21,7 +21,7 @@ from tomllib import load
 if environ.get("GITHUB_REF_TYPE") != "tag":
     raise SystemExit
 
-version = environ["GITHUB_REF_NAME"].removeprefix("v")
+version = environ["GITHUB_REF_NAME"]
 for file, table, expected in [
     ("pyproject.toml", "project", version),
     ("Cargo.toml",     "package", sub(r"\.?(a|b|rc|dev|post)(\d+)", r"-\1.\2", version)),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # Prose release pipeline · tag-driven publish to PyPI via OIDC.
 #
-# Triggers on `v*` tag push (build + publish) and packaging-relevant PRs
+# Triggers on bare-semver tag push (build + publish) and packaging-relevant PRs
 # (build dry-run only). Builds wheels for Linux x86_64/aarch64, macOS
 # x86_64/aarch64, Windows x86_64, plus an sdist. Trusted publishing means
 # no API tokens are stored in repo or org secrets.
@@ -24,7 +24,7 @@ run-name : 🪻 Release · ${{ github.head_ref || github.ref_name }}
 
 on:
   push:
-    tags: ['v*']
+    tags: ['[0-9]*']
   pull_request:
     paths:
       - pyproject.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.82"
-version      = "0.1.0-dev"
+version      = "0.1.0"
 
 [dependencies]
 anyhow             = "1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires      = ["maturin>=1.7,<2.0"]
 [project]
 authors         = [{ name = "Jibbs" }]
 classifiers     = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -23,7 +23,7 @@ license         = { text = "MIT" }
 name            = "prose-formatter"
 readme          = "README.md"
 requires-python = ">=3.10"
-version         = "0.1.0.dev0"
+version         = "0.1.0"
 
 [project.urls]
 Repository = "https://github.com/Jybbs/prose"

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "prose-formatter"
-version = "0.1.0.dev0"
+version = "0.1.0"
 source = { editable = "." }


### PR DESCRIPTION
### 🪻 Quick Summary

Ships *Prose*'s 0.1.0 PyPI release by bumping the version across `Cargo.toml` and `pyproject.toml`, promoting the PyPI development-status classifier from `2 - Pre-Alpha` to `3 - Alpha`, and dropping the `v` prefix from release tags. The `.github/workflows/release.yml` trigger pattern moves to `[0-9]*` and `.github/scripts/parse-version.py` no longer strips a leading `v`, so post-merge release creation runs against bare semver tags.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` and `pyproject.toml` to `0.1.0`

- Promotes the PyPI development-status classifier from `2 - Pre-Alpha` to `3 - Alpha`

- Drops the `v` prefix from release tags, updating `.github/workflows/release.yml`'s tag trigger from `v*` to `[0-9]*` and removing the `v`-stripping call in `.github/scripts/parse-version.py`

---

### 🧵 Related Issues

- Closes #23