### PR TITLE
[49] Finalize `0.1.1` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.82"
-version      = "0.1.0"
+version      = "0.1.1"
 
 [dependencies]
 anyhow             = "1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license         = { text = "MIT" }
 name            = "prose-formatter"
 readme          = "README.md"
 requires-python = ">=3.10"
-version         = "0.1.0"
+version         = "0.1.1"
 
 [project.urls]
 Repository = "https://github.com/Jybbs/prose"

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "prose-formatter"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes *Prose*'s first PyPI release as `0.1.1` by bumping `Cargo.toml`, `pyproject.toml`, `Cargo.lock`, and `uv.lock` from `0.1.0` to `0.1.1`. Same code as the would-have-been `0.1.0`, shipped under a fresh tag because GitHub's immutable-release enforcement locked the `0.1.0` tag after the failed publish addressed in #47.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` and `pyproject.toml` from `0.1.0` to `0.1.1`

- Regenerates `Cargo.lock` and `uv.lock` against the new manifest version

---

### 🧵 Related Issues

- Closes #49