### PR TITLE
[54] Add stable rule IDs and the `Rule::id()` accessor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "insta",
  "rayon",
  "ruff_diagnostics",
+ "ruff_macros",
  "ruff_python_ast",
  "ruff_python_formatter",
  "ruff_python_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ fs-err             = "3"
 ignore             = "0.4"
 rayon              = "1.10"
 ruff_diagnostics   = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
+ruff_macros        = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
 ruff_python_ast    = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10", features = ["serde"] }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
 ruff_python_trivia = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ use std::path::Path;
 use serde::{de::IntoDeserializer, Deserialize};
 use thiserror::Error;
 
+pub use crate::rule::RuleConfigs;
+
 /// Configuration shared by the alignment rules (`align_colons`, `align_equals`).
 #[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
@@ -143,24 +145,6 @@ pub enum MaxAlignShiftPolicy {
     Skip,
     #[default]
     Split,
-}
-
-/// Per-rule configuration parsed from `[tool.prose.rules.<name>]`.
-///
-/// Each field is a sub-table whose `enabled` key (defaulting to
-/// `true`) toggles the rule and whose remaining keys carry that
-/// rule's knobs.
-#[derive(Debug, Default, Deserialize)]
-#[serde(default, rename_all = "kebab-case")]
-pub struct RuleConfigs {
-    pub align_colons: AlignmentConfig,
-    pub align_equals: AlignmentConfig,
-    pub align_imports: AlignmentConfig,
-    pub alphabetize: ToggleOnly,
-    pub collection_layout: CollectionLayoutConfig,
-    pub match_case_align: AlignmentConfig,
-    pub singleton_rule: ToggleOnly,
-    pub strip_trailing_commas: ToggleOnly,
 }
 
 /// Sub-table shape for rules whose only knob is `enabled`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod config;
 pub mod pipeline;
 mod primitives;
+pub mod rule;
 mod rules;
 pub mod source;
 #[cfg(test)]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -5,27 +5,19 @@
 //! `Source` to the next rule. Alignment rules run last so earlier
 //! rewrites settle before padding widths are computed.
 
-use ruff_diagnostics::Edit;
 use ruff_python_parser::ParseError;
-use ruff_text_size::Ranged;
 use thiserror::Error;
 
-use crate::config::Config;
-use crate::rules::align_colons::AlignColons;
-use crate::rules::align_equals::AlignEquals;
-use crate::rules::align_imports::AlignImports;
-use crate::rules::alphabetize::Alphabetize;
-use crate::rules::collection_layout::CollectionLayout;
-use crate::rules::match_case_align::MatchCaseAlign;
-use crate::rules::singleton_rule::SingletonRule;
-use crate::rules::strip_trailing_commas::StripTrailingCommas;
+use crate::primitives::edit::apply_edits;
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 /// Ordered sequence of enabled rules, run against each source file.
 ///
-/// Use [`Pipeline::with_defaults`] to build one from a loaded [`Config`],
-/// [`Pipeline::for_rule`] to register exactly one rule by name, or
-/// [`Pipeline::empty`] for a pipeline with no rules.
+/// Use [`Pipeline::with_defaults`] to build one from a loaded
+/// [`crate::config::Config`], [`Pipeline::for_rule`] to register
+/// exactly one rule by name, or [`Pipeline::empty`] for a pipeline
+/// with no rules.
 pub struct Pipeline {
     rules: Vec<Box<dyn Rule>>,
 }
@@ -37,61 +29,7 @@ impl Pipeline {
         Self { rules: Vec::new() }
     }
 
