### PR TITLE
[47] Pin `pypa/gh-action-pypi-publish` to a version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@
 # breaks the trust relationship. Update PyPI before the next tag.
 #
 # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+#
+# Note: `pypa/gh-action-pypi-publish` pins by version (`@v1.14.0`) rather
+# than commit SHA. Its GHCR image is tagged by version only, so SHA-pinning
+# a Docker-based action breaks at image pull. Every other third-party action
+# in this pipeline intentionally uses a SHA pin.
 
 name     : 🪻 Release
 run-name : 🪻 Release · ${{ github.head_ref || github.ref_name }}
@@ -125,7 +130,7 @@ jobs:
           prose --version
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d
+        uses: pypa/gh-action-pypi-publish@v1.14.0
 
   gate:
     name            : 🗞️ Brief

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 
 *Prose* formats Python source to be *legible at a glance*. It aligns equals signs and colons vertically across consecutive lines, places one entry per line in dictionaries and lists, alphabetizes methods and fields within their groups, applies a singleton rule for colon padding, and treats code like prose rather than minified text.
 
-> [!WARNING]
-> Pre-alpha. Under active development. No public release yet.
+> [!NOTE]
+> Alpha (`0.1.0`). The eight rules below are stable, with additional rules planned for later releases.
 
 ---
 
@@ -32,9 +32,6 @@ The trade-offs minimalist formatters were built to avoid (*wider diffs, more ver
 ```bash
 uv tool install prose-formatter
 ```
-
-> [!IMPORTANT]
-> Not yet on PyPI. Build from source until `0.1.0` ships.
 
 ```bash
 prose format path/              # rewrite files in place


### PR DESCRIPTION
### 🪻 Quick Summary

Pins `pypa/gh-action-pypi-publish` to `@v1.14.0` rather than commit SHA, because the action's GHCR image is tagged by version only. The deviation applies to this Docker-based action alone, with every other third-party action keeping its SHA pin. The `README.md` "Not yet on PyPI" callout drops out and the alpha-status block updates to reflect the published `0.1.0` classifier.

---

### 🗞️ Key Changes

- Pins `pypa/gh-action-pypi-publish` from commit SHA to `@v1.14.0`

- Documents the version-pin deviation in the workflow file's header docstring, naming the GHCR-tag-by-version constraint and confirming every other third-party action keeps its SHA pin

- Removes the `> [!IMPORTANT]` "Not yet on PyPI" block from `README.md` and updates the alpha-status block from a `> [!WARNING]` "Pre-alpha" framing to a `> [!NOTE]` "Alpha (`0.1.0`)" framing

---

### 🧵 Related Issues

- Closes #47