### PR TITLE
[82] Add `target-version` config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,11 @@ Per-rule knobs:
 | `code-line-length` | positive int | top-level `[tool.prose]` | Honored by line-length-aware rules, defaulting to `88` |
 | `docstring-line-length` | positive int | top-level `[tool.prose]` | Description-prose budget for `docstring-wrap`, defaulting to `76` |
 | `docstring-structured-policy` | `"code-line-length"` \| `"docstring-line-length"` | top-level `[tool.prose]` | Source budget for structured docstring sections, defaulting to `"code-line-length"` |
+| `target-version` | `"3.X"` version string | top-level `[tool.prose]` | Python runtime the project ships to. Consumed by version-gated rules, defaulting to unset |
 
 Docstrings carry two readings inside one triple-quoted region. Description prose between the opening `"""` and the first section heading reads as paragraphs, where 76 characters is the comfortable line for sustained reading. Structured sections (*`Args:`, `Returns:`, `Raises:`*) read as code-shaped tables and reuse `code-line-length` (*88 by default*) to match surrounding indentation, though `docstring-structured-policy` switches them to `docstring-line-length` if a project prefers a single narrower budget across the whole docstring. The `docstring-wrap` rule will consume both budgets when it lands later in `0.2`.
+
+`target-version` names the Python runtime a project ships to, taking the bare `major.minor` form (*`"3.13"`, `"3.14"`*) used by `mypy`'s `python_version` setting. Rules whose safety depends on the runtime read this field directly, treating an unset value as the cue to skip every version-dependent arm rather than assume a default. The first consumers arrive with the auto-fix wave landing later in `0.2`.
 
 **Alignment rules** are `align-colons`, `align-equals`, `align-imports`, and `match-case-align`. **Toggle-only rules** are `alphabetize`, `singleton-rule`, and `strip-trailing-commas`.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@
 use std::num::NonZeroUsize;
 use std::path::Path;
 
+use ruff_python_ast::PythonVersion;
 use serde::{de::IntoDeserializer, Deserialize};
 use thiserror::Error;
 
@@ -55,9 +56,9 @@ impl Default for CollectionLayoutConfig {
 ///
 /// `code_line_length` defaults to `Some(88)`. `docstring_line_length`
 /// defaults to `Some(76)`. `docstring_structured_policy` defaults
-/// to `CodeLineLength`. Per-rule settings live under `rules`, where
-/// each rule's sub-table carries `enabled` plus that rule's own
-/// knobs.
+/// to `CodeLineLength`. `target_version` defaults to `None`.
+/// Per-rule settings live under `rules`, where each rule's sub-table
+/// carries `enabled` plus that rule's own knobs.
 #[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
@@ -65,6 +66,7 @@ pub struct Config {
     pub docstring_line_length: Option<NonZeroUsize>,
     pub docstring_structured_policy: DocstringStructuredPolicy,
     pub rules: RuleConfigs,
+    pub target_version: Option<PythonVersion>,
 }
 
 impl Default for Config {
@@ -74,6 +76,7 @@ impl Default for Config {
             docstring_line_length: NonZeroUsize::new(76),
             docstring_structured_policy: DocstringStructuredPolicy::default(),
             rules: RuleConfigs::default(),
+            target_version: None,
         }
     }
 }
@@ -403,5 +406,35 @@ mod tests {
         let config = Config::load(&nested).expect("loads");
 
         assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+    }