-    /// Builds a pipeline registering exactly one rule by name.
-    ///
-    /// Returns `None` when `name` does not match any registered rule.
-    /// Bypasses each rule's `enabled` flag. Names accept either the
-    /// kebab-case form returned by [`Rule::name`] (`align-colons`,
-    /// `align-equals`, `align-imports`, `alphabetize`,
-    /// `collection-layout`, `match-case-align`, `singleton-rule`,
-    /// `strip-trailing-commas`) or the snake-case equivalent.
-    pub fn for_rule(name: &str, config: &Config) -> Option<Self> {
-        let rule: Box<dyn Rule> = match name.replace('_', "-").as_str() {
-            "align-colons" => Box::new(AlignColons::from_config(config)),
-            "align-equals" => Box::new(AlignEquals::from_config(config)),
-            "align-imports" => Box::new(AlignImports::from_config(config)),
-            "alphabetize" => Box::new(Alphabetize::from_config(config)),
-            "collection-layout" => Box::new(CollectionLayout::from_config(config)),
-            "match-case-align" => Box::new(MatchCaseAlign::from_config(config)),
-            "singleton-rule" => Box::new(SingletonRule::from_config(config)),
-            "strip-trailing-commas" => Box::new(StripTrailingCommas::from_config(config)),
-            _ => return None,
-        };
-        Some(Self::from_rules(vec![rule]))
-    }
-
-    fn from_rules(rules: Vec<Box<dyn Rule>>) -> Self {
-        Self { rules }
-    }
-
-    /// Builds a pipeline registering every rule enabled in `config`.
-    /// Rules whose `enabled` flag is `false` are silently skipped.
-    pub fn with_defaults(config: &Config) -> Self {
-        let mut rules: Vec<Box<dyn Rule>> = Vec::new();
-        if config.rules.collection_layout.enabled {
-            rules.push(Box::new(CollectionLayout::from_config(config)));
-        }
-        if config.rules.alphabetize.enabled {
-            rules.push(Box::new(Alphabetize::from_config(config)));
-        }
-        if config.rules.strip_trailing_commas.enabled {
-            rules.push(Box::new(StripTrailingCommas::from_config(config)));
-        }
-        if config.rules.match_case_align.enabled {
-            rules.push(Box::new(MatchCaseAlign::from_config(config)));
-        }
-        if config.rules.align_imports.enabled {
-            rules.push(Box::new(AlignImports::from_config(config)));
-        }
-        if config.rules.align_colons.enabled {
-            rules.push(Box::new(AlignColons::from_config(config)));
-        }
-        if config.rules.align_equals.enabled {
-            rules.push(Box::new(AlignEquals::from_config(config)));
-        }
-        if config.rules.singleton_rule.enabled {
-            rules.push(Box::new(SingletonRule::from_config(config)));
-        }
+    pub(crate) fn from_rules(rules: Vec<Box<dyn Rule>>) -> Self {
         Self { rules }
     }
 
@@ -103,6 +41,14 @@ impl Pipeline {
     #[cfg(test)]
     fn len(&self) -> usize {
         self.rules.len()
+    }
+
+    /// Returns every registered rule's id in a stable order. Useful
+    /// for CLI `--select` / `--ignore` validation and for rule
+    /// listings. Surfaces the same registry that
+    /// [`RuleId::from_str`](crate::rule::RuleId) consults.
+    pub fn known_ids() -> &'static [RuleId] {
+        crate::rule::KNOWN_IDS
     }
 
     /// Runs each registered rule against `source` in order and reports
@@ -130,13 +76,13 @@ impl Pipeline {
                 debug_assert!(
                     new_text != source.text(),
                     "rule `{}` emitted edits that produced identical text",
-                    rule.name(),
+                    rule.id(),
                 );
                 source
                     .reparse(new_text)
                     .map(|src| (src, true))
                     .map_err(|source| PipelineError::Reparse {
-                        rule: rule.name(),
+                        rule: rule.id(),
                         source,
                     })
             })
