### PR TITLE
[61] Implement `blank-lines` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ***Prose*** formats Python source to be *legible at a glance*. It aligns equals signs and colons vertically across consecutive lines, places one entry per line in dictionaries and lists, alphabetizes methods and fields within their groups, applies a singleton rule for colon padding, and treats code like prose rather than minified text.
 
 > [!NOTE]
-> ***Prose*** is currently in alpha, meaning the **eight** [auto-fix rules](#rules) below ship in `0.1.x`. The `0.2` cycle expands the surface around them (*structured output formats, suppression directives, rule subsetting, an exit-code matrix*) and brings additional auto-fix and lint-only rules online.
+> ***Prose*** is currently in alpha, meaning the **eight** [auto-fix rules](#-rules) below ship in `0.1.x`. The `0.2` cycle expands the surface around them (*structured output formats, suppression directives, rule subsetting, an exit-code matrix*) and brings additional auto-fix and lint-only rules online.
 
 ---
 
@@ -96,6 +96,7 @@ When two outcomes apply to the same run, the higher number wins. `prose --help` 
 | `align-equals` | Consecutive assignments at the same indentation |
 | `align-imports` | The `import` keyword in `from ... import ...` groups and `as` in `import ... as ...` groups |
 | `alphabetize` | Classes, methods (*grouped dunders → properties → privates → publics*), enum members, Pydantic fields (*required then optional*), function parameters, keyword arguments, and `from` imports |
+| `blank-lines` | Module-level `def` and `class` carry 2 blank lines before them, methods inside a class body carry 1, and a module-level statement after `if __name__ == "__main__":` carries 1 |
 | `collection-layout` | Expands `dict`, `list`, and `set` literals to one entry per line, even when they fit inline |
 | `match-case-align` | Single-expression case bodies |
 | `singleton-rule` | Skips colon padding when only one item exists in the aligned group |
@@ -202,7 +203,7 @@ Docstrings carry two readings inside one triple-quoted region. Description prose
 
 **Alignment rules** are `align-colons`, `align-equals`, `align-imports`, and `match-case-align`. **Toggle-only rules** are `alphabetize`, `singleton-rule`, and `strip-trailing-commas`.
 
-Per-invocation overrides via `--select` and `--ignore` (*see [Install & Usage](#install--usage) above*) take precedence over the configured-enabled set.
+Per-invocation overrides via `--select` and `--ignore` (*see [Install & Usage](#-install--usage) above*) take precedence over the configured-enabled set.
 
 ---
 
@@ -270,7 +271,7 @@ For findings that persist across runs and surface in [Code Scanning](https://doc
     sarif_file: prose.sarif
 ```
 
-CI gates compile against the [exit-code matrix](#exit-codes) above. A non-zero status without `continue-on-error` fails the step.
+CI gates compile against the [exit-code matrix](#-exit-codes) above. A non-zero status without `continue-on-error` fails the step.
 
 ### Editor
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -346,7 +346,7 @@ mod tests {
     fn with_defaults_registers_enabled_rules() {
         let config = Config::default();
         let pipeline = Pipeline::with_defaults(&config);
-        assert_eq!(pipeline.len(), 8);
+        assert_eq!(pipeline.len(), 9);
     }
 
     #[test]
@@ -356,6 +356,7 @@ mod tests {
         config.rules.align_equals.enabled = false;
         config.rules.align_imports.enabled = false;
         config.rules.alphabetize.enabled = false;
+        config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.singleton_rule.enabled = false;
@@ -372,7 +373,7 @@ mod tests {
             &[RuleId::from("align-equals"), RuleId::from("alphabetize")],
         );
         let slugs = registered_slugs(&pipeline);
-        assert_eq!(slugs.len(), 6);
+        assert_eq!(slugs.len(), 7);
         assert!(!slugs.contains(&"align-equals"));
         assert!(!slugs.contains(&"alphabetize"));
     }
@@ -394,6 +395,7 @@ mod tests {
         config.rules.align_equals.enabled = false;
         config.rules.align_imports.enabled = false;
         config.rules.alphabetize.enabled = false;
+        config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.singleton_rule.enabled = false;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -20,6 +20,7 @@ use crate::rules::align_colons::AlignColons;
 use crate::rules::align_equals::AlignEquals;
 use crate::rules::align_imports::AlignImports;
 use crate::rules::alphabetize::Alphabetize;
+use crate::rules::blank_lines::BlankLines;
 use crate::rules::collection_layout::CollectionLayout;
 use crate::rules::match_case_align::MatchCaseAlign;
 use crate::rules::singleton_rule::SingletonRule;
@@ -194,6 +195,7 @@ register_rules! {
     collection_layout:     CollectionLayoutConfig => CollectionLayout    => "expand collection to one entry per line",
     alphabetize:           ToggleOnly             => Alphabetize         => "alphabetize this group",
     strip_trailing_commas: ToggleOnly             => StripTrailingCommas => "strip trailing comma",
+    blank_lines:           ToggleOnly             => BlankLines          => "normalize blank-line spacing",
     match_case_align:      AlignmentConfig        => MatchCaseAlign      => "align match-case arrows",
     align_imports:         AlignmentConfig        => AlignImports        => "align consecutive `import`s",
     align_colons:          AlignmentConfig        => AlignColons         => "align consecutive `:` separators",

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -1,0 +1,341 @@
+//! Normalizes vertical spacing between adjacent statements. Module-level
+//! `def` and `class` carry 2 blank lines before them. Methods inside a
+//! class body carry 1 blank line. A class-scope predecessor that is a
+//! string-literal docstring carries 1 blank line before the next member.
+//! A module-level statement following an `if __name__ == "__main__":`
+//! block carries 1 blank line of separation. Own-line comments between
+//! adjacent statements carry 1 blank line of separation from the
+//! following statement.
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::helpers::is_docstring_stmt;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::{CmpOp, Expr, Stmt};
+use ruff_python_trivia::{lines_after, lines_before, CommentRanges};
+use ruff_source_file::LineRanges;
+use ruff_text_size::{Ranged, TextRange, TextSize};
+
+use crate::config::Config;
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+pub(crate) struct BlankLines;
+
+impl BlankLines {
+    pub(crate) fn from_config(_: &Config) -> Self {
+        Self
+    }
+}
+
+impl Rule for BlankLines {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let body = &source.ast().body;
+        let mut walker = Walker {
+            edits: Vec::new(),
+            source,
+        };
+        walker.pair_count(body, BodyScope::Module);
+        walker.visit_body(body);
+        walker.edits
+    }
+
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(BlankLines))
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BodyScope {
+    Class,
+    Function,
+    Module,
+}
+
+#[derive(Clone, Copy)]
+struct CommentBlock {
+    bottom_end: TextSize,
+    top_line_start: TextSize,
+}
+
+struct Walker<'a> {
+    edits: Vec<Edit>,
+    source: &'a Source,
+}
+
+impl Walker<'_> {
+    /// Places `target_newlines` line breaks immediately above
+    /// `line_start`. Emits a replacement edit when the actual count
+    /// differs. Preserves any indent that sits on `line_start`'s line.
+    fn normalize_above(&mut self, line_start: TextSize, target_newlines: u32) {
+        let text = self.source.text();
+        if lines_before(line_start, text) == target_newlines {
+            return;
+        }
+        let span_start = whitespace_start_before(text, line_start);
+        let replacement = self.source.newline_str().repeat(target_newlines as usize);
+        self.edits.push(Edit::range_replacement(
+            replacement,
+            TextRange::new(span_start, line_start),
+        ));
+    }
+
+    /// Places exactly 1 blank line between `block_end` and
+    /// `curr_line_start`. The target gap is 2 line breaks: one to end
+    /// the block's last line and one to form the blank.
+    fn normalize_below_block(&mut self, block_end: TextSize, curr_line_start: TextSize) {
+        let target_newlines: u32 = 2;
+        if lines_after(block_end, self.source.text()) == target_newlines {
+            return;
+        }
+        let replacement = self.source.newline_str().repeat(target_newlines as usize);
+        self.edits.push(Edit::range_replacement(
+            replacement,
+            TextRange::new(block_end, curr_line_start),
+        ));
+    }
+
+    fn pair_count(&mut self, body: &[Stmt], scope: BodyScope) {
+        for (prev, curr) in body.iter().zip(body.iter().skip(1)) {
+            let Some(canonical) = canonical_blanks(prev, curr, scope) else {
+                continue;
+            };
+            let block = leading_block_of(self.source, prev.end(), curr);
+            self.push_pair_edits(curr, canonical, block);
+        }
+    }
+
+    fn push_pair_edits(&mut self, curr: &Stmt, canonical: u32, block: Option<CommentBlock>) {
+        let curr_line_start = self.source.text().line_start(curr.start());
+        let above_line_start = block.map_or(curr_line_start, |b| b.top_line_start);
+        self.normalize_above(above_line_start, canonical + 1);
+        if let Some(b) = block {
+            self.normalize_below_block(b.bottom_end, curr_line_start);
+        }
+    }
+}
+
+impl<'a> StatementVisitor<'a> for Walker<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::ClassDef(c) => self.pair_count(&c.body, BodyScope::Class),
+            Stmt::FunctionDef(f) => self.pair_count(&f.body, BodyScope::Function),
+            _ => {}
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+/// Returns the canonical blank-line count for the pair `(prev, curr)`
+/// at `scope`. `None` means no case applies; the above-block gap is
+/// left alone, but a leading comment block still triggers below-gap
+/// normalization.
+fn canonical_blanks(prev: &Stmt, curr: &Stmt, scope: BodyScope) -> Option<u32> {
+    match scope {
+        BodyScope::Class => (is_docstring_stmt(prev)
+            || matches!((prev, curr), (Stmt::FunctionDef(_), Stmt::FunctionDef(_))))
+        .then_some(1),
+        BodyScope::Function => None,
+        BodyScope::Module => {
+            if is_main_guard(prev) {
+                Some(1)
+            } else {
+                matches!(curr, Stmt::FunctionDef(_) | Stmt::ClassDef(_)).then_some(2)
+            }
+        }
+    }
+}
+
+/// True when `stmt` is `if __name__ == "__main__":`.
+fn is_main_guard(stmt: &Stmt) -> bool {
+    let Some(if_stmt) = stmt.as_if_stmt() else {
+        return false;
+    };
+    let Some(cmp) = if_stmt.test.as_compare_expr() else {
+        return false;
+    };
+    let ([CmpOp::Eq], Some(left), Some(right)) = (
+        cmp.ops.as_ref(),
+        cmp.left.as_name_expr(),
+        cmp.comparators
+            .first()
+            .and_then(Expr::as_string_literal_expr),
+    ) else {
+        return false;
+    };
+    left.id == "__name__" && right.value == *"__main__"
+}
+
+/// Returns the contiguous range of own-line comments lying between
+/// `prev_end` and `curr.start()`. `None` when no own-line comment
+/// sits in that gap. End-of-line comments on the predecessor's line
+/// are excluded.
+fn leading_block_of(source: &Source, prev_end: TextSize, curr: &Stmt) -> Option<CommentBlock> {
+    let text = source.text();
+    let mut own_lines = source
+        .comment_ranges()
+        .comments_in_range(TextRange::new(prev_end, curr.start()))
+        .iter()
+        .copied()
+        .filter(|r| CommentRanges::is_own_line(r.start(), text));
+    let first = own_lines.next()?;
+    let last = own_lines.next_back().unwrap_or(first);
+    Some(CommentBlock {
+        top_line_start: text.line_start(first.start()),
+        bottom_end: last.end(),
+    })
+}
+
+/// Returns the start of the contiguous ASCII-whitespace run immediately
+/// preceding `offset` in `text`.
+fn whitespace_start_before(text: &str, offset: TextSize) -> TextSize {
+    let trimmed = text[..offset.to_usize()].trim_end_matches(|c: char| c.is_ascii_whitespace());
+    TextSize::of(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::parse;
+
+    fn main_guard_src() -> &'static str {
+        "if __name__ == \"__main__\":\n    main()\n"
+    }
+
+    #[test]
+    fn canonical_blanks_class_docstring_predecessor_returns_one() {
+        let s = parse("class C:\n    '''doc'''\n    def m1(self): pass\n");
+        let class = s.ast().body[0].as_class_def_stmt().expect("class");
+        assert_eq!(
+            canonical_blanks(&class.body[0], &class.body[1], BodyScope::Class),
+            Some(1),
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_in_class_body_pairs_method_after_method_to_one() {
+        let s = parse("class C:\n    def m1(self): pass\n    def m2(self): pass\n");
+        let class = s.ast().body[0].as_class_def_stmt().expect("class");
+        assert_eq!(
+            canonical_blanks(&class.body[0], &class.body[1], BodyScope::Class),
+            Some(1),
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_in_function_body_returns_none() {
+        let s = parse("def f():\n    x = 1\n    y = 2\n");
+        let func = s.ast().body[0].as_function_def_stmt().expect("def");
+        assert_eq!(
+            canonical_blanks(&func.body[0], &func.body[1], BodyScope::Function),
+            None,
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_module_after_main_guard_returns_one() {
+        let s = parse(&format!("{}xs = 1\n", main_guard_src()));
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_module_def_after_module_stmt_returns_two() {
+        let s = parse("x = 1\ndef f(): pass\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_unrelated_pair_returns_none() {
+        let s = parse("x = 1\ny = 2\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            None
+        );
+    }
+
+    #[test]
+    fn is_main_guard_accepts_canonical_form() {
+        let s = parse(main_guard_src());
+        assert!(is_main_guard(&s.ast().body[0]));
+    }
+
+    #[test]
+    fn is_main_guard_rejects_non_if_statements() {
+        let s = parse("x = 1\n");
+        assert!(!is_main_guard(&s.ast().body[0]));
+    }
+
+    #[test]
+    fn is_main_guard_rejects_other_if_conditions() {
+        for src in [
+            "if x:\n    pass\n",
+            "if __name__ != \"__main__\":\n    pass\n",
+            "if __name__ == \"main\":\n    pass\n",
+            "if other == \"__main__\":\n    pass\n",
+            "if __name__ == __main__:\n    pass\n",
+            "if __name__ == \"__main__\" and x:\n    pass\n",
+        ] {
+            let s = parse(src);
+            assert!(!is_main_guard(&s.ast().body[0]), "src = {src:?}");
+        }
+    }
+
+    #[test]
+    fn leading_block_of_returns_block_for_chain_of_own_line_comments() {
+        let s = parse("x = 1\n# a\n# b\ndef f(): pass\n");
+        let body = &s.ast().body;
+        let block = leading_block_of(&s, body[0].end(), &body[1]).expect("block");
+        let comments: Vec<TextRange> = s.comment_ranges().iter().copied().collect();
+        assert_eq!(
+            block.top_line_start,
+            s.text().line_start(comments[0].start())
+        );
+        assert_eq!(block.bottom_end, comments[1].end());
+    }
+
+    #[test]
+    fn leading_block_of_returns_none_when_no_own_line_comments_between() {
+        let s = parse("x = 1\ndef f(): pass\n");
+        let body = &s.ast().body;
+        assert!(leading_block_of(&s, body[0].end(), &body[1]).is_none());
+    }
+
+    #[test]
+    fn leading_block_of_skips_trailing_end_of_line_comments() {
+        let s = parse("x = 1  # trail\ndef f(): pass\n");
+        let body = &s.ast().body;
+        assert!(leading_block_of(&s, body[0].end(), &body[1]).is_none());
+    }
+
+    #[test]
+    fn whitespace_start_before_handles_crlf() {
+        assert_eq!(
+            whitespace_start_before("a\r\n\r\nb", TextSize::new(5)),
+            TextSize::new(1),
+        );
+    }
+
+    #[test]
+    fn whitespace_start_before_returns_zero_for_leading_whitespace() {
+        assert_eq!(
+            whitespace_start_before("   \n\n\nx", TextSize::new(6)),
+            TextSize::new(0),
+        );
+    }
+
+    #[test]
+    fn whitespace_start_before_stops_at_non_whitespace() {
+        assert_eq!(
+            whitespace_start_before("ab\n\ncd", TextSize::new(4)),
+            TextSize::new(2),
+        );
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod align_colons;
 pub(crate) mod align_equals;
 pub(crate) mod align_imports;
 pub(crate) mod alphabetize;
+pub(crate) mod blank_lines;
 pub(crate) mod collection_layout;
 pub(crate) mod match_case_align;
 pub(crate) mod singleton_rule;

--- a/tests/fixtures/blank_lines/banner_comments.input.py
+++ b/tests/fixtures/blank_lines/banner_comments.input.py
@@ -1,0 +1,14 @@
+"""
+A banner-style block of own-line comments above a def is treated as
+a section header. The rule places the pair's canonical gap above the
+banner and 1 blank line between the banner and the following def.
+"""
+
+
+def first():
+    return 1
+# ============================================================
+# Section: Auxiliary Helpers
+# ============================================================
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/class_with_docstring.input.py
+++ b/tests/fixtures/blank_lines/class_with_docstring.input.py
@@ -1,0 +1,16 @@
+"""
+A class with its own docstring (here using triple-apostrophe quotes)
+gets 1 blank line between the docstring and its first method. The
+class-scope canonical fires on the (docstring, method) pair.
+"""
+
+
+class Posting:
+    '''Inline class docstring using triple-apostrophe quotes.'''
+    def m1(self):
+        return 1
+
+
+
+    def m2(self):
+        return 2

--- a/tests/fixtures/blank_lines/comment_with_blank_above_def.input.py
+++ b/tests/fixtures/blank_lines/comment_with_blank_above_def.input.py
@@ -1,0 +1,19 @@
+"""
+A comment sitting between two statements is treated as the second
+statement's leading block. The rule normalizes the canonical gap
+above the comment and 1 blank line between the comment and the
+following statement, regardless of the source's blank-count drift.
+"""
+
+
+def first():
+    return 1
+
+
+# detached header
+
+
+
+
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/compound_then_def.input.py
+++ b/tests/fixtures/blank_lines/compound_then_def.input.py
@@ -1,0 +1,12 @@
+"""
+A compound statement at module level pairs with a following def the
+same way any other module-level statement does. The rule normalizes
+the gap to 2 blank lines.
+"""
+
+
+for setup in initial_steps:
+    setup.run()
+
+def main():
+    return 0

--- a/tests/fixtures/blank_lines/decorated_def.input.py
+++ b/tests/fixtures/blank_lines/decorated_def.input.py
@@ -1,0 +1,13 @@
+"""
+A module-level def with a leading decorator has its leading edge
+counted from the decorator line. The rule normalizes the blank-line
+count above the decorator.
+"""
+
+
+def first():
+    return 1
+
+@decorator
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/decorated_method.input.py
+++ b/tests/fixtures/blank_lines/decorated_method.input.py
@@ -1,0 +1,16 @@
+"""
+A class-body method with a leading decorator has its leading edge
+counted from the decorator. The rule normalizes the class-scope
+canonical of 1 blank line above the decorator line.
+"""
+
+
+class Posting:
+    def first(self):
+        return 1
+
+
+
+    @cached_property
+    def second(self):
+        return 2

--- a/tests/fixtures/blank_lines/def_in_if_body.input.py
+++ b/tests/fixtures/blank_lines/def_in_if_body.input.py
@@ -1,0 +1,12 @@
+"""
+Defs sitting inside an `if` block at module level do not pair-count.
+The walker descends into the if body to find nested classes and
+functions but applies no canonical rule at the if-body indentation.
+"""
+
+
+if FEATURE_X:
+    def alpha():
+        return 1
+    def beta():
+        return 2

--- a/tests/fixtures/blank_lines/extra_blanks_collapse.input.py
+++ b/tests/fixtures/blank_lines/extra_blanks_collapse.input.py
@@ -1,0 +1,14 @@
+"""
+Four blank lines before a module-level def collapse to the canonical
+2. The rule replaces the whole inter-statement whitespace run.
+"""
+
+
+def first():
+    return 1
+
+
+
+
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/field_then_method.input.py
+++ b/tests/fixtures/blank_lines/field_then_method.input.py
@@ -1,0 +1,20 @@
+"""
+The class-scope rule fires only on adjacent `(method, method)` pairs.
+A field-to-field or field-to-method gap carries no canonical count,
+so only the inter-method gap normalizes to 1 blank line.
+"""
+
+
+class Posting:
+    field: int = 1
+    name: str = "x"
+
+
+
+    def m1(self):
+        return 1
+
+
+
+    def m2(self):
+        return 2

--- a/tests/fixtures/blank_lines/idempotent.input.py
+++ b/tests/fixtures/blank_lines/idempotent.input.py
@@ -1,0 +1,21 @@
+"""
+A module that already carries canonical blank-line spacing round-trips
+unchanged. Two-blank gaps around module-level defs and a one-blank gap
+between methods both satisfy the rule.
+"""
+
+
+def alpha():
+    return 1
+
+
+class Posting:
+    def first(self):
+        return 1
+
+    def second(self):
+        return 2
+
+
+def beta():
+    return 2

--- a/tests/fixtures/blank_lines/main_guard.input.py
+++ b/tests/fixtures/blank_lines/main_guard.input.py
@@ -1,0 +1,16 @@
+"""
+A module-level statement following an `if __name__ == "__main__":`
+block carries 1 blank line of separation.
+"""
+
+
+def main():
+    return 0
+
+
+if __name__ == "__main__":
+    main()
+
+
+
+trailing = True

--- a/tests/fixtures/blank_lines/main_guard_then_def.input.py
+++ b/tests/fixtures/blank_lines/main_guard_then_def.input.py
@@ -1,0 +1,14 @@
+"""
+A module-level def following the `if __name__ == "__main__":` block
+carries 1 blank line of separation. The main-guard case takes
+precedence over the 2-blank def-after-stmt case.
+"""
+
+
+if __name__ == "__main__":
+    main()
+
+
+
+def cleanup():
+    return None

--- a/tests/fixtures/blank_lines/methods_in_class.input.py
+++ b/tests/fixtures/blank_lines/methods_in_class.input.py
@@ -1,0 +1,14 @@
+"""
+Two methods inside a class body normalize to 1 blank line between
+them, collapsing extra blanks and expanding missing ones.
+"""
+
+
+class Posting:
+    def first(self):
+        return 1
+
+
+
+    def second(self):
+        return 2

--- a/tests/fixtures/blank_lines/methods_with_comment.input.py
+++ b/tests/fixtures/blank_lines/methods_with_comment.input.py
@@ -1,0 +1,16 @@
+"""
+A class-body method preceded by an own-line comment normalizes to
+1 blank line above the comment and 1 blank line between the comment
+and the method.
+"""
+
+
+class Posting:
+    def first(self):
+        return 1
+
+
+
+    # describes the second helper
+    def second(self):
+        return 2

--- a/tests/fixtures/blank_lines/missing_blanks_insert.input.py
+++ b/tests/fixtures/blank_lines/missing_blanks_insert.input.py
@@ -1,0 +1,11 @@
+"""
+Zero blank lines between two module-level defs expand to the
+canonical 2. The rule inserts the missing newlines into the
+inter-statement whitespace.
+"""
+
+
+def first():
+    return 1
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/multi_comment_attached.input.py
+++ b/tests/fixtures/blank_lines/multi_comment_attached.input.py
@@ -1,0 +1,15 @@
+"""
+A chain of own-line comments between two statements forms a single
+leading comment block for the second statement. The rule normalizes
+2 blank lines above the topmost comment and 1 blank line between
+the bottommost comment and the following def.
+"""
+
+
+def first():
+    return 1
+# explains why
+# bookkeeping
+# second helper
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/multiple_consecutive_defs.input.py
+++ b/tests/fixtures/blank_lines/multiple_consecutive_defs.input.py
@@ -1,0 +1,14 @@
+"""
+Three back-to-back module-level defs each pair-count independently.
+Each adjacent pair normalizes to 2 blank lines, regardless of the
+source's actual gap.
+"""
+
+
+def alpha():
+    return 1
+def beta():
+    return 2
+
+def gamma():
+    return 3

--- a/tests/fixtures/blank_lines/nested_class.input.py
+++ b/tests/fixtures/blank_lines/nested_class.input.py
@@ -1,0 +1,15 @@
+"""
+A method inside a class nested in an outer class normalizes to 1
+blank line between siblings.
+"""
+
+
+class Outer:
+    class Inner:
+        def alpha(self):
+            return 1
+
+
+
+        def beta(self):
+            return 2

--- a/tests/fixtures/blank_lines/nested_function.input.py
+++ b/tests/fixtures/blank_lines/nested_function.input.py
@@ -1,0 +1,13 @@
+"""
+Nested function defs inside another function body do not pair-count.
+The Function scope has no canonical blank-line rule, so the inner
+defs round-trip unchanged regardless of their source spacing.
+"""
+
+
+def outer():
+    def inner_a():
+        return 1
+    def inner_b():
+        return 2
+    return inner_a, inner_b

--- a/tests/fixtures/blank_lines/overload_chain.input.py
+++ b/tests/fixtures/blank_lines/overload_chain.input.py
@@ -1,0 +1,15 @@
+"""
+A module-level chain of `@overload`-decorated defs treats each
+adjacent pair as a regular def-after-def case, normalizing to 2 blank
+lines. The rule does not special-case overloads.
+"""
+
+
+from typing import overload
+
+@overload
+def process(x: int) -> int: ...
+@overload
+def process(x: str) -> str: ...
+def process(x):
+    return x

--- a/tests/fixtures/blank_lines/stacked_decorators.input.py
+++ b/tests/fixtures/blank_lines/stacked_decorators.input.py
@@ -1,0 +1,14 @@
+"""
+A module-level def with stacked decorators has its leading edge at
+the topmost decorator. The rule normalizes the blank-line count above
+that decorator, with the rest of the decorator chain riding along.
+"""
+
+
+def first():
+    return 1
+
+@first_decorator
+@second_decorator
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/top_level_class_then_def.input.py
+++ b/tests/fixtures/blank_lines/top_level_class_then_def.input.py
@@ -1,0 +1,10 @@
+"""
+A module-level class followed by a def normalizes to 2 blank lines
+between them, regardless of the source's actual count.
+"""
+
+
+class Posting:
+    title = "x"
+def helper():
+    return None

--- a/tests/fixtures/blank_lines/top_level_defs.input.py
+++ b/tests/fixtures/blank_lines/top_level_defs.input.py
@@ -1,0 +1,12 @@
+"""
+Two module-level defs separated by a single blank line expand to the
+canonical 2-blank separation. The rule replaces the inter-statement
+whitespace run in place.
+"""
+
+
+def first():
+    return 1
+
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/trailing_comment_on_predecessor.input.py
+++ b/tests/fixtures/blank_lines/trailing_comment_on_predecessor.input.py
@@ -1,0 +1,12 @@
+"""
+A trailing end-of-line comment on the predecessor stays on its line
+without joining the next def's leading region. The blank-line rewrite
+lands between the two statements.
+"""
+
+
+def first():
+    return 1  # short note
+
+def second():
+    return 2

--- a/tests/fixtures/blank_lines/with_comments.input.py
+++ b/tests/fixtures/blank_lines/with_comments.input.py
@@ -1,0 +1,13 @@
+"""
+An own-line comment between two statements forms the second
+statement's leading block. The rule normalizes the canonical gap
+above the comment and 1 blank line between the comment and the
+following statement.
+"""
+
+
+def first():
+    return 1
+# describes the second helper
+def second():
+    return 2

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -15,6 +15,9 @@ enabled = false
 [tool.prose.rules.alphabetize]
 enabled = false
 
+[tool.prose.rules.blank-lines]
+enabled = false
+
 [tool.prose.rules.collection-layout]
 enabled = false
 max-atomics-per-line = 3

--- a/tests/snapshots/blank_lines/banner_comments.input.py.snap
+++ b/tests/snapshots/blank_lines/banner_comments.input.py.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/banner_comments.input.py
+---
+"""
+A banner-style block of own-line comments above a def is treated as
+a section header. The rule places the pair's canonical gap above the
+banner and 1 blank line between the banner and the following def.
+"""
+
+
+def first():
+    return 1
+
+
+# ============================================================
+# Section: Auxiliary Helpers
+# ============================================================
+
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/class_with_docstring.input.py.snap
+++ b/tests/snapshots/blank_lines/class_with_docstring.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/class_with_docstring.input.py
+---
+"""
+A class with its own docstring (here using triple-apostrophe quotes)
+gets 1 blank line between the docstring and its first method. The
+class-scope canonical fires on the (docstring, method) pair.
+"""
+
+
+class Posting:
+    '''Inline class docstring using triple-apostrophe quotes.'''
+
+    def m1(self):
+        return 1
+
+    def m2(self):
+        return 2

--- a/tests/snapshots/blank_lines/comment_with_blank_above_def.input.py.snap
+++ b/tests/snapshots/blank_lines/comment_with_blank_above_def.input.py.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/comment_with_blank_above_def.input.py
+---
+"""
+A comment sitting between two statements is treated as the second
+statement's leading block. The rule normalizes the canonical gap
+above the comment and 1 blank line between the comment and the
+following statement, regardless of the source's blank-count drift.
+"""
+
+
+def first():
+    return 1
+
+
+# detached header
+
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/compound_then_def.input.py.snap
+++ b/tests/snapshots/blank_lines/compound_then_def.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/compound_then_def.input.py
+---
+"""
+A compound statement at module level pairs with a following def the
+same way any other module-level statement does. The rule normalizes
+the gap to 2 blank lines.
+"""
+
+
+for setup in initial_steps:
+    setup.run()
+
+
+def main():
+    return 0

--- a/tests/snapshots/blank_lines/decorated_def.input.py.snap
+++ b/tests/snapshots/blank_lines/decorated_def.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/decorated_def.input.py
+---
+"""
+A module-level def with a leading decorator has its leading edge
+counted from the decorator line. The rule normalizes the blank-line
+count above the decorator.
+"""
+
+
+def first():
+    return 1
+
+
+@decorator
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/decorated_method.input.py.snap
+++ b/tests/snapshots/blank_lines/decorated_method.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/decorated_method.input.py
+---
+"""
+A class-body method with a leading decorator has its leading edge
+counted from the decorator. The rule normalizes the class-scope
+canonical of 1 blank line above the decorator line.
+"""
+
+
+class Posting:
+    def first(self):
+        return 1
+
+    @cached_property
+    def second(self):
+        return 2

--- a/tests/snapshots/blank_lines/def_in_if_body.input.py.snap
+++ b/tests/snapshots/blank_lines/def_in_if_body.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/def_in_if_body.input.py
+---
+"""
+Defs sitting inside an `if` block at module level do not pair-count.
+The walker descends into the if body to find nested classes and
+functions but applies no canonical rule at the if-body indentation.
+"""
+
+
+if FEATURE_X:
+    def alpha():
+        return 1
+    def beta():
+        return 2

--- a/tests/snapshots/blank_lines/diagnostics.snap
+++ b/tests/snapshots/blank_lines/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+---
+blank-lines@238..239
+blank-lines@393..394

--- a/tests/snapshots/blank_lines/extra_blanks_collapse.input.py.snap
+++ b/tests/snapshots/blank_lines/extra_blanks_collapse.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/extra_blanks_collapse.input.py
+---
+"""
+Four blank lines before a module-level def collapse to the canonical
+2. The rule replaces the whole inter-statement whitespace run.
+"""
+
+
+def first():
+    return 1
+
+
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/field_then_method.input.py.snap
+++ b/tests/snapshots/blank_lines/field_then_method.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/field_then_method.input.py
+---
+"""
+The class-scope rule fires only on adjacent `(method, method)` pairs.
+A field-to-field or field-to-method gap carries no canonical count,
+so only the inter-method gap normalizes to 1 blank line.
+"""
+
+
+class Posting:
+    field: int = 1
+    name: str = "x"
+
+
+
+    def m1(self):
+        return 1
+
+    def m2(self):
+        return 2

--- a/tests/snapshots/blank_lines/idempotent.input.py.snap
+++ b/tests/snapshots/blank_lines/idempotent.input.py.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/idempotent.input.py
+---
+"""
+A module that already carries canonical blank-line spacing round-trips
+unchanged. Two-blank gaps around module-level defs and a one-blank gap
+between methods both satisfy the rule.
+"""
+
+
+def alpha():
+    return 1
+
+
+class Posting:
+    def first(self):
+        return 1
+
+    def second(self):
+        return 2
+
+
+def beta():
+    return 2

--- a/tests/snapshots/blank_lines/main_guard.input.py.snap
+++ b/tests/snapshots/blank_lines/main_guard.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/main_guard.input.py
+---
+"""
+A module-level statement following an `if __name__ == "__main__":`
+block carries 1 blank line of separation.
+"""
+
+
+def main():
+    return 0
+
+
+if __name__ == "__main__":
+    main()
+
+trailing = True

--- a/tests/snapshots/blank_lines/main_guard_then_def.input.py.snap
+++ b/tests/snapshots/blank_lines/main_guard_then_def.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/main_guard_then_def.input.py
+---
+"""
+A module-level def following the `if __name__ == "__main__":` block
+carries 1 blank line of separation. The main-guard case takes
+precedence over the 2-blank def-after-stmt case.
+"""
+
+
+if __name__ == "__main__":
+    main()
+
+def cleanup():
+    return None

--- a/tests/snapshots/blank_lines/methods_in_class.input.py.snap
+++ b/tests/snapshots/blank_lines/methods_in_class.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/methods_in_class.input.py
+---
+"""
+Two methods inside a class body normalize to 1 blank line between
+them, collapsing extra blanks and expanding missing ones.
+"""
+
+
+class Posting:
+    def first(self):
+        return 1
+
+    def second(self):
+        return 2

--- a/tests/snapshots/blank_lines/methods_with_comment.input.py.snap
+++ b/tests/snapshots/blank_lines/methods_with_comment.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/methods_with_comment.input.py
+---
+"""
+A class-body method preceded by an own-line comment normalizes to
+1 blank line above the comment and 1 blank line between the comment
+and the method.
+"""
+
+
+class Posting:
+    def first(self):
+        return 1
+
+    # describes the second helper
+
+    def second(self):
+        return 2

--- a/tests/snapshots/blank_lines/missing_blanks_insert.input.py.snap
+++ b/tests/snapshots/blank_lines/missing_blanks_insert.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/missing_blanks_insert.input.py
+---
+"""
+Zero blank lines between two module-level defs expand to the
+canonical 2. The rule inserts the missing newlines into the
+inter-statement whitespace.
+"""
+
+
+def first():
+    return 1
+
+
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/multi_comment_attached.input.py.snap
+++ b/tests/snapshots/blank_lines/multi_comment_attached.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/multi_comment_attached.input.py
+---
+"""
+A chain of own-line comments between two statements forms a single
+leading comment block for the second statement. The rule normalizes
+2 blank lines above the topmost comment and 1 blank line between
+the bottommost comment and the following def.
+"""
+
+
+def first():
+    return 1
+
+
+# explains why
+# bookkeeping
+# second helper
+
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/multiple_consecutive_defs.input.py.snap
+++ b/tests/snapshots/blank_lines/multiple_consecutive_defs.input.py.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/multiple_consecutive_defs.input.py
+---
+"""
+Three back-to-back module-level defs each pair-count independently.
+Each adjacent pair normalizes to 2 blank lines, regardless of the
+source's actual gap.
+"""
+
+
+def alpha():
+    return 1
+
+
+def beta():
+    return 2
+
+
+def gamma():
+    return 3

--- a/tests/snapshots/blank_lines/nested_class.input.py.snap
+++ b/tests/snapshots/blank_lines/nested_class.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/nested_class.input.py
+---
+"""
+A method inside a class nested in an outer class normalizes to 1
+blank line between siblings.
+"""
+
+
+class Outer:
+    class Inner:
+        def alpha(self):
+            return 1
+
+        def beta(self):
+            return 2

--- a/tests/snapshots/blank_lines/nested_function.input.py.snap
+++ b/tests/snapshots/blank_lines/nested_function.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/nested_function.input.py
+---
+"""
+Nested function defs inside another function body do not pair-count.
+The Function scope has no canonical blank-line rule, so the inner
+defs round-trip unchanged regardless of their source spacing.
+"""
+
+
+def outer():
+    def inner_a():
+        return 1
+    def inner_b():
+        return 2
+    return inner_a, inner_b

--- a/tests/snapshots/blank_lines/overload_chain.input.py.snap
+++ b/tests/snapshots/blank_lines/overload_chain.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/overload_chain.input.py
+---
+"""
+A module-level chain of `@overload`-decorated defs treats each
+adjacent pair as a regular def-after-def case, normalizing to 2 blank
+lines. The rule does not special-case overloads.
+"""
+
+
+from typing import overload
+
+
+@overload
+def process(x: int) -> int: ...
+
+
+@overload
+def process(x: str) -> str: ...
+
+
+def process(x):
+    return x

--- a/tests/snapshots/blank_lines/stacked_decorators.input.py.snap
+++ b/tests/snapshots/blank_lines/stacked_decorators.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/stacked_decorators.input.py
+---
+"""
+A module-level def with stacked decorators has its leading edge at
+the topmost decorator. The rule normalizes the blank-line count above
+that decorator, with the rest of the decorator chain riding along.
+"""
+
+
+def first():
+    return 1
+
+
+@first_decorator
+@second_decorator
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/top_level_class_then_def.input.py.snap
+++ b/tests/snapshots/blank_lines/top_level_class_then_def.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/top_level_class_then_def.input.py
+---
+"""
+A module-level class followed by a def normalizes to 2 blank lines
+between them, regardless of the source's actual count.
+"""
+
+
+class Posting:
+    title = "x"
+
+
+def helper():
+    return None

--- a/tests/snapshots/blank_lines/top_level_defs.input.py.snap
+++ b/tests/snapshots/blank_lines/top_level_defs.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/top_level_defs.input.py
+---
+"""
+Two module-level defs separated by a single blank line expand to the
+canonical 2-blank separation. The rule replaces the inter-statement
+whitespace run in place.
+"""
+
+
+def first():
+    return 1
+
+
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/trailing_comment_on_predecessor.input.py.snap
+++ b/tests/snapshots/blank_lines/trailing_comment_on_predecessor.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/trailing_comment_on_predecessor.input.py
+---
+"""
+A trailing end-of-line comment on the predecessor stays on its line
+without joining the next def's leading region. The blank-line rewrite
+lands between the two statements.
+"""
+
+
+def first():
+    return 1  # short note
+
+
+def second():
+    return 2

--- a/tests/snapshots/blank_lines/with_comments.input.py.snap
+++ b/tests/snapshots/blank_lines/with_comments.input.py.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/with_comments.input.py
+---
+"""
+An own-line comment between two statements forms the second
+statement's leading block. The rule normalizes the canonical gap
+above the comment and 1 blank line between the comment and the
+following statement.
+"""
+
+
+def first():
+    return 1
+
+
+# describes the second helper
+
+def second():
+    return 2

--- a/tests/snapshots/composition/match_dispatch.input.py.snap
+++ b/tests/snapshots/composition/match_dispatch.input.py.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/composition/match_dispatch.input.py
 ---
 """
@@ -11,6 +11,7 @@ removes the dangling commas the source carries, and the singleton
 rule strips the lone-key dict's pre-`:` padding. The full pipeline
 running twice produces no further change.
 """
+
 
 def dispatch(event):
     match event.kind:

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -24,6 +24,9 @@ Config {
         strip_trailing_commas: ToggleOnly {
             enabled: false,
         },
+        blank_lines: ToggleOnly {
+            enabled: false,
+        },
         match_case_align: AlignmentConfig {
             enabled: false,
             max_shift: 8,


### PR DESCRIPTION
### 🪻 Quick Summary

Implements `blank-lines` as the ninth auto-fix rule, normalizing the gap above each `def`, `class`, post-`__main__`-guard pair, and class-scope post-docstring member to the canonical blank-line count. The rule walks class, function, and module bodies via `StatementVisitor`, pairs adjacent statements at each scope, computes the canonical count from the pair shape, and emits an `Edit::range_replacement` for the above-block gap, plus a second one for the below-block gap when a leading comment block lies between the pair. Function bodies stay untouched, since inter-statement spacing inside a function is the author's call.

Own-line comment blocks lying between adjacent statements attach to the following statement, with the above-block gap normalized to the pair's canonical count and the below-block gap normalized to exactly 1 blank line. End-of-line comments on the predecessor's line are excluded from the block via `CommentRanges::is_own_line`. The `__main__` guard recognizer destructures the `if` test against `[CmpOp::Eq]`, `as_name_expr()`, and the first comparator's `as_string_literal_expr` in a single tuple `let-else`, so a chained comparison or a non-string comparator falls through cleanly.

---

### 🗞️ Key Changes

- Adds `BlankLines` normalizing inter-statement gaps in class, function, and module bodies, dispatched via `StatementVisitor` with `pair_count` per body scope

- Pairs adjacent statements via `body.iter().zip(body.iter().skip(1))` and routes the pair through `canonical_blanks(prev, curr, scope)`, returning the target blank-line count or `None` when no rule applies

- Targets 2 blanks before module-level `def` and `class`, 1 blank before a method inside a class body or after a class-scope docstring, and 1 blank between an `if __name__ == "__main__":` block and the following module-level statement

- Detects the `__main__` guard via slice-pattern destructure on `cmp.ops`, `cmp.left.as_name_expr()`, and the first comparator's `as_string_literal_expr`, rejecting chained comparisons and non-string comparators in one `let-else`

- Routes own-line comment blocks into the normalized span, with the above-block gap taking the pair's canonical count and the below-block gap normalizing to exactly 1 blank line via a second `Edit::range_replacement`

- Counts the actual gap via `ruff_python_trivia::lines_before` and `lines_after`, emitting an edit only when the actual count differs from the canonical, and reuses `Source::newline_str()` for the replacement so the source's existing CRLF or LF convention survives

- Registers the rule via `register_rules!` with the `"normalize blank-line spacing"` message and adds the toggle to `tests/fixtures/config/full_override.toml` plus the matching `tests/snapshots/config/full_override.snap`

- Adds 25 fixtures spanning the spec's nine canonical cases plus sixteen additional scenarios (*decorator chains, overload chains, banner comments, trailing end-of-line comments, multi-comment-attached blocks, compound-then-def, def-in-if-body*)

- Adds 15 inline unit tests covering `canonical_blanks` per scope, `is_main_guard` against the canonical form plus six negative-shape variants, `leading_block_of` against chain / no-comment / end-of-line-exclusion inputs, and `whitespace_start_before` against CRLF, leading-whitespace, and non-whitespace boundary inputs

---

### 🧵 Related Issues

- Closes #61
