### PR TITLE
[55] Implement `# fmt: off` / `# fmt: on` block-level suppression

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod primitives;
 pub mod rule;
 mod rules;
 pub mod source;
+pub mod suppression;
 #[cfg(test)]
 mod test_support;
 mod walker;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -68,7 +68,8 @@ impl Pipeline {
         self.rules
             .iter()
             .try_fold((source, false), |(source, changed), rule| {
-                let edits = rule.apply(&source);
+                let mut edits = rule.apply(&source);
+                edits.retain(|edit| !source.suppression_map().intersects(edit));
                 if edits.is_empty() {
                     return Ok((source, changed));
                 }
@@ -244,6 +245,29 @@ mod tests {
     }
 
     #[test]
+    fn run_drops_edits_whose_range_overlaps_a_suppressed_span() {
+        // Source: "# fmt: off\nx = 1\n# fmt: on\nz = 9\n"
+        //         |0--------|11----|17--------|27----|33
+        // Edit at 11..16 (`x = 1`) sits inside the suppressed
+        // [0..17) span and must be dropped, leaving the unsuppressed
+        // edit at 27..32 (`z = 9`) to apply.
+        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
+            edits: vec![
+                Edit::range_replacement("y".to_owned(), range(11, 16)),
+                Edit::range_replacement("Z".to_owned(), range(27, 32)),
+            ],
+            id: RuleId::from("rewrite-x-and-z"),
+            log: Arc::new(Mutex::new(Vec::new())),
+        })]);
+        let source = parse("# fmt: off\nx = 1\n# fmt: on\nz = 9\n");
+
+        let (result, changed) = pipeline.run(source).expect("filtered run succeeds");
+
+        assert_eq!(result.text(), "# fmt: off\nx = 1\n# fmt: on\nZ\n");
+        assert!(changed);
+    }
+
+    #[test]
     fn run_reports_changed_when_a_rule_rewrites_text() {
         let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
             edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
@@ -256,6 +280,21 @@ mod tests {
 
         assert_eq!(result.text(), "y = 1\n");
         assert!(changed);
+    }
+
+    #[test]
+    fn run_skips_reparse_when_every_edit_is_suppressed() {
+        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
+            edits: vec![Edit::range_replacement("y".to_owned(), range(11, 16))],
+            id: RuleId::from("rewrite-x-to-y"),
+            log: Arc::new(Mutex::new(Vec::new())),
+        })]);
+        let source = parse("# fmt: off\nx = 1\n# fmt: on\n");
+
+        let (result, changed) = pipeline.run(source).expect("filtered run succeeds");
+
+        assert_eq!(result.text(), "# fmt: off\nx = 1\n# fmt: on\n");
+        assert!(!changed);
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -69,7 +69,10 @@ impl Pipeline {
             .iter()
             .try_fold((source, false), |(source, changed), rule| {
                 let mut edits = rule.apply(&source);
-                edits.retain(|edit| !source.suppression_map().intersects(edit));
+                let suppression = source.suppression_map();
+                if !suppression.is_empty() {
+                    edits.retain(|edit| !suppression.intersects(edit));
+                }
                 if edits.is_empty() {
                     return Ok((source, changed));
                 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -17,15 +17,19 @@ use ruff_source_file::{
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use thiserror::Error;
 
+use crate::suppression::SuppressionMap;
+
 /// Owned wrapper around a parsed Python source file.
 ///
 /// Holds the source text, the parsed AST, the token stream, a lazy
-/// line index, and a `CommentRanges` index built during parsing.
+/// line index, a `CommentRanges` index built during parsing, and a
+/// `SuppressionMap` of `# fmt: off` / `# fmt: skip` spans.
 #[derive(Debug)]
 pub struct Source {
     comment_ranges: CommentRanges,
     file: SourceFile,
     parsed: Parsed<ModModule>,
+    suppression: SuppressionMap,
 }
 
 impl Source {
@@ -33,10 +37,12 @@ impl Source {
         let parsed = parse_module(&text)?;
         let file = SourceFileBuilder::new(name, text).finish();
         let comment_ranges = CommentRanges::from(parsed.tokens());
+        let suppression = SuppressionMap::from_comments(file.source_text(), &comment_ranges);
         Ok(Self {
             comment_ranges,
             file,
             parsed,
+            suppression,
         })
     }
 
@@ -163,6 +169,11 @@ impl Source {
     /// emits ranges aligned to source token boundaries.
     pub fn slice<R: Ranged>(&self, ranged: R) -> &str {
         self.file.slice(ranged.range())
+    }
+
+    /// Returns the suppression index built during parsing.
+    pub fn suppression_map(&self) -> &SuppressionMap {
+        &self.suppression
     }
 
     pub fn text(&self) -> &str {

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -1,0 +1,99 @@
+//! Per-`Source` index of `# fmt: off` / `# fmt: on` / `# fmt: skip`
+//! suppressed spans (plus the `# yapf: disable` / `# yapf: enable`
+//! aliases). Built once during `Source` construction and consulted by
+//! `Pipeline::run` to drop edits whose ranges overlap any span.
+
+use ruff_python_trivia::{CommentLinePosition, CommentRanges, SuppressionKind};
+use ruff_source_file::LineRanges;
+use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
+
+/// Sorted, non-overlapping list of byte ranges where format-affecting
+/// rules must not emit edits. Range queries run in O(log n) over the
+/// list.
+#[derive(Debug)]
+pub struct SuppressionMap {
+    spans: Vec<TextRange>,
+}
+
+impl SuppressionMap {
+    /// Walks `comments` against `source_text`, classifying each comment
+    /// with `SuppressionKind` and folding the directive line offsets
+    /// into the suppressed-span list. An unmatched `# fmt: off`
+    /// extends through end of file. A stray `# fmt: on` is a no-op.
+    /// Two consecutive `# fmt: off` directives flatten, with the first
+    /// `# fmt: on` closing the block.
+    pub fn from_comments(source_text: &str, comments: &CommentRanges) -> Self {
+        let mut spans: Vec<TextRange> = Vec::new();
+        let mut open_off: Option<TextSize> = None;
+        for range in comments {
+            let comment = &source_text[range];
+            let Some(kind) = SuppressionKind::from_comment(comment) else {
+                continue;
+            };
+            let position = CommentLinePosition::for_range(range, source_text);
+            match kind {
+                SuppressionKind::Off if position.is_own_line() => {
+                    open_off.get_or_insert_with(|| source_text.line_start(range.start()));
+                }
+                SuppressionKind::On if position.is_own_line() => {
+                    spans.extend(
+                        open_off.take().map(|start| {
+                            TextRange::new(start, source_text.line_start(range.start()))
+                        }),
+                    );
+                }
+                SuppressionKind::Skip => {
+                    spans.push(source_text.full_line_range(range.start()));
+                }
+                _ => {}
+            }
+        }
+        spans.extend(open_off.map(|start| TextRange::new(start, source_text.text_len())));
+        Self {
+            spans: merge(spans),
+        }
+    }
+
+    /// Returns `true` when `ranged`'s span overlaps any suppressed
+    /// span by at least one byte. Empty ranges report overlap when
+    /// their offset strictly sits inside a span.
+    pub fn intersects<R: Ranged>(&self, ranged: R) -> bool {
+        let range = ranged.range();
+        self.spans.binary_search_by(|s| s.ordering(range)).is_ok()
+    }
+}
+
+fn merge(mut spans: Vec<TextRange>) -> Vec<TextRange> {
+    spans.sort_unstable_by_key(|s| s.start());
+    spans.dedup_by(|next, prev| {
+        let overlaps = next.start() <= prev.end();
+        if overlaps {
+            *prev = prev.cover(*next);
+        }
+        overlaps
+    });
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_support::{parse, range};
+
+    #[test]
+    fn empty_source_yields_empty_map() {
+        let source = parse("");
+        let map = source.suppression_map();
+        assert!(!map.intersects(range(0, 1)));
+        assert!(!map.intersects(range(0, 0)));
+    }
+
+    #[test]
+    fn intersects_catches_edit_that_fully_contains_a_span() {
+        let text = "# fmt: off\nx = 1\n# fmt: on\n";
+        let source = parse(text);
+        let map = source.suppression_map();
+        // Edit spanning the entire suppressed block (offsets 0..27)
+        // overlaps the span and must be dropped.
+        assert!(map.intersects(range(0, 27)));
+    }
+}

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -61,6 +61,11 @@ impl SuppressionMap {
         let range = ranged.range();
         self.spans.binary_search_by(|s| s.ordering(range)).is_ok()
     }
+
+    /// Returns `true` when the source carries no suppressed spans.
+    pub fn is_empty(&self) -> bool {
+        self.spans.is_empty()
+    }
 }
 
 fn merge(mut spans: Vec<TextRange>) -> Vec<TextRange> {

--- a/tests/fixtures/suppression/basic_block.input.py
+++ b/tests/fixtures/suppression/basic_block.input.py
@@ -1,0 +1,20 @@
+"""
+A fmt: off / fmt: on block sits between two assignment runs that
+the alignment rules would otherwise touch. The block survives
+verbatim while the runs above and below it pad to their group
+widths.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+much_longer_name = 2
+mid = 3
+# fmt: on
+
+a = 1
+bb = 2
+ccc = 3

--- a/tests/fixtures/suppression/idempotent.input.py
+++ b/tests/fixtures/suppression/idempotent.input.py
@@ -1,0 +1,20 @@
+"""
+Already-formatted source carrying every directive shape produces
+no further edits on a fresh pipeline run.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+much_longer_name = 2
+mid = 3
+# fmt: on
+
+skipped = 4  # fmt: skip
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/fixtures/suppression/multiple_blocks.input.py
+++ b/tests/fixtures/suppression/multiple_blocks.input.py
@@ -1,0 +1,27 @@
+"""
+Two distinct fmt: off / fmt: on blocks remain separate suppressed
+spans rather than fusing into one. Code outside the blocks aligns
+normally while code inside each block stays verbatim.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# fmt: off
+inside_one_alpha = 1
+inside_one_beta = 2
+# fmt: on
+
+a = 1
+bb = 2
+ccc = 3
+
+# fmt: off
+inside_two_alpha = 1
+inside_two_beta = 2
+# fmt: on
+
+ww = 1
+xxx = 2
+yyyy = 3

--- a/tests/fixtures/suppression/nested_flat.input.py
+++ b/tests/fixtures/suppression/nested_flat.input.py
@@ -1,0 +1,20 @@
+"""
+Two consecutive fmt: off directives flatten, with the first
+fmt: on closing the block. The second fmt: off does not nest, so
+text after the closing fmt: on aligns normally.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+# fmt: off
+much_longer_name = 2
+mid = 3
+# fmt: on
+
+a = 1
+bb = 2
+ccc = 3

--- a/tests/fixtures/suppression/rule_diversity.input.py
+++ b/tests/fixtures/suppression/rule_diversity.input.py
@@ -1,0 +1,12 @@
+"""
+The pipeline-level filter applies to every rule, not only
+alignment. A function call inside a fmt: off block keeps its
+trailing comma while a similar call outside the block has the
+comma stripped.
+"""
+
+# fmt: off
+inside(1, 2, 3,)
+# fmt: on
+
+outside(4, 5, 6,)

--- a/tests/fixtures/suppression/skip_inside_off_block.input.py
+++ b/tests/fixtures/suppression/skip_inside_off_block.input.py
@@ -1,0 +1,19 @@
+"""
+A fmt: skip line sits inside an active fmt: off block. Every line
+within the block stays verbatim, leaving the assignment runs above
+and below the block to align as separate groups.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+inside = 2  # fmt: skip
+mid = 3
+# fmt: on
+
+a = 1
+bb = 2
+ccc = 3

--- a/tests/fixtures/suppression/skip_line.input.py
+++ b/tests/fixtures/suppression/skip_line.input.py
@@ -1,0 +1,14 @@
+"""
+A trailing fmt: skip pins one line's original spacing. The other
+members of the same alignment group still pad to the group's
+target column, and the assignment run after the skip line aligns
+as a separate group.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+short = 4  # fmt: skip
+aa = 5
+bbb = 6
+cccc = 7

--- a/tests/fixtures/suppression/stray_on.input.py
+++ b/tests/fixtures/suppression/stray_on.input.py
@@ -1,0 +1,14 @@
+"""
+A bare fmt: on with no preceding fmt: off is a no-op. Every
+assignment in the file is eligible for alignment.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# fmt: on
+
+aa = 1
+bbb = 2
+cccc = 3

--- a/tests/fixtures/suppression/trailing_off_inside_block.input.py
+++ b/tests/fixtures/suppression/trailing_off_inside_block.input.py
@@ -1,0 +1,12 @@
+"""
+A trailing fmt: off comment is a normal end-of-line comment, not
+a block-opener. The line carrying it still receives its
+alignment edit, and code after it is not suppressed.
+"""
+
+x = 1
+foo = 2
+short = 3  # fmt: off
+aa = 4
+bbb = 5
+cccc = 6

--- a/tests/fixtures/suppression/unmatched_off.input.py
+++ b/tests/fixtures/suppression/unmatched_off.input.py
@@ -1,0 +1,14 @@
+"""
+An unmatched fmt: off suppresses through end of file. Assignments
+below it stay verbatim while the assignments above pad to their
+group width.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+much_longer_name = 2
+mid = 3

--- a/tests/fixtures/suppression/yapf_aliases.input.py
+++ b/tests/fixtures/suppression/yapf_aliases.input.py
@@ -1,0 +1,19 @@
+"""
+The yapf: disable / yapf: enable aliases produce the same
+suppressed span as fmt: off / fmt: on, leaving the bracketed
+assignments verbatim.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# yapf: disable
+short = 1
+much_longer_name = 2
+mid = 3
+# yapf: enable
+
+a = 1
+bb = 2
+ccc = 3

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,7 +13,7 @@ use ruff_python_formatter::{format_module_source, PyFormatOptions};
 
 fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
     match directory {
-        "composition" => Pipeline::with_defaults(config),
+        "composition" | "suppression" => Pipeline::with_defaults(config),
         "identity" => Pipeline::empty(),
         _ => Pipeline::for_rule(directory, config)
             .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),

--- a/tests/snapshots/suppression/basic_block.input.py.snap
+++ b/tests/snapshots/suppression/basic_block.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/basic_block.input.py
+---
+"""
+A fmt: off / fmt: on block sits between two assignment runs that
+the alignment rules would otherwise touch. The block survives
+verbatim while the runs above and below it pad to their group
+widths.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+much_longer_name = 2
+mid = 3
+# fmt: on
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/snapshots/suppression/idempotent.input.py.snap
+++ b/tests/snapshots/suppression/idempotent.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/idempotent.input.py
+---
+"""
+Already-formatted source carrying every directive shape produces
+no further edits on a fresh pipeline run.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+much_longer_name = 2
+mid = 3
+# fmt: on
+
+skipped = 4  # fmt: skip
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/snapshots/suppression/multiple_blocks.input.py.snap
+++ b/tests/snapshots/suppression/multiple_blocks.input.py.snap
@@ -1,0 +1,32 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/multiple_blocks.input.py
+---
+"""
+Two distinct fmt: off / fmt: on blocks remain separate suppressed
+spans rather than fusing into one. Code outside the blocks aligns
+normally while code inside each block stays verbatim.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: off
+inside_one_alpha = 1
+inside_one_beta = 2
+# fmt: on
+
+a   = 1
+bb  = 2
+ccc = 3
+
+# fmt: off
+inside_two_alpha = 1
+inside_two_beta = 2
+# fmt: on
+
+ww   = 1
+xxx  = 2
+yyyy = 3

--- a/tests/snapshots/suppression/nested_flat.input.py.snap
+++ b/tests/snapshots/suppression/nested_flat.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/nested_flat.input.py
+---
+"""
+Two consecutive fmt: off directives flatten, with the first
+fmt: on closing the block. The second fmt: off does not nest, so
+text after the closing fmt: on aligns normally.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+# fmt: off
+much_longer_name = 2
+mid = 3
+# fmt: on
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/snapshots/suppression/rule_diversity.input.py.snap
+++ b/tests/snapshots/suppression/rule_diversity.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/rule_diversity.input.py
+---
+"""
+The pipeline-level filter applies to every rule, not only
+alignment. A function call inside a fmt: off block keeps its
+trailing comma while a similar call outside the block has the
+comma stripped.
+"""
+
+# fmt: off
+inside(1, 2, 3,)
+# fmt: on
+
+outside(4, 5, 6)

--- a/tests/snapshots/suppression/skip_inside_off_block.input.py.snap
+++ b/tests/snapshots/suppression/skip_inside_off_block.input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/skip_inside_off_block.input.py
+---
+"""
+A fmt: skip line sits inside an active fmt: off block. Every line
+within the block stays verbatim, leaving the assignment runs above
+and below the block to align as separate groups.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+inside = 2  # fmt: skip
+mid = 3
+# fmt: on
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/snapshots/suppression/skip_line.input.py.snap
+++ b/tests/snapshots/suppression/skip_line.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/skip_line.input.py
+---
+"""
+A trailing fmt: skip pins one line's original spacing. The other
+members of the same alignment group still pad to the group's
+target column, and the assignment run after the skip line aligns
+as a separate group.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+short = 4  # fmt: skip
+aa   = 5
+bbb  = 6
+cccc = 7

--- a/tests/snapshots/suppression/stray_on.input.py.snap
+++ b/tests/snapshots/suppression/stray_on.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/stray_on.input.py
+---
+"""
+A bare fmt: on with no preceding fmt: off is a no-op. Every
+assignment in the file is eligible for alignment.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: on
+
+aa   = 1
+bbb  = 2
+cccc = 3

--- a/tests/snapshots/suppression/trailing_off_inside_block.input.py.snap
+++ b/tests/snapshots/suppression/trailing_off_inside_block.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/trailing_off_inside_block.input.py
+---
+"""
+A trailing fmt: off comment is a normal end-of-line comment, not
+a block-opener. The line carrying it still receives its
+alignment edit, and code after it is not suppressed.
+"""
+
+x     = 1
+foo   = 2
+short = 3  # fmt: off
+aa   = 4
+bbb  = 5
+cccc = 6

--- a/tests/snapshots/suppression/unmatched_off.input.py.snap
+++ b/tests/snapshots/suppression/unmatched_off.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/unmatched_off.input.py
+---
+"""
+An unmatched fmt: off suppresses through end of file. Assignments
+below it stay verbatim while the assignments above pad to their
+group width.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# fmt: off
+short = 1
+much_longer_name = 2
+mid = 3

--- a/tests/snapshots/suppression/yapf_aliases.input.py.snap
+++ b/tests/snapshots/suppression/yapf_aliases.input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/yapf_aliases.input.py
+---
+"""
+The yapf: disable / yapf: enable aliases produce the same
+suppressed span as fmt: off / fmt: on, leaving the bracketed
+assignments verbatim.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# yapf: disable
+short = 1
+much_longer_name = 2
+mid = 3
+# yapf: enable
+
+a   = 1
+bb  = 2
+ccc = 3


### PR DESCRIPTION
### 🪻 Quick Summary

Honors the `# fmt: off` / `# fmt: on` / `# fmt: skip` directives that [Black](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#ignoring-sections) established and [Ruff](https://docs.astral.sh/ruff/formatter/#format-suppression) inherited, by indexing every directive in the source into a `SuppressionMap` during `Source` construction and dropping any rule's `Edit` whose range overlaps a suppressed span before the splice. The classification lives entirely in `ruff_python_trivia::SuppressionKind`, so the `# yapf: disable` / `# yapf: enable` aliases come along for free, and rules stay suppression-unaware because the filter sits in `Pipeline::run` rather than inside any individual rule.

---

### 🗞️ Key Changes

- Adds `src/suppression.rs` housing `SuppressionMap`, a sorted `Vec<TextRange>` queried via `TextRange::ordering` for O(log n) overlap checks

- Builds the map during `Source` construction by walking `CommentRanges` through `ruff_python_trivia::SuppressionKind` and `CommentLinePosition`, with `# yapf: disable` / `# yapf: enable` honored via `SuppressionKind::from_comment`'s built-in classification

- Filters every `Edit` whose range overlaps a suppressed span out of `Pipeline::run` before reparse, leaving rules suppression-unaware

- Gates the per-edit `retain` walk on `SuppressionMap::is_empty()` so suppression-free inputs skip the filter loop entirely

- Adds eleven fixture cases under `tests/fixtures/suppression/` covering each directive shape, the unmatched-off / stray-on / nested-flat / multiple-blocks edge cases, and pipeline-wide rule diversity

---

### 🧵 Related Issues

- Closes #55