@@ -148,80 +94,38 @@ impl Pipeline {
 pub enum PipelineError {
     #[error("rule `{rule}` produced output that did not parse")]
     Reparse {
-        rule: &'static str,
+        rule: RuleId,
         #[source]
         source: ParseError,
     },
-}
-
-/// Every rule in Prose implements this trait and nothing more.
-///
-/// Implementations inspect `source` and return the edits that would
-/// bring it into conformance. An empty `Vec<Edit>` means the rule has
-/// nothing to say, and the pipeline skips the reparse for that rule.
-///
-/// Rules must be `Send + Sync` so that the pipeline can run across
-/// files in parallel without moving the rule list per worker.
-pub(crate) trait Rule: Send + Sync {
-    /// Computes the edit list this rule would apply to `source`.
-    /// Edits must not overlap after sorting, an invariant the
-    /// pipeline's applicator debug-asserts.
-    fn apply(&self, source: &Source) -> Vec<Edit>;
-
-    /// Stable identifier matching the rule's `[tool.prose.rules]` key
-    /// (kebab-case, e.g. `"align-equals"`). Surfaces in diagnostic
-    /// output when a rule produces unparseable text.
-    fn name(&self) -> &'static str;
-}
-
-/// Splices `edits` into `text` and returns the resulting string.
-///
-/// Sorts edits by start-then-end (via `Edit`'s `Ord` impl), then walks
-/// the list forward once, copying the unchanged spans between edits
-/// into a pre-sized buffer and substituting each edit's replacement
-/// at its position. Linear in the source length regardless of how
-/// many edits apply. Debug builds assert the sorted edits are
-/// non-overlapping, a rule-authoring invariant.
-fn apply_edits(text: &str, mut edits: Vec<Edit>) -> String {
-    edits.sort_unstable();
-    debug_assert!(
-        edits.is_sorted_by(|a, b| a.end() <= b.start()),
-        "edits overlap"
-    );
-    let mut out = String::with_capacity(text.len());
-    let mut cursor = 0usize;
-    for edit in edits {
-        out.push_str(&text[cursor..edit.start().to_usize()]);
-        out.push_str(edit.content().unwrap_or_default());
-        cursor = edit.end().to_usize();
-    }
-    out.push_str(&text[cursor..]);
-    out
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    use ruff_diagnostics::Edit;
+
     use super::*;
+    use crate::config::Config;
     use crate::test_support::{assert_send_sync, parse, range};
 
-    /// Test-only rule that records its own name into a shared log and
+    /// Test-only rule that records its own id into a shared log and
     /// returns the edit list supplied at construction time.
     struct SentinelRule {
         edits: Vec<Edit>,
+        id: RuleId,
         log: Arc<Mutex<Vec<&'static str>>>,
-        name: &'static str,
     }
 
     impl Rule for SentinelRule {
         fn apply(&self, _source: &Source) -> Vec<Edit> {
-            self.log.lock().expect("log mutex").push(self.name);
+            self.log.lock().expect("log mutex").push(self.id.as_str());
             self.edits.clone()
         }
 
-        fn name(&self) -> &'static str {
-            self.name
+        fn id(&self) -> RuleId {
+            self.id
         }
     }
 
@@ -229,7 +133,7 @@ mod tests {
     /// returns the edit list supplied at construction.
     struct TextCapturingRule {
         edits: Vec<Edit>,
-        name: &'static str,
+        id: RuleId,
         seen: Arc<Mutex<Vec<String>>>,
     }
 
@@ -239,61 +143,9 @@ mod tests {
             self.edits.clone()
         }
 
-        fn name(&self) -> &'static str {
-            self.name
+        fn id(&self) -> RuleId {
+            self.id
         }
-    }
-
-    #[test]
-    fn apply_edits_handles_insertions_and_deletions() {
-        let out = apply_edits(
-            "abcd",
-            vec![
-                Edit::insertion("<".to_owned(), 0u32.into()),
-                Edit::range_deletion(range(2, 3)),
-            ],
-        );
-
-        assert_eq!(out, "<abd");
-    }
-
-    #[test]
-    fn apply_edits_handles_multiple_non_overlapping_edits() {
-        let out = apply_edits(
-            "abcdef",
-            vec![
-                Edit::range_replacement("X".to_owned(), range(0, 1)),
-                Edit::range_replacement("Y".to_owned(), range(4, 5)),
-            ],
-        );
-
-        assert_eq!(out, "XbcdYf");
-    }
-
-    #[test]
-    #[cfg(debug_assertions)]
-    #[should_panic(expected = "edits overlap")]
-    fn apply_edits_panics_on_overlap_in_debug() {
-        let _ = apply_edits(
-            "abcdef",
-            vec![
-                Edit::range_replacement("X".to_owned(), range(0, 3)),
-                Edit::range_replacement("Y".to_owned(), range(2, 4)),
-            ],
-        );
-    }
-
-    #[test]
-    fn apply_edits_sorts_unsorted_input() {
-        let out = apply_edits(
-            "abcdef",
-            vec![
-                Edit::range_replacement("Y".to_owned(), range(4, 5)),
-                Edit::range_replacement("X".to_owned(), range(0, 1)),
-            ],
-        );
-
-        assert_eq!(out, "XbcdYf");
     }
 
     #[test]
@@ -302,12 +154,12 @@ mod tests {
         let pipeline = Pipeline::from_rules(vec![
             Box::new(TextCapturingRule {
                 edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
-                name: "rewrite-x-to-y",
+                id: RuleId::from("rewrite-x-to-y"),
                 seen: seen.clone(),
             }),
             Box::new(TextCapturingRule {
                 edits: Vec::new(),
-                name: "downstream-observer",
+                id: RuleId::from("downstream-observer"),
                 seen: seen.clone(),
             }),
         ]);
@@ -330,24 +182,37 @@ mod tests {
     }
 
     #[test]
+    fn known_ids_matches_with_defaults_registration() {
+        let config = Config::default();
+        let pipeline = Pipeline::with_defaults(&config);
+        let mut registered: Vec<&'static str> =
+            pipeline.rules.iter().map(|r| r.id().as_str()).collect();
+        registered.sort_unstable();
+        let mut known: Vec<&'static str> =
+            Pipeline::known_ids().iter().map(|id| id.as_str()).collect();
+        known.sort_unstable();
+        assert_eq!(registered, known);
+    }
+
+    #[test]
     fn pipeline_is_send_and_sync() {
         assert_send_sync::<Pipeline>();
     }
 
     #[test]
-    fn reparse_failure_surfaces_rule_name() {
+    fn reparse_failure_surfaces_rule_id() {
         let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
         let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
             edits: vec![Edit::range_replacement("def foo(".to_owned(), range(0, 5))],
+            id: RuleId::from("breaks-parse"),
             log: log.clone(),
-            name: "breaks-parse",
         })]);
         let source = parse("x = 1\n");
 
         let err = pipeline.run(source).expect_err("reparse should fail");
 
         match err {
-            PipelineError::Reparse { rule, .. } => assert_eq!(rule, "breaks-parse"),
+            PipelineError::Reparse { rule, .. } => assert_eq!(rule.as_str(), "breaks-parse"),
         }
     }
 
