### PR TITLE
[53] Name all GitHub Actions workflow steps explicitly

### DIFF
--- a/.github/actions/checkout-prose/action.yml
+++ b/.github/actions/checkout-prose/action.yml
@@ -1,7 +1,0 @@
-name        : Check out the Prose repo
-description : Wrap `actions/checkout` at the project's pinned SHA so every workflow shares one site for SHA-pin updates.
-
-runs:
-  using: composite
-  steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/actions/checkout-prose/action.yml
+++ b/.github/actions/checkout-prose/action.yml
@@ -1,0 +1,7 @@
+name        : Check out the Prose repo
+description : Wrap `actions/checkout` at the project's pinned SHA so every workflow shares one site for SHA-pin updates.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/actions/download-wheels/action.yml
+++ b/.github/actions/download-wheels/action.yml
@@ -1,0 +1,12 @@
+name        : Download wheel artifacts
+description : Pull every `wheels-*` artifact uploaded by the build matrix into `dist/`, with one site for the `actions/download-artifact` SHA pin.
+
+runs:
+  using: composite
+  steps:
+    - name: Download wheel artifacts
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      with:
+        path           : dist
+        pattern        : wheels-*
+        merge-multiple : true

--- a/.github/actions/provision-uv/action.yml
+++ b/.github/actions/provision-uv/action.yml
@@ -1,11 +1,18 @@
 name        : Provision uv with a warm wheel cache
