### PR TITLE
[60] Add the `docstring_line_length` config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ config = {
 
 ```toml
 [tool.prose]
-line-length = 88
+code-line-length = 88
 
 [tool.prose.rules.align-equals]
 enabled = false                # disable a rule outright
@@ -194,7 +194,11 @@ Per-rule knobs:
 | `max-shift` | positive int | alignment rules | Ceiling on per-line padding, defaulting to `8` |
 | `max-shift-policy` | `"split"` \| `"drop"` \| `"skip"` | alignment rules | How to handle a group whose widest member exceeds `max-shift`. `split` partitions the group, `drop` excludes the widest members from the padding calculation, `skip` leaves the whole group unaligned, defaulting to `"split"` |
 | `max-atomics-per-line` | positive int | `collection-layout` | Keep short collections on one line when each entry is an atomic literal and the run fits the cap, defaulting to `8` |
-| `line-length` | positive int | top-level `[tool.prose]` | Honored by line-length-aware rules, defaulting to `88` |
+| `code-line-length` | positive int | top-level `[tool.prose]` | Honored by line-length-aware rules, defaulting to `88` |
+| `docstring-line-length` | positive int | top-level `[tool.prose]` | Description-prose budget for `docstring-wrap`, defaulting to `76` |
+| `docstring-structured-policy` | `"code-line-length"` \| `"docstring-line-length"` | top-level `[tool.prose]` | Source budget for structured docstring sections, defaulting to `"code-line-length"` |
+
+Docstrings carry two readings inside one triple-quoted region. Description prose between the opening `"""` and the first section heading reads as paragraphs, where 76 characters is the comfortable line for sustained reading. Structured sections (*`Args:`, `Returns:`, `Raises:`*) read as code-shaped tables and reuse `code-line-length` (*88 by default*) to match surrounding indentation, though `docstring-structured-policy` switches them to `docstring-line-length` if a project prefers a single narrower budget across the whole docstring. The `docstring-wrap` rule will consume both budgets when it lands later in `0.2`.
 
 **Alignment rules** are `align-colons`, `align-equals`, `align-imports`, and `match-case-align`. **Toggle-only rules** are `alphabetize`, `singleton-rule`, and `strip-trailing-commas`.
 

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -56,7 +56,7 @@ pub(crate) fn format_with_io<R: Read, W: Write>(
         return format_stdin(stdin, args.diff, args.output_format, &pipeline, &mut stdout);
     }
     if args.diff {
-        format_paths_diff(&args.paths, args.output_format, &pipeline, &mut stdout)
+        format_paths_diff(&args.paths, &pipeline, &mut stdout)
     } else {
         format_paths_rewrite(&args.paths, args.output_format, &pipeline, &mut stdout)
     }
@@ -99,7 +99,6 @@ fn emit_outcomes<W: Write>(
 
 fn format_paths_diff<W: Write>(
     paths: &[PathBuf],
-    format: OutputFormat,
     pipeline: &Pipeline,
     stdout: &mut W,
 ) -> anyhow::Result<ExitStatus> {
@@ -128,9 +127,6 @@ fn format_paths_diff<W: Write>(
             Ok(outcome)
         })
         .collect::<anyhow::Result<_>>()?;
-    if !format.is_text() {
-        emit_outcomes(&outcomes, format, stdout)?;
-    }
     Ok(status_from_outcomes(&outcomes, false))
 }
 
@@ -492,6 +488,37 @@ mod tests {
     }
 
     #[test]
+    fn format_diff_returns_clean_for_already_canonical_file() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "x = 1\n").expect("writes");
+
+        let status = format_with_io(
+            format_args(vec![tmp.path().to_path_buf()], false, true),
+            io::empty(),
+            Vec::<u8>::new(),
+        )
+        .expect("runs successfully");
+
+        assert_eq!(status, ExitStatus::Clean);
+    }
+
+    #[test]
+    fn format_diff_returns_config_error_for_missing_path() {
+        let tmp = TempDir::new().expect("tempdir");
+        let missing = tmp.path().join("does_not_exist");
+
+        let status = format_with_io(
+            format_args(vec![missing], false, true),
+            io::empty(),
+            Vec::<u8>::new(),
+        )
+        .expect("runs without anyhow");
+
+        assert_eq!(status, ExitStatus::ConfigError);
+    }
+
+    #[test]
     fn format_diff_returns_format_change_for_pending_change() {
         let tmp = TempDir::new().expect("tempdir");
         let file = tmp.path().join("a.py");
@@ -616,6 +643,25 @@ mod tests {
         assert_eq!(status, ExitStatus::Clean);
         let after = std::fs::read_to_string(&file).expect("reads");
         assert_ne!(after, "alpha = 1\nb = 22\n");
+    }
+
+    #[test]
+    fn format_writes_return_config_error_when_target_is_readonly() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+        let mut perms = std::fs::metadata(&file).expect("metadata").permissions();
+        perms.set_readonly(true);
+        std::fs::set_permissions(&file, perms).expect("set_permissions");
+
+        let status = format_with_io(
+            format_args(vec![tmp.path().to_path_buf()], false, false),
+            io::empty(),
+            Vec::<u8>::new(),
+        )
+        .expect("runs successfully");
+
+        assert_eq!(status, ExitStatus::ConfigError);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,23 +46,36 @@ impl Default for CollectionLayoutConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            max_atomics_per_line: None,
+            max_atomics_per_line: NonZeroUsize::new(8),
         }
     }
 }
 
 /// The `[tool.prose]` section of a user's `pyproject.toml`.
 ///
-/// `None` on `line_length` means the user did not set that key in
-/// their `pyproject.toml`. Downstream consumers apply their own
-/// fallback rather than reading a synthesized default here. Per-rule
-/// settings live under `rules`, where each rule's sub-table carries
-/// `enabled` plus that rule's own knobs.
-#[derive(Debug, Default, Deserialize)]
+/// `code_line_length` defaults to `Some(88)`. `docstring_line_length`
+/// defaults to `Some(76)`. `docstring_structured_policy` defaults
+/// to `CodeLineLength`. Per-rule settings live under `rules`, where
+/// each rule's sub-table carries `enabled` plus that rule's own
+/// knobs.
+#[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
-    pub line_length: Option<NonZeroUsize>,
+    pub code_line_length: Option<NonZeroUsize>,
+    pub docstring_line_length: Option<NonZeroUsize>,
+    pub docstring_structured_policy: DocstringStructuredPolicy,
     pub rules: RuleConfigs,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            code_line_length: NonZeroUsize::new(88),
+            docstring_line_length: NonZeroUsize::new(76),
+            docstring_structured_policy: DocstringStructuredPolicy::default(),
+            rules: RuleConfigs::default(),
+        }
+    }
 }
 
 impl Config {
@@ -103,20 +116,16 @@ impl Config {
         P: AsRef<Path>,
         F: FnMut(&str),
     {
-        for dir in from.as_ref().ancestors() {
-            let candidate = dir.join("pyproject.toml");
-            match fs_err::read_to_string(&candidate) {
-                Ok(contents) => {
-                    if let Some(config) = parse_prose_section(&contents, &mut on_unknown)? {
-                        return Ok(config);
-                    }
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => return Err(e.into()),
-            }
-        }
-
-        Ok(Self::default())
+        from.as_ref()
+            .ancestors()
+            .find_map(
+                |dir| match fs_err::read_to_string(dir.join("pyproject.toml")) {
+                    Ok(contents) => parse_prose_section(&contents, &mut on_unknown).transpose(),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(e) => Some(Err(e.into())),
+                },
+            )
+            .unwrap_or_else(|| Ok(Self::default()))
     }
 }
 
@@ -127,6 +136,18 @@ pub enum ConfigError {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     Toml(#[from] toml::de::Error),
+}
+
+/// Which budget structured docstring sections wrap to.
+///
+/// `CodeLineLength` reuses `Config::code_line_length`.
+/// `DocstringLineLength` reuses `Config::docstring_line_length`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DocstringStructuredPolicy {
+    #[default]
+    CodeLineLength,
+    DocstringLineLength,
 }
 
 /// What to do when an alignment group's widest padding exceeds the
@@ -187,17 +208,78 @@ mod tests {
 
     use super::*;
 
+    fn assert_toml_error(toml: &str) {
+        assert!(matches!(
+            Config::from_pyproject_str(toml),
+            Err(ConfigError::Toml(_))
+        ));
+    }
+
     fn write_pyproject(dir: &Path, contents: &str) {
         std::fs::write(dir.join("pyproject.toml"), contents).expect("pyproject writes");
     }
 
     #[test]
-    fn from_pyproject_str_with_unknown_key_warns_and_returns_config() {
-        let config =
-            Config::from_pyproject_str("[tool.prose]\nline-length = 100\nunknown-future-key = 1\n")
-                .expect("parses");
+    fn docstring_line_length_defaults_to_76_when_field_absent() {
+        let config = Config::from_pyproject_str("[tool.prose]\n").expect("parses");
 
-        assert_eq!(config.line_length, NonZeroUsize::new(100));
+        assert_eq!(config.docstring_line_length, NonZeroUsize::new(76));
+    }
+
+    #[test]
+    fn docstring_line_length_explicit_override_takes_effect() {
+        let config = Config::from_pyproject_str("[tool.prose]\ndocstring-line-length = 100\n")
+            .expect("parses");
+
+        assert_eq!(config.docstring_line_length, NonZeroUsize::new(100));
+    }
+
+    #[test]
+    fn docstring_line_length_negative_returns_toml_error() {
+        assert_toml_error("[tool.prose]\ndocstring-line-length = -1\n");
+    }
+
+    #[test]
+    fn docstring_line_length_zero_returns_toml_error() {
+        assert_toml_error("[tool.prose]\ndocstring-line-length = 0\n");
+    }
+
+    #[test]
+    fn docstring_structured_policy_defaults_to_code_line_length_when_field_absent() {
+        let config = Config::from_pyproject_str("[tool.prose]\n").expect("parses");
+
+        assert_eq!(
+            config.docstring_structured_policy,
+            DocstringStructuredPolicy::CodeLineLength
+        );
+    }
+
+    #[test]
+    fn docstring_structured_policy_explicit_override_to_docstring_line_length() {
+        let config = Config::from_pyproject_str(
+            "[tool.prose]\ndocstring-structured-policy = \"docstring-line-length\"\n",
+        )
+        .expect("parses");
+
+        assert_eq!(
+            config.docstring_structured_policy,
+            DocstringStructuredPolicy::DocstringLineLength
+        );
+    }
+
+    #[test]
+    fn docstring_structured_policy_invalid_value_returns_toml_error() {
+        assert_toml_error("[tool.prose]\ndocstring-structured-policy = \"nonsense\"\n");
+    }
+
+    #[test]
+    fn from_pyproject_str_with_unknown_key_warns_and_returns_config() {
+        let config = Config::from_pyproject_str(
+            "[tool.prose]\ncode-line-length = 100\nunknown-future-key = 1\n",
+        )
+        .expect("parses");
+
+        assert_eq!(config.code_line_length, NonZeroUsize::new(100));
     }
 
     #[test]
@@ -205,7 +287,7 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let config = Config::load(tmp.path()).expect("loads");
 
-        assert_eq!(config.line_length, None);
+        assert_eq!(config.code_line_length, NonZeroUsize::new(88));
         assert!(config.rules.align_equals.enabled);
     }
 
@@ -216,7 +298,7 @@ mod tests {
 
         let config = Config::load(tmp.path()).expect("loads");
 
-        assert_eq!(config.line_length, None);
+        assert_eq!(config.code_line_length, NonZeroUsize::new(88));
         assert!(config.rules.align_equals.enabled);
     }
 
@@ -277,12 +359,12 @@ mod tests {
         let nested = tmp.path().join("a/b");
         std::fs::create_dir_all(&nested).expect("nested dirs create");
 
-        write_pyproject(tmp.path(), "[tool.prose]\nline-length = 80\n");
-        write_pyproject(&nested, "[tool.prose]\nline-length = 120\n");
+        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+        write_pyproject(&nested, "[tool.prose]\ncode-line-length = 120\n");
 
         let config = Config::load(&nested).expect("loads");
 
-        assert_eq!(config.line_length, NonZeroUsize::new(120));
+        assert_eq!(config.code_line_length, NonZeroUsize::new(120));
     }
 
     #[test]
@@ -316,10 +398,10 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let nested = tmp.path().join("a/b/c");
         std::fs::create_dir_all(&nested).expect("nested dirs create");
-        write_pyproject(tmp.path(), "[tool.prose]\nline-length = 120\n");
+        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 120\n");
 
         let config = Config::load(&nested).expect("loads");
 
-        assert_eq!(config.line_length, NonZeroUsize::new(120));
+        assert_eq!(config.code_line_length, NonZeroUsize::new(120));
     }
 }

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -1,10 +1,9 @@
 //! Expands multi-item `dict`, `list`, and `set` literals when the
-//! inline form would overflow `Config::line_length`. Comprehensions,
-//! tuple literals, and any literal whose source range contains a
-//! comment are out of scope.
+//! inline form would overflow `Config::code_line_length`.
+//! Comprehensions, tuple literals, and any literal whose source range
+//! contains a comment are out of scope.
 
 use std::borrow::Cow;
-use std::num::NonZeroUsize;
 use std::ops::Range;
 
 use ruff_diagnostics::Edit;
@@ -20,26 +19,26 @@ use crate::primitives::edit::narrowed_replacement;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
-const DEFAULT_LINE_LENGTH: usize = 88;
-const DEFAULT_MAX_ATOMICS_PER_LINE: usize = 8;
 const INDENT_STEP: usize = 4;
 
 pub(crate) struct CollectionLayout {
-    line_length: usize,
+    code_line_length: usize,
     max_atomics_per_line: usize,
 }
 
 impl CollectionLayout {
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
-            line_length: config
-                .line_length
-                .map_or(DEFAULT_LINE_LENGTH, NonZeroUsize::get),
+            code_line_length: config
+                .code_line_length
+                .expect("Config::default synthesizes Some(88)")
+                .get(),
             max_atomics_per_line: config
                 .rules
                 .collection_layout
                 .max_atomics_per_line
-                .map_or(DEFAULT_MAX_ATOMICS_PER_LINE, NonZeroUsize::get),
+                .expect("CollectionLayoutConfig::default synthesizes Some(8)")
+                .get(),
         }
     }
 }
@@ -47,8 +46,8 @@ impl CollectionLayout {
 impl Rule for CollectionLayout {
     fn apply(&self, source: &Source) -> Vec<Edit> {
         let mut visitor = Expander {
+            code_line_length: self.code_line_length,
             edits: Vec::new(),
-            line_length: self.line_length,
             max_atomics_per_line: self.max_atomics_per_line,
             newline: source.newline_str(),
             source,
@@ -63,8 +62,8 @@ impl Rule for CollectionLayout {
 }
 
 struct Expander<'a> {
+    code_line_length: usize,
     edits: Vec<Edit>,
-    line_length: usize,
     max_atomics_per_line: usize,
     newline: &'static str,
     source: &'a Source,
@@ -84,7 +83,7 @@ impl<'a> Expander<'a> {
         } = self.gather_items(expr, item_indent);
         let total = texts.len();
         let item_prefix = " ".repeat(item_indent);
-        let available = self.line_length.saturating_sub(item_indent);
+        let available = self.code_line_length.saturating_sub(item_indent);
         let mut out = String::new();
         out.push(open);
         out.push_str(self.newline);
@@ -107,14 +106,12 @@ impl<'a> Expander<'a> {
                 }
                 Segment::Flow(range) => {
                     let run_start = range.start;
-                    let widths: Vec<usize> = range.map(|i| texts[i].width()).collect();
+                    let widths: Vec<usize> = texts[range].iter().map(|c| c.width()).collect();
                     for line_range in flow_lines(&widths, available, self.max_atomics_per_line) {
                         let line_start = run_start + line_range.start;
                         let line_end = run_start + line_range.end;
-                        let parts: Vec<&str> =
-                            (line_start..line_end).map(|i| texts[i].as_ref()).collect();
                         out.push_str(&item_prefix);
-                        out.push_str(&parts.join(", "));
+                        out.push_str(&texts[line_start..line_end].join(", "));
                         if line_end < total {
                             out.push(',');
                         }
@@ -123,7 +120,7 @@ impl<'a> Expander<'a> {
                 }
             }
         }
-        out.push_str(&" ".repeat(indent));
+        out.extend(std::iter::repeat_n(' ', indent));
         out.push(close);
         out
     }
@@ -138,12 +135,17 @@ impl<'a> Expander<'a> {
     fn gather_items(&self, expr: &Expr, indent: usize) -> GatheredItems<'a> {
         let parent = AnyNodeRef::from(expr);
         if let Expr::Dict(d) = expr {
-            let (texts, ranges): (Vec<Cow<'a, str>>, Vec<TextRange>) = d
+            let (texts, (atomics, ranges)): (Vec<_>, (Vec<_>, Vec<_>)) = d
                 .iter()
-                .map(|item| (self.serialize_dict_item(item, parent, indent), item.range()))
+                .map(|item| {
+                    (
+                        self.serialize_dict_item(item, parent, indent),
+                        (false, item.range()),
+                    )
+                })
                 .unzip();
             return GatheredItems {
-                atomics: vec![false; d.len()],
+                atomics,
                 close: '}',
                 open: '{',
                 ranges,
@@ -155,14 +157,15 @@ impl<'a> Expander<'a> {
             Expr::Set(s) => ('{', '}', &s.elts),
             _ => unreachable!("gather_items called on non-collection expr"),
         };
-        let mut texts = Vec::with_capacity(elts.len());
-        let mut atomics = Vec::with_capacity(elts.len());
-        let mut ranges = Vec::with_capacity(elts.len());
-        for e in elts {
-            texts.push(self.serialize_expr(e, parent, indent, indent));
-            atomics.push(is_atomic(e));
-            ranges.push(e.range());
-        }
+        let (texts, (atomics, ranges)): (Vec<_>, (Vec<_>, Vec<_>)) = elts
+            .iter()
+            .map(|e| {
+                (
+                    self.serialize_expr(e, parent, indent, indent),
+                    (is_atomic(e), e.range()),
+                )
+            })
+            .unzip();
         GatheredItems {
             atomics,
             close,
@@ -176,7 +179,7 @@ impl<'a> Expander<'a> {
     ///
     /// `indent` is the column where the item sits (the item-indent of
     /// the enclosing dict). The value's actual column for the
-    /// line-length check is offset by the key text plus `": "`, so a
+    /// `code-line-length` check is offset by the key text plus `": "`, so a
     /// long key that pushes its value past the budget correctly
     /// triggers expansion of the value. When the value does expand,
     /// its closing bracket still lands at `indent`. When the value
@@ -199,10 +202,9 @@ impl<'a> Expander<'a> {
             let aligned = is_align_colons_gap(gap);
             if aligned && matches!(value_text, Cow::Borrowed(_)) {
                 Cow::Borrowed(self.source.slice(item))
-            } else if aligned {
-                Cow::Owned(format!("{key_text}{gap}{value_text}"))
             } else {
-                Cow::Owned(format!("{key_text}: {value_text}"))
+                let separator = if aligned { gap } else { ": " };
+                Cow::Owned(format!("{key_text}{separator}{value_text}"))
             }
         } else {
             let value_text = self.serialize_expr(&item.value, parent, indent + 2, indent);
@@ -216,7 +218,7 @@ impl<'a> Expander<'a> {
     /// `expr` itself expands.
     ///
     /// `column` is where the expression actually begins on its line
-    /// (used for the line-length overflow check). `indent` is where
+    /// (used for the `code-line-length` overflow check). `indent` is where
     /// its closing bracket should land if it expands. They differ for
     /// dict values, where the key text sits between the line indent
     /// and the value's own starting column. `parent` is the immediate
@@ -238,9 +240,10 @@ impl<'a> Expander<'a> {
     }
 
     /// Returns `true` when `expr` is a qualifying collection whose
-    /// inline form would overflow the line-length budget at `column`.
+    /// inline form would overflow the `code-line-length` budget at `column`.
     /// Multi-line input always returns `true`. Single-line input
-    /// returns `true` only when `column + inline_length > line_length`.
+    /// returns `true` only when `column + inline_length >
+    /// code_line_length`.
     fn should_expand(&self, expr: &Expr, column: usize) -> bool {
         let multi_item = match expr {
             Expr::Dict(d) => d.len() > 1,
@@ -252,7 +255,7 @@ impl<'a> Expander<'a> {
         multi_item
             && !self.source.intersects_comment(range)
             && (self.source.contains_line_break(range)
-                || column + self.source.slice(range).width() > self.line_length)
+                || column + self.source.slice(range).width() > self.code_line_length)
     }
 }
 
@@ -300,13 +303,12 @@ fn flow_lines(widths: &[usize], available: usize, max_atomics: usize) -> Vec<Ran
         return Vec::new();
     }
     let n = widths.len();
-    let mut prefix = Vec::with_capacity(n + 1);
-    let mut sum = 0usize;
-    prefix.push(sum);
-    for &w in widths {
-        sum += w;
-        prefix.push(sum);
-    }
+    let prefix: Vec<usize> = std::iter::once(0)
+        .chain(widths.iter().scan(0usize, |sum, &w| {
+            *sum += w;
+            Some(*sum)
+        }))
+        .collect();
     let total_slot = prefix[n] + 2 * n.saturating_sub(1);
     let by_width = total_slot.div_ceil(available.max(1));
     let by_cap = n.div_ceil(max_atomics.max(1));
@@ -329,11 +331,10 @@ fn is_align_colons_gap(gap: &str) -> bool {
 /// expressions are non-atomic so a spread splits surrounding atomics
 /// into independent runs.
 fn is_atomic(expr: &Expr) -> bool {
-    expr.is_literal_expr()
-        || is_dotted_name(expr)
-        || expr
-            .as_unary_op_expr()
-            .is_some_and(|u| is_atomic(&u.operand))
+    std::iter::successors(Some(expr), |e| {
+        e.as_unary_op_expr().map(|u| u.operand.as_ref())
+    })
+    .any(|e| e.is_literal_expr() || is_dotted_name(e))
 }
 
 /// Partitions `atomics` into segments. Every contiguous run of
@@ -341,17 +342,16 @@ fn is_atomic(expr: &Expr) -> bool {
 /// becomes a singleton `OnePerLine` segment. Non-atomic items always
 /// break atomic runs.
 fn segments(atomics: &[bool]) -> Vec<Segment> {
-    let mut start = 0;
     atomics
         .chunk_by(|a, b| a == b)
-        .map(|chunk| {
-            let range = start..start + chunk.len();
-            start += chunk.len();
-            if chunk[0] {
+        .scan(0, |start, chunk| {
+            let range = *start..*start + chunk.len();
+            *start += chunk.len();
+            Some(if chunk[0] {
                 Segment::Flow(range)
             } else {
                 Segment::OnePerLine(range)
-            }
+            })
         })
         .collect()
 }

--- a/tests/fixtures/collection_layout/list_literal.input.py
+++ b/tests/fixtures/collection_layout/list_literal.input.py
@@ -2,7 +2,7 @@
 A multi-item list literal stays inline when the whole line fits in
 the 88-character budget. A list whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
-across as few balanced lines as fit under the line-length budget and
+across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
 """
 

--- a/tests/fixtures/collection_layout/nested.input.py
+++ b/tests/fixtures/collection_layout/nested.input.py
@@ -3,7 +3,7 @@ Nested collections expand independently. A qualifying child serializes
 through the parent's `expand` when the parent also qualifies. A
 qualifying child inside a non-qualifying parent expands via `walk_expr`
 falling through into the parent's descendants. Each child's
-line-length check uses its own column, including the key-offset for
+`code-line-length` check uses its own column, including the key-offset for
 dict values, so tiered structures expand level-by-level only where
 the inline form would overflow.
 """

--- a/tests/fixtures/collection_layout/set_literal.input.py
+++ b/tests/fixtures/collection_layout/set_literal.input.py
@@ -2,7 +2,7 @@
 A multi-item set literal stays inline when the whole line fits in
 the 88-character budget. A set whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
-across as few balanced lines as fit under the line-length budget and
+across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
 """
 

--- a/tests/fixtures/collection_layout/single_item.input.py
+++ b/tests/fixtures/collection_layout/single_item.input.py
@@ -2,7 +2,7 @@
 Single-item and empty literals keep their original inline form
 regardless of line length. `item_count` returns `Some(0)` or
 `Some(1)` for these cases, both of which short-circuit
-`should_expand` ahead of the line-length check.
+`should_expand` ahead of the `code-line-length` check.
 """
 
 only_list  = [42]

--- a/tests/fixtures/composition/expanded_collection.input.py
+++ b/tests/fixtures/composition/expanded_collection.input.py
@@ -1,6 +1,6 @@
 """
 Long dict literal that fits on one line in source but overflows the
-line-length budget once expanded. collection_layout puts each entry on
+`code-line-length` budget once expanded. collection_layout puts each entry on
 its own line and recursively expands the long nested dict, alphabetize
 partitions single-line entries before the multi-line entry and sorts
 within each partition, align_colons aligns the colons across the

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -1,5 +1,7 @@
 [tool.prose]
-line-length = 100
+code-line-length = 100
+docstring-line-length = 60
+docstring-structured-policy = "docstring-line-length"
 
 [tool.prose.rules.align-colons]
 enabled = false
@@ -15,6 +17,7 @@ enabled = false
 
 [tool.prose.rules.collection-layout]
 enabled = false
+max-atomics-per-line = 3
 
 [tool.prose.rules.match-case-align]
 enabled = false

--- a/tests/snapshots/collection_layout/list_literal.input.py.snap
+++ b/tests/snapshots/collection_layout/list_literal.input.py.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/list_literal.input.py
 ---
 """
 A multi-item list literal stays inline when the whole line fits in
 the 88-character budget. A list whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
-across as few balanced lines as fit under the line-length budget and
+across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
 """
 

--- a/tests/snapshots/collection_layout/nested.input.py.snap
+++ b/tests/snapshots/collection_layout/nested.input.py.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/nested.input.py
 ---
 """
@@ -8,7 +8,7 @@ Nested collections expand independently. A qualifying child serializes
 through the parent's `expand` when the parent also qualifies. A
 qualifying child inside a non-qualifying parent expands via `walk_expr`
 falling through into the parent's descendants. Each child's
-line-length check uses its own column, including the key-offset for
+`code-line-length` check uses its own column, including the key-offset for
 dict values, so tiered structures expand level-by-level only where
 the inline form would overflow.
 """

--- a/tests/snapshots/collection_layout/set_literal.input.py.snap
+++ b/tests/snapshots/collection_layout/set_literal.input.py.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/set_literal.input.py
 ---
 """
 A multi-item set literal stays inline when the whole line fits in
 the 88-character budget. A set whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
-across as few balanced lines as fit under the line-length budget and
+across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
 """
 

--- a/tests/snapshots/collection_layout/single_item.input.py.snap
+++ b/tests/snapshots/collection_layout/single_item.input.py.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/single_item.input.py
 ---
 """
 Single-item and empty literals keep their original inline form
 regardless of line length. `item_count` returns `Some(0)` or
 `Some(1)` for these cases, both of which short-circuit
-`should_expand` ahead of the line-length check.
+`should_expand` ahead of the `code-line-length` check.
 """
 
 only_list  = [42]

--- a/tests/snapshots/composition/expanded_collection.input.py.snap
+++ b/tests/snapshots/composition/expanded_collection.input.py.snap
@@ -1,11 +1,11 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/composition/expanded_collection.input.py
 ---
 """
 Long dict literal that fits on one line in source but overflows the
-line-length budget once expanded. collection_layout puts each entry on
+`code-line-length` budget once expanded. collection_layout puts each entry on
 its own line and recursively expands the long nested dict, alphabetize
 partitions single-line entries before the multi-line entry and sorts
 within each partition, align_colons aligns the colons across the

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -4,13 +4,19 @@ expression: config
 input_file: tests/fixtures/config/full_override.toml
 ---
 Config {
-    line_length: Some(
+    code_line_length: Some(
         100,
     ),
+    docstring_line_length: Some(
+        60,
+    ),
+    docstring_structured_policy: DocstringLineLength,
     rules: RuleConfigs {
         collection_layout: CollectionLayoutConfig {
             enabled: false,
-            max_atomics_per_line: None,
+            max_atomics_per_line: Some(
+                3,
+            ),
         },
         alphabetize: ToggleOnly {
             enabled: false,


### PR DESCRIPTION
### 🪻 Quick Summary

Adds `docstring_line_length` to `Config` with a `Some(76)` default and the [kebab-case](https://serde.rs/container-attrs.html#rename_all) `docstring-line-length` key, plus the documentation that frames the docstring two-budget split, so the `docstring-wrap` rule landing in #66 has a stable shape to consume.

`Config` also gains `docstring-structured-policy`, a `"code-line-length"` | `"docstring-line-length"` enum that picks which budget wraps the structured docstring sections (*`Args:`, `Returns:`, `Raises:`*), defaulting to `"code-line-length"`. The existing top-level `line-length` key renames to `code-line-length` for symmetric pairing, and `Config::code_line_length` and `Config::max_atomics_per_line` both pick up synthesized `Some(N)` defaults so the consumer in `src/rules/collection_layout.rs` drops two fallback constants in favour of `.expect(...).get()` against the `Option` fields directly.

The same branch tightens the `collection_layout` consumer with stdlib primitives sitting one composition away:

- `iter::successors` over the unary-op chain
- `Iterator::scan` over `<[T]>::chunk_by`
- `iter::repeat_n` for indent padding
- `[S]::join` directly on the `Cow<'_, str>` slice
- `find_map` for the pyproject ancestor walk
- nested-tuple `unzip` for parallel-vec construction
- a two-arm dict-item branch with a `separator` binding

---

### 🗞️ Key Changes

- Adds `docstring_line_length: Option<NonZeroUsize>` (*kebab-case `docstring-line-length`, default `Some(76)`*), pinning the description-prose budget ahead of `docstring-wrap` in #66

- Adds `DocstringStructuredPolicy` to let Args / Returns / Raises opt into the docstring budget, defaulting to `CodeLineLength` so structured sections track the surrounding code budget out of the box

- Renames `line-length` to `code-line-length` for symmetric pairing with `docstring-line-length`, so the two top-level budgets read as a deliberate pair

- Synthesizes `Some(88)` for `code-line-length` and `Some(8)` for `max-atomics-per-line`, letting `collection_layout` drop two fallback constants in favour of `.expect(...).get()`

- Rewrites `Config::load_with_warnings` over `Path::ancestors` with `find_map` and `Option::transpose`, swapping a manual walk-upward loop for the stdlib iterator primitive

- Swaps hand-rolled traversals in `is_atomic`, `segments`, and `flow_lines` for their `iter::successors` and `Iterator::scan` equivalents, matching the prior patterns' shape

- Drops two intermediate allocations in `expand` via `iter::repeat_n` for indent padding and `[S]::join` directly on the `Cow` slice

- Unzips `gather_items`'s three parallel push-loops via nested-tuple `unzip` over stdlib's `Extend<(A, B)>` blanket impl, with the dict arm folding `vec![false; n]` into the inner tuple

- Folds `serialize_dict_item`'s three-arm cascade into two arms via a `separator` binding

---

### ☕ Implementation Notes

Scope expansions beyond the spec (*`docstring-structured-policy` as a third knob, `line-length` → `code-line-length` rename, synthesized `Some(N)` defaults for the two existing `Option` fields*) live in [this issue comment](https://github.com/Jybbs/prose/issues/60#issuecomment-4416586709).

The `docstring-structured-policy` knob and the `docstring-line-length` budget are declarative for now. The consumer arrives with `docstring-wrap` in #66.

---

### 🧵 Related Issues

- Closes #60