@@ -357,18 +222,18 @@ mod tests {
         let pipeline = Pipeline::from_rules(vec![
             Box::new(SentinelRule {
                 edits: Vec::new(),
+                id: RuleId::from("first"),
                 log: log.clone(),
-                name: "first",
             }),
             Box::new(SentinelRule {
                 edits: Vec::new(),
+                id: RuleId::from("second"),
                 log: log.clone(),
-                name: "second",
             }),
             Box::new(SentinelRule {
                 edits: Vec::new(),
+                id: RuleId::from("third"),
                 log: log.clone(),
-                name: "third",
             }),
         ]);
         let source = parse("x = 1\n");
@@ -382,8 +247,8 @@ mod tests {
     fn run_reports_changed_when_a_rule_rewrites_text() {
         let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
             edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+            id: RuleId::from("rewrite-x-to-y"),
             log: Arc::new(Mutex::new(Vec::new())),
-            name: "rewrite-x-to-y",
         })]);
         let source = parse("x = 1\n");
 

--- a/src/primitives/edit.rs
+++ b/src/primitives/edit.rs
@@ -1,7 +1,9 @@
-//! Edit-shaping primitives shared across rules. `narrow_edit` trims
-//! a candidate replacement to its minimal divergent range against
-//! the source. `apply_inline_edits` folds a list of edits into a
-//! source range, returning `Cow::Borrowed` when no edit applies.
+//! Edit-shaping primitives shared across rules. `apply_edits` splices
+//! a sorted edit list into a source string, the pipeline runner's
+//! transform between rules. `apply_inline_edits` folds a list of
+//! edits into a source range, returning `Cow::Borrowed` when no
+//! edit applies. `narrow_edit` trims a candidate replacement to its
+//! minimal divergent range against the source.
 
 use std::borrow::Cow;
 
@@ -9,6 +11,31 @@ use ruff_diagnostics::Edit;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::source::Source;
+
+/// Splices `edits` into `text` and returns the resulting string.
+///
+/// Sorts edits by start-then-end (via `Edit`'s `Ord` impl), then walks
+/// the list forward once, copying the unchanged spans between edits
+/// into a pre-sized buffer and substituting each edit's replacement
+/// at its position. Linear in the source length regardless of how
+/// many edits apply. Debug builds assert the sorted edits are
+/// non-overlapping, a rule-authoring invariant.
+pub(crate) fn apply_edits(text: &str, mut edits: Vec<Edit>) -> String {
+    edits.sort_unstable();
+    debug_assert!(
+        edits.is_sorted_by(|a, b| a.end() <= b.start()),
+        "edits overlap"
+    );
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = TextSize::default();
+    for edit in edits {
+        out.push_str(&text[TextRange::new(cursor, edit.start())]);
+        out.push_str(edit.content().unwrap_or_default());
+        cursor = edit.end();
+    }
+    out.push_str(&text[TextRange::new(cursor, text.text_len())]);
+    out
+}
 
 /// Folds any leaf edits whose range falls inside `range` into the
 /// source slice for that range. Returns `Cow::Borrowed` when no leaf