+
+    #[test]
+    fn target_version_defaults_to_none_when_field_absent() {
+        let config = Config::from_pyproject_str("[tool.prose]\n").expect("parses");
+
+        assert_eq!(config.target_version, None);
+    }
+
+    #[test]
+    fn target_version_every_variant_round_trips_through_serde() {
+        for version in PythonVersion::iter() {
+            let toml = format!("[tool.prose]\ntarget-version = \"{version}\"\n");
+            let config = Config::from_pyproject_str(&toml).expect("parses");
+
+            assert_eq!(config.target_version, Some(version));
+        }
+    }
+
+    #[test]
+    fn target_version_explicit_value_takes_effect() {
+        let config = Config::from_pyproject_str("[tool.prose]\ntarget-version = \"3.14\"\n")
+            .expect("parses");
+
+        assert_eq!(config.target_version, Some(PythonVersion::PY314));
+    }
+
+    #[test]
+    fn target_version_invalid_value_returns_toml_error() {
+        assert_toml_error("[tool.prose]\ntarget-version = \"py310\"\n");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,6 +409,20 @@ mod tests {
     }
 
     #[test]
+    fn target_version_accepts_unrecognized_minor() {
+        let config = Config::from_pyproject_str("[tool.prose]\ntarget-version = \"3.99\"\n")
+            .expect("parses");
+
+        assert_eq!(
+            config.target_version,
+            Some(PythonVersion {
+                major: 3,
+                minor: 99
+            })
+        );
+    }
+
+    #[test]
     fn target_version_defaults_to_none_when_field_absent() {
         let config = Config::from_pyproject_str("[tool.prose]\n").expect("parses");
 
@@ -426,11 +440,8 @@ mod tests {
     }
 
     #[test]
-    fn target_version_explicit_value_takes_effect() {
-        let config = Config::from_pyproject_str("[tool.prose]\ntarget-version = \"3.14\"\n")
-            .expect("parses");
-
-        assert_eq!(config.target_version, Some(PythonVersion::PY314));
+    fn target_version_extra_period_returns_toml_error() {
+        assert_toml_error("[tool.prose]\ntarget-version = \"3.14.0\"\n");
     }
 
     #[test]

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -2,6 +2,7 @@
 code-line-length = 100
 docstring-line-length = 60
 docstring-structured-policy = "docstring-line-length"
+target-version = "3.14"
 
 [tool.prose.rules.align-colons]
 enabled = false

--- a/tests/fixtures/config/target_version_only.toml
+++ b/tests/fixtures/config/target_version_only.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -51,4 +51,10 @@ Config {
             enabled: false,
         },
     },
+    target_version: Some(
+        PythonVersion {
+            major: 3,
+            minor: 14,
+        },
+    ),
 }

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -1,0 +1,60 @@
+---
+source: tests/config_parsing.rs
+expression: config
+input_file: tests/fixtures/config/target_version_only.toml
+---
+Config {
+    code_line_length: Some(
+        88,
+    ),
+    docstring_line_length: Some(
+        76,
+    ),
+    docstring_structured_policy: CodeLineLength,
+    rules: RuleConfigs {
+        collection_layout: CollectionLayoutConfig {
+            enabled: true,
+            max_atomics_per_line: Some(
+                8,
+            ),
+        },
+        alphabetize: ToggleOnly {
+            enabled: true,
+        },
+        strip_trailing_commas: ToggleOnly {
+            enabled: true,
+        },
+        blank_lines: ToggleOnly {
+            enabled: true,
+        },
+        match_case_align: AlignmentConfig {
+            enabled: true,
+            max_shift: 8,
+            max_shift_policy: Split,
+        },
+        align_imports: AlignmentConfig {
+            enabled: true,
+            max_shift: 8,
+            max_shift_policy: Split,
+        },
+        align_colons: AlignmentConfig {
+            enabled: true,
+            max_shift: 8,
+            max_shift_policy: Split,
+        },
+        align_equals: AlignmentConfig {
+            enabled: true,
+            max_shift: 8,
+            max_shift_policy: Split,
+        },
+        singleton_rule: ToggleOnly {
+            enabled: true,
+        },
+    },
+    target_version: Some(
+        PythonVersion {
+            major: 3,
+            minor: 10,
+        },
+    ),
+}


### PR DESCRIPTION
### 🪻 Quick Summary

Adds `target_version: Option<PythonVersion>` to `Config`, reviving the `0.1.x` field that issue #16 dropped as unused. The field returns ahead of the auto-fix wave landing later in `0.2`, because the upcoming `unused-future-annotations` (*#62*) and `legacy-union-syntax` (*#68*) rules both gate their safety on the consumer's target Python version. The shape reuses `ruff_python_ast::PythonVersion` directly, so the kebab-case `target-version = "3.14"` serde path inherits the upstream `FromStr` impl's parsing and rejection rules without a hand-rolled validator.

`None` means "no version gate." Consumer rules treat the absent value as the cue to skip every version-dependent arm rather than assume any specific default, leaving `Config::default()` safe for projects that have not declared a target version. The first consumers arrive with #62 and #68.

---

### 🗞️ Key Changes

- Adds `target_version: Option<PythonVersion>` to `Config` (*kebab-case `target-version`, default `None`*), reusing `ruff_python_ast::PythonVersion` through the already-enabled `serde` feature for free deserialization

- Documents the field in the `README.md` config-table row and paragraph alongside `code-line-length` and `docstring-line-length`, framing `None` as the cue to skip every version-dependent arm

- Covers the spec's four-scenario shape with inline tests for default (*field absent resolves to `None`*), invalid value rejection (*`"py310"`*), and round-trip through every `PythonVersion::iter()` variant including `PY314`

- Pins the existing `tests/fixtures/config/full_override.toml` and its snapshot with `target-version = "3.14"`, anchoring the explicit-version assertion alongside the rest of the composed config

- Adds `tests/fixtures/config/target_version_only.toml` and its snapshot, isolating `target-version = "3.10"` against the full default `Config` debug repr so a regression on any other field surfaces alongside the new one

- Probes the upstream `FromStr` recovery paths via two boundary tests, accepting an unrecognized `"3.99"` minor and rejecting an extra-period `"3.14.0"` with a TOML deserialization error

---

### 🧵 Related Issues

- Closes #82