### PR TITLE
[51] Finalize `0.1.2` release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           command : sdist
 
   publish:
-    name            : 📯 Publish to PyPI
+    name            : ${{ github.ref_type == 'tag' && '📯 Publish to PyPI' || '🕯️ Publish dry-run' }}
     needs           : [build, sdist]
     runs-on         : ubuntu-latest
     timeout-minutes : 15
@@ -116,6 +116,8 @@ jobs:
           merge-multiple : true
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+        with:
+          cache-dependency-glob: ""
 
       - name: Smoke-install built wheel
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,6 @@
 # breaks the trust relationship. Update PyPI before the next tag.
 #
 # https://docs.pypi.org/trusted-publishers/adding-a-publisher/
-#
-# Note: `pypa/gh-action-pypi-publish` pins by version (`@v1.14.0`) rather
-# than commit SHA. Its GHCR image is tagged by version only, so SHA-pinning
-# a Docker-based action breaks at image pull. Every other third-party action
-# in this pipeline intentionally uses a SHA pin.
 
 name     : 🪻 Release
 run-name : 🪻 Release · ${{ github.head_ref || github.ref_name }}
@@ -105,15 +100,13 @@ jobs:
   publish:
     name            : 📯 Publish to PyPI
     needs           : [build, sdist]
-    if              : github.ref_type == 'tag'
     runs-on         : ubuntu-latest
     timeout-minutes : 15
     environment:
       name : release
       url  : https://pypi.org/p/prose-formatter
     permissions:
-      id-token     : write
-      attestations : write
+      id-token: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -129,8 +122,13 @@ jobs:
           uv tool install --no-index --find-links=dist prose-formatter
           prose --version
 
+      - name: Generate PEP 740 attestations
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027
+        if: github.ref_type == 'tag'
+
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        if: github.ref_type == 'tag'
+        run: uv publish --trusted-publishing=always dist/*
 
   gate:
     name            : 🗞️ Brief

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.82"
-version      = "0.1.1"
+version      = "0.1.2"
 
 [dependencies]
 anyhow             = "1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license         = { text = "MIT" }
 name            = "prose-formatter"
 readme          = "README.md"
 requires-python = ">=3.10"
-version         = "0.1.1"
+version         = "0.1.2"
 
 [project.urls]
 Repository = "https://github.com/Jybbs/prose"

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "prose-formatter"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes *Prose* `0.1.2` as the first PyPI ship under [Astral](https://astral.sh)'s publish toolchain. The new path brings publishing under SHA-pinnable composite actions that comply with the repo's action-pinning policy, and gains [PEP 740](https://peps.python.org/pep-0740/) attestation generation along the way.

---

### 🗞️ Key Changes

- Replaces the [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) Docker action with [`astral-sh/attest-action`](https://github.com/astral-sh/attest-action) for PEP 740 attestation generation followed by [`uv publish`](https://docs.astral.sh/uv/guides/package/) `--trusted-publishing=always` for upload

- Moves the tag gate from the publish job to the attest and publish steps so PRs exercise action resolution against the SHA-only policy without uploading

- Bumps `Cargo.toml` and `pyproject.toml` from `0.1.1` to `0.1.2` and regenerates `Cargo.lock` and `uv.lock`

- Drops the unused `attestations: write` permission and the docstring block from #47 about the Docker pin deviation

---

### 🧵 Related Issues

- Closes #51