@@ -91,6 +118,58 @@ pub(crate) fn narrowed_replacement(source: &Source, span: TextRange, text: Strin
 mod tests {
     use super::*;
     use crate::test_support::range;
+
+    #[test]
+    fn apply_edits_handles_insertions_and_deletions() {
+        let out = apply_edits(
+            "abcd",
+            vec![
+                Edit::insertion("<".to_owned(), 0u32.into()),
+                Edit::range_deletion(range(2, 3)),
+            ],
+        );
+
+        assert_eq!(out, "<abd");
+    }
+
+    #[test]
+    fn apply_edits_handles_multiple_non_overlapping_edits() {
+        let out = apply_edits(
+            "abcdef",
+            vec![
+                Edit::range_replacement("X".to_owned(), range(0, 1)),
+                Edit::range_replacement("Y".to_owned(), range(4, 5)),
+            ],
+        );
+
+        assert_eq!(out, "XbcdYf");
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "edits overlap")]
+    fn apply_edits_panics_on_overlap_in_debug() {
+        let _ = apply_edits(
+            "abcdef",
+            vec![
+                Edit::range_replacement("X".to_owned(), range(0, 3)),
+                Edit::range_replacement("Y".to_owned(), range(2, 4)),
+            ],
+        );
+    }
+
+    #[test]
+    fn apply_edits_sorts_unsorted_input() {
+        let out = apply_edits(
+            "abcdef",
+            vec![
+                Edit::range_replacement("Y".to_owned(), range(4, 5)),
+                Edit::range_replacement("X".to_owned(), range(0, 1)),
+            ],
+        );
+
+        assert_eq!(out, "XbcdYf");
+    }
 
     #[test]
     fn narrow_edit_handles_multibyte_codepoint_at_divergence() {

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -1,0 +1,201 @@
+//! Rule abstraction, identifier types, and the registry that ties
+//! concrete rule structs to the pipeline orchestrator.
+//!
+//! Each concrete rule lives under `crate::rules`. The [`Rule`] trait
+//! and the [`RuleId`] newtype defined here are the canonical handles.
+//! The `register_rules!` macro emits [`KNOWN_IDS`], [`RuleConfigs`],
+//! [`Pipeline::for_rule`], and [`Pipeline::with_defaults`] from a
+//! registry table.
+
+use std::fmt;
+use std::str::FromStr;
+
+use ruff_diagnostics::Edit;
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::config::{AlignmentConfig, CollectionLayoutConfig, Config, ToggleOnly};
+use crate::pipeline::Pipeline;
+use crate::rules::align_colons::AlignColons;
+use crate::rules::align_equals::AlignEquals;
+use crate::rules::align_imports::AlignImports;
+use crate::rules::alphabetize::Alphabetize;
+use crate::rules::collection_layout::CollectionLayout;
+use crate::rules::match_case_align::MatchCaseAlign;
+use crate::rules::singleton_rule::SingletonRule;
+use crate::rules::strip_trailing_commas::StripTrailingCommas;
+use crate::source::Source;
+
+/// Returned when a string fails to match any registered rule slug.
+/// Carries the offending input so callers can surface it verbatim.
+#[derive(Debug, Error)]
+#[error("unknown rule id `{0}`")]
+pub struct ParseRuleIdError(pub String);
+
+/// Every rule in Prose implements this trait and nothing more.
+///
+/// Implementations inspect `source` and return the edits that would
+/// bring it into conformance. An empty `Vec<Edit>` means the rule has
+/// nothing to say, and the pipeline skips the reparse for that rule.
+///
+/// Rules must be `Send + Sync` so that the pipeline can run across
+/// files in parallel without moving the rule list per worker.
+pub(crate) trait Rule: Send + Sync {
+    /// Computes the edit list this rule would apply to `source`.
+    /// Edits must not overlap after sorting, an invariant the
+    /// pipeline's applicator debug-asserts.
+    fn apply(&self, source: &Source) -> Vec<Edit>;
+
+    /// Stable, kebab-case identifier matching the rule's
+    /// `[tool.prose.rules]` key. Surfaces in `--select`,
+    /// `# prose: ignore`, and diagnostic output.
+    fn id(&self) -> RuleId;
+}
+
+/// Stable, parseable rule identifier wrapping a kebab-case slug.
+/// Returned by [`Rule::id`] and parsed from CLI / pragma input via
+/// [`FromStr`]. The canonical handle in `--select` / `--ignore`,
+/// `# prose: ignore[...]`, JSON `"rule"` fields, and `github`
+/// annotations.
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub struct RuleId(&'static str);
+
+impl RuleId {
+    pub const fn as_str(&self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Debug for RuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl fmt::Display for RuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl From<&'static str> for RuleId {
+    fn from(slug: &'static str) -> Self {
+        Self(slug)
+    }
+}
+
+impl FromStr for RuleId {
+    type Err = ParseRuleIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        KNOWN_IDS
+            .iter()
+            .copied()
+            .find(|id| id.0 == s)
+            .ok_or_else(|| ParseRuleIdError(s.to_owned()))
+    }
+}
+
+/// Generates [`KNOWN_IDS`], [`RuleConfigs`], [`Pipeline::for_rule`],
+/// and [`Pipeline::with_defaults`] from a registry table. Each row
+/// pairs the rule's `[tool.prose.rules]` field name with its config
+/// sub-table type and rule struct. The kebab-case slug is derived
+/// from the type identifier via `ruff_macros::kebab_case!`.
+macro_rules! register_rules {
+    ($($field:ident: $config:ty => $ty:ident),* $(,)?) => {
+        pub(crate) const KNOWN_IDS: &[RuleId] = &[
+            $(RuleId(ruff_macros::kebab_case!($ty))),*
+        ];
+
+        /// Per-rule configuration parsed from `[tool.prose.rules.<name>]`.
+        ///
+        /// Each field is a sub-table whose `enabled` key (defaulting
+        /// to `true`) toggles the rule and whose remaining keys carry
+        /// that rule's knobs.
+        #[derive(Debug, Default, Deserialize)]
+        #[serde(default, rename_all = "kebab-case")]
+        pub struct RuleConfigs {
+            $(pub $field: $config,)*
+        }
+
+        // Routes a missing-`Default` error to the offending `$config`
+        // row instead of the macro-emitted derive site.
+        $(const _: fn() -> $config = <$config as Default>::default;)*
+
+        impl Pipeline {
+            /// Builds a pipeline registering exactly one rule by name.
+            ///
+            /// Returns `None` when `name` does not match any registered
+            /// rule, see [`Pipeline::known_ids`] for the full list.
+            /// Bypasses each rule's `enabled` flag. Snake-case input is
+            /// normalized to the canonical kebab form.
+            pub fn for_rule(name: &str, config: &Config) -> Option<Self> {
+                let rule: Box<dyn Rule> = match name.replace('_', "-").as_str() {
+                    $(ruff_macros::kebab_case!($ty) => Box::new($ty::from_config(config)),)*
+                    _ => return None,
+                };
+                Some(Self::from_rules(vec![rule]))
+            }
+
+            /// Builds a pipeline registering every rule enabled in
+            /// `config`. Rules whose `enabled` flag is `false` are
+            /// silently skipped.
+            pub fn with_defaults(config: &Config) -> Self {
+                let mut rules: Vec<Box<dyn Rule>> = Vec::new();
+                $(
+                    if config.rules.$field.enabled {
+                        rules.push(Box::new($ty::from_config(config)));
+                    }
+                )*
+                Self::from_rules(rules)
+            }
+        }
+    };
+}
+
+register_rules! {
+    collection_layout:     CollectionLayoutConfig => CollectionLayout,
+    alphabetize:           ToggleOnly             => Alphabetize,
+    strip_trailing_commas: ToggleOnly             => StripTrailingCommas,
+    match_case_align:      AlignmentConfig        => MatchCaseAlign,
+    align_imports:         AlignmentConfig        => AlignImports,
+    align_colons:          AlignmentConfig        => AlignColons,
+    align_equals:          AlignmentConfig        => AlignEquals,
+    singleton_rule:        ToggleOnly             => SingletonRule,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rule_id_display_and_debug_print_bare_slug() {
+        let id = RuleId("align-equals");
+        assert_eq!(format!("{id}"), "align-equals");
+        assert_eq!(format!("{id:?}"), "align-equals");
+    }
+
+    #[test]
+    fn rule_id_from_str_rejects_prose_prefixed_slug() {
+        let err = "PROSE-align-equals"
+            .parse::<RuleId>()
+            .expect_err("prefixed form is not the canonical");
+        assert_eq!(err.0, "PROSE-align-equals");
+    }
+
+    #[test]
+    fn rule_id_from_str_rejects_unknown_slug() {
+        let err = "not-a-rule"
+            .parse::<RuleId>()
+            .expect_err("unknown rejected");
+        assert_eq!(err.0, "not-a-rule");
+    }
+
+    #[test]
+    fn rule_id_round_trips_through_display_and_from_str() {
+        for id in KNOWN_IDS {
+            let parsed: RuleId = id.to_string().parse().expect("known id parses");
+            assert_eq!(parsed, *id);
+        }
+    }
+}

--- a/src/rules/align_colons.rs
+++ b/src/rules/align_colons.rs
@@ -9,9 +9,9 @@ use ruff_diagnostics::Edit;
 use ruff_python_ast::ExprDict;
 
 use crate::config::Config;
-use crate::pipeline::Rule;
 use crate::primitives::aligner;
 use crate::primitives::colon_targets::ColonEmitter;
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct AlignColons {
@@ -38,8 +38,8 @@ impl Rule for AlignColons {
         emitter.edits
     }
 
-    fn name(&self) -> &'static str {
-        "align-colons"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(AlignColons))
     }
 }
 

--- a/src/rules/align_equals.rs
+++ b/src/rules/align_equals.rs
@@ -13,8 +13,8 @@ use ruff_python_ast::Stmt;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::config::Config;
-use crate::pipeline::Rule;
 use crate::primitives::aligner;
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct AlignEquals {
@@ -40,8 +40,8 @@ impl Rule for AlignEquals {
         visitor.edits
     }
 
-    fn name(&self) -> &'static str {
-        "align-equals"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(AlignEquals))
     }
 }
 