-description : Install the uv binary and restore `~/.cache/uv` keyed off the PEP 723 scripts so subsequent `uv run --script` invocations skip the PyPI fetch.
+description : Install the uv binary and restore `~/.cache/uv` keyed off the PEP 723 scripts so subsequent `uv run --script` invocations skip the PyPI fetch. Callers that do not run scripts (*publish job downloading wheels*) may pass an empty `cache-dependency-glob` to skip the cache key.
+
+inputs:
+  cache-dependency-glob:
+    description : Files whose hash keys the uv cache. Empty disables the cache.
+    required    : false
+    default     : .github/scripts/*.py
 
 runs:
   using: composite
   steps:
-    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         version               : latest
         enable-cache          : true
-        cache-dependency-glob : .github/scripts/*.py
+        cache-dependency-glob : ${{ inputs.cache-dependency-glob }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on : ubuntu-latest
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-prose
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install mise tools
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,8 @@ jobs:
     name    : ${{ inputs.command }}
     runs-on : ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Check out repository
+        uses: ./.github/actions/checkout-prose
 
       - name: Install mise tools
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ run-name : 🪻 CI · ${{ github.head_ref || github.ref_name }}
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - LICENSE
+      - assets/**
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - LICENSE
+      - assets/**
   workflow_dispatch:
 
 concurrency:
@@ -43,7 +51,7 @@ jobs:
       shared-key : ${{ matrix.shared-key }}
 
   gate:
-    name    : 🗞️ CI Brief
+    name    : 🗞️ Brief
     needs   : check
     if      : always()
     runs-on : ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,15 @@ jobs:
       shared-key : ${{ matrix.shared-key }}
 
   gate:
-    name    : 🗞️ Brief
+    name    : 🗞️ CI Brief
     needs   : check
     if      : always()
     runs-on : ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: ./.github/actions/provision-uv
+      - name: Check out repository
+        uses: ./.github/actions/checkout-prose
+      - name: Provision uv
+        uses: ./.github/actions/provision-uv
 
       - name: Summarize and gate
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on : ubuntu-latest
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-prose
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Provision uv
         uses: ./.github/actions/provision-uv
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes : 5
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-prose
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Provision uv
         uses: ./.github/actions/provision-uv
 
@@ -80,7 +80,7 @@ jobs:
             target    : x86_64-pc-windows-msvc
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-prose
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Build wheel
         uses: ./.github/actions/build-wheel
         with:
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes : 10
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-prose
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Build sdist
         uses: ./.github/actions/build-wheel
         with:
@@ -114,6 +114,9 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
       - name: Download all artifacts
         uses: ./.github/actions/download-wheels
 
@@ -143,7 +146,7 @@ jobs:
     timeout-minutes : 5
     steps:
       - name: Check out repository
-        uses: ./.github/actions/checkout-prose
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Provision uv
         uses: ./.github/actions/provision-uv
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
         run: uv publish --trusted-publishing=always dist/*
 
   gate:
-    name            : 🗞️ Release Brief
+    name            : 🗞️ Brief
     needs           : [build, sdist, publish]
     if              : always()
     runs-on         : ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,10 @@ jobs:
     runs-on         : ubuntu-latest
     timeout-minutes : 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: ./.github/actions/provision-uv
+      - name: Check out repository
+        uses: ./.github/actions/checkout-prose
+      - name: Provision uv
+        uses: ./.github/actions/provision-uv
 
       - name : Parse tag and validate versions
         run  : ./.github/scripts/parse-version.py
@@ -77,8 +79,10 @@ jobs:
             runner    : windows-latest
             target    : x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: ./.github/actions/build-wheel
+      - name: Check out repository
+        uses: ./.github/actions/checkout-prose
+      - name: Build wheel
+        uses: ./.github/actions/build-wheel
         with:
           command   : build
           target    : ${{ matrix.target }}
@@ -92,8 +96,10 @@ jobs:
     runs-on         : ubuntu-latest
     timeout-minutes : 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: ./.github/actions/build-wheel
+      - name: Check out repository
+        uses: ./.github/actions/checkout-prose
+      - name: Build sdist
+        uses: ./.github/actions/build-wheel
         with:
           command : sdist
 
@@ -109,13 +115,10 @@ jobs:
       id-token: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          path           : dist
-          pattern        : wheels-*
-          merge-multiple : true
+        uses: ./.github/actions/download-wheels
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
+      - name: Provision uv
+        uses: ./.github/actions/provision-uv
         with:
           cache-dependency-glob: ""
 
@@ -133,22 +136,20 @@ jobs:
         run: uv publish --trusted-publishing=always dist/*
 
   gate:
-    name            : 🗞️ Brief
+    name            : 🗞️ Release Brief
     needs           : [build, sdist, publish]
     if              : always()
     runs-on         : ubuntu-latest
     timeout-minutes : 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: ./.github/actions/provision-uv
+      - name: Check out repository
+        uses: ./.github/actions/checkout-prose
+      - name: Provision uv
+        uses: ./.github/actions/provision-uv
 
       - name: Download all artifacts
         if: needs.build.result != 'cancelled' && needs.sdist.result != 'cancelled'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          path           : dist
-          pattern        : wheels-*
-          merge-multiple : true
+        uses: ./.github/actions/download-wheels
 
       - name: Write release summary
         env:


### PR DESCRIPTION
### 🪻 Quick Summary

Names every step under `.github/workflows/` so the GitHub Actions UI reads as a scannable progression (*Install Rust toolchain, Run clippy lint pass, Build release wheel*) rather than the bare-`uses:` and `run:` fallbacks. The diff also extracts `actions/download-artifact` into a composite wrapper and routes `release.yml` publish through the existing `provision-uv` wrapper, so each third-party SHA pin lives at one site.

---

### 🗞️ Key Changes

- Adds an explicit `name:` to every step across `.github/workflows/check.yml`, `.github/workflows/ci.yml`, and `.github/workflows/release.yml`, with imperative phrasing matching the project's commit-subject shape

- Extracts `actions/download-artifact` into a composite wrapper under `.github/actions/download-wheels`, so its SHA pin updates from one site

- Adds an optional `cache-dependency-glob` input to `.github/actions/provision-uv` defaulting to the existing PEP 723 glob, letting `release.yml` publish reuse the wrapper with caching disabled

- Adds an `actions/checkout` step to `release.yml` publish so its local-composite uses resolve in the workspace

- Adds a `paths-ignore` filter to `.github/workflows/ci.yml` so docs-only PRs touching `**.md`, `LICENSE`, or `assets/**` skip the cargo matrix

---

### 🧵 Related Issues

- Closes #53