--- a/src/rules/align_imports.rs
+++ b/src/rules/align_imports.rs
@@ -16,8 +16,8 @@ use ruff_python_ast::Stmt;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::config::Config;
-use crate::pipeline::Rule;
 use crate::primitives::aligner;
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct AlignImports {
@@ -43,8 +43,8 @@ impl Rule for AlignImports {
         visitor.edits
     }
 
-    fn name(&self) -> &'static str {
-        "align-imports"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(AlignImports))
     }
 }
 

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -28,11 +28,11 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::config::Config;
-use crate::pipeline::Rule;
 use crate::primitives::edit::{apply_inline_edits, narrowed_replacement};
 use crate::primitives::orderer::{
     assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
 };
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct Alphabetize;
@@ -65,8 +65,8 @@ impl Rule for Alphabetize {
         }
     }
 
-    fn name(&self) -> &'static str {
-        "alphabetize"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(Alphabetize))
     }
 }
 

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -16,8 +16,8 @@ use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
-use crate::pipeline::Rule;
 use crate::primitives::edit::narrowed_replacement;
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 const DEFAULT_LINE_LENGTH: usize = 88;
@@ -57,8 +57,8 @@ impl Rule for CollectionLayout {
         visitor.edits
     }
 
-    fn name(&self) -> &'static str {
-        "collection-layout"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(CollectionLayout))
     }
 }
 

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -15,8 +15,8 @@ use ruff_python_ast::{MatchCase, Stmt, StmtMatch};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::config::Config;
-use crate::pipeline::Rule;
 use crate::primitives::{aligner, colon_targets};
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct MatchCaseAlign {
@@ -43,8 +43,8 @@ impl Rule for MatchCaseAlign {
         visitor.edits
     }
 
-    fn name(&self) -> &'static str {
-        "match-case-align"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(MatchCaseAlign))
     }
 }
 

--- a/src/rules/singleton_rule.rs
+++ b/src/rules/singleton_rule.rs
@@ -11,9 +11,9 @@
 use ruff_diagnostics::Edit;
 
 use crate::config::Config;
-use crate::pipeline::Rule;
 use crate::primitives::aligner;
 use crate::primitives::colon_targets::ColonEmitter;
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct SingletonRule;
@@ -31,8 +31,8 @@ impl Rule for SingletonRule {
         emitter.edits
     }
 
-    fn name(&self) -> &'static str {
-        "singleton-rule"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(SingletonRule))
     }
 }
 

--- a/src/rules/strip_trailing_commas.rs
+++ b/src/rules/strip_trailing_commas.rs
@@ -12,7 +12,7 @@ use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::config::Config;
-use crate::pipeline::Rule;
+use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct StripTrailingCommas;
@@ -33,8 +33,8 @@ impl Rule for StripTrailingCommas {
         visitor.edits
     }
 
-    fn name(&self) -> &'static str {
-        "strip-trailing-commas"
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(StripTrailingCommas))
     }
 }
 

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -8,6 +8,26 @@ Config {
         100,
     ),
     rules: RuleConfigs {
+        collection_layout: CollectionLayoutConfig {
+            enabled: false,
+            max_atomics_per_line: None,
+        },
+        alphabetize: ToggleOnly {
+            enabled: false,
+        },
+        strip_trailing_commas: ToggleOnly {
+            enabled: false,
+        },
+        match_case_align: AlignmentConfig {
+            enabled: false,
+            max_shift: 8,
+            max_shift_policy: Split,
+        },
+        align_imports: AlignmentConfig {
+            enabled: false,
+            max_shift: 8,
+            max_shift_policy: Split,
+        },
         align_colons: AlignmentConfig {
             enabled: false,
             max_shift: 8,
@@ -18,27 +38,7 @@ Config {
             max_shift: 8,
             max_shift_policy: Split,
         },
-        align_imports: AlignmentConfig {
-            enabled: false,
-            max_shift: 8,
-            max_shift_policy: Split,
-        },
-        alphabetize: ToggleOnly {
-            enabled: false,
-        },
-        collection_layout: CollectionLayoutConfig {
-            enabled: false,
-            max_atomics_per_line: None,
-        },
-        match_case_align: AlignmentConfig {
-            enabled: false,
-            max_shift: 8,
-            max_shift_policy: Split,
-        },
         singleton_rule: ToggleOnly {
-            enabled: false,
-        },
-        strip_trailing_commas: ToggleOnly {
             enabled: false,
         },
     },


### PR DESCRIPTION
### 🪻 Quick Summary

Promotes the kebab-case slug each rule already exposes into a typed `RuleId` newtype, the canonical handle that `--select` / `--ignore` (#56), per-line `# prose: ignore[...]` (#59), and diagnostic output (#57) will all flow through. The shape mirrors Astral's [`ty`](https://docs.astral.sh/ty/suppression/) and the rest of the post-2020 Python type-checker cohort ([mypy](https://mypy.readthedocs.io/en/stable/error_codes.html), [pyright](https://microsoft.github.io/pyright/#/comments), [pyrefly](https://pyrefly.org/en/docs/error-suppressions/)): a bare kebab slug in the comment body, with the tool name carried by the comment leader. Along the way the rule registry collapses into a single declarative table, and the slug literal disappears from the codebase entirely thanks to `ruff_macros::kebab_case!`.

---

### 🗞️ Key Changes

- Introduces the `RuleId(&'static str)` newtype in a new `src/rule.rs` module, with `Display`, `Debug`, `From`, and `FromStr` impls plus a `ParseRuleIdError` that surfaces unknown slugs verbatim

- Replaces `Rule::name()` with a required `Rule::id() -> RuleId`, leaves the trait at two methods, and routes `PipelineError::Reparse` through the typed identifier

- Folds the rule registry into a `register_rules!` declarative table that emits `KNOWN_IDS`, `RuleConfigs`, and the `Pipeline::for_rule` / `Pipeline::with_defaults` impls from one source, plus a compile-time assertion that every per-rule config row implements `Default`

- Adopts `ruff_macros::kebab_case!` so each rule's slug derives from its struct identifier, the same primitive Astral's [`ty`](https://docs.astral.sh/ty/) uses inside its `declare_lint!` macro

- Moves `apply_edits` from `src/pipeline.rs` to `src/primitives/edit.rs` next to its splice siblings, and threads `ruff_text_size::TextLen` plus the `Index<TextRange> for str` impl so the function stays in `TextSize`-land throughout

---

### ☕ Implementation Notes

Rationale for the spec departures and the additional primitives this PR adopts lives in [this issue comment](https://github.com/Jybbs/prose/issues/54#issuecomment-4399413226).

---

### 🧵 Related Issues

- Closes #54

