### PR TITLE
[64] Implement multi-line-docstring formatting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ When two outcomes apply to the same run, the higher number wins. `prose --help` 
 | `blank-lines` | Module-level `def` and `class` carry 2 blank lines before them, methods inside a class body carry 1, and a module-level statement after `if __name__ == "__main__":` carries 1 |
 | `collection-layout` | Expands `dict`, `list`, and `set` literals to one entry per line, even when they fit inline |
 | `match-case-align` | Single-expression case bodies |
+| `multi-line-docstrings` | Multi-line docstring placement, with opener and closer each on their own line |
+| `no-single-line-docstrings` | Single-line triple-quoted docstrings, expanded into the canonical multi-line shape |
 | `singleton-rule` | Skips colon padding when only one item exists in the aligned group |
 | `strip-trailing-commas` | Multi-line collections and signatures |
 
@@ -204,7 +206,7 @@ Docstrings carry two readings inside one triple-quoted region. Description prose
 
 `target-version` names the Python runtime a project ships to, taking the bare `major.minor` form (*`"3.13"`, `"3.14"`*) used by `mypy`'s `python_version` setting. Rules whose safety depends on the runtime read this field directly, treating an unset value as the cue to skip every version-dependent arm rather than assume a default. The first consumers arrive with the auto-fix wave landing later in `0.2`.
 
-**Alignment rules** are `align-colons`, `align-equals`, `align-imports`, and `match-case-align`. **Toggle-only rules** are `alphabetize`, `singleton-rule`, and `strip-trailing-commas`.
+**Alignment rules** are `align-colons`, `align-equals`, `align-imports`, and `match-case-align`. **Toggle-only rules** are `alphabetize`, `blank-lines`, `multi-line-docstrings`, `no-single-line-docstrings`, `singleton-rule`, and `strip-trailing-commas`.
 
 Per-invocation overrides via `--select` and `--ignore` (*see [Install & Usage](#-install--usage) above*) take precedence over the configured-enabled set.
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -346,7 +346,7 @@ mod tests {
     fn with_defaults_registers_enabled_rules() {
         let config = Config::default();
         let pipeline = Pipeline::with_defaults(&config);
-        assert_eq!(pipeline.len(), 9);
+        assert_eq!(pipeline.len(), Pipeline::known_ids().len());
     }
 
     #[test]
@@ -359,6 +359,8 @@ mod tests {
         config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
         config.rules.match_case_align.enabled = false;
+        config.rules.multi_line_docstrings.enabled = false;
+        config.rules.no_single_line_docstrings.enabled = false;
         config.rules.singleton_rule.enabled = false;
         config.rules.strip_trailing_commas.enabled = false;
         let pipeline = Pipeline::with_defaults(&config);
@@ -373,7 +375,7 @@ mod tests {
             &[RuleId::from("align-equals"), RuleId::from("alphabetize")],
         );
         let slugs = registered_slugs(&pipeline);
-        assert_eq!(slugs.len(), 7);
+        assert_eq!(slugs.len(), Pipeline::known_ids().len() - 2);
         assert!(!slugs.contains(&"align-equals"));
         assert!(!slugs.contains(&"alphabetize"));
     }

--- a/src/primitives/docstring.rs
+++ b/src/primitives/docstring.rs
@@ -1,0 +1,200 @@
+//! Shared walker for PEP 257 docstring statements, the first
+//! body-statement of the module, each class, and each function that
+//! satisfies `is_docstring_stmt`. Implementors of [`DocstringHandler`]
+//! receive every such docstring literal in source order via the
+//! trait's `walk` method. Implicitly concatenated docstring
+//! expressions are skipped, since their rewrite shape is not defined.
+
+use ruff_python_ast::helpers::is_docstring_stmt;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::{Stmt, StringFlags, StringLiteral};
+use ruff_python_trivia::{has_leading_content, leading_indentation};
+use ruff_source_file::LineRanges;
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::source::Source;
+
+/// Body slice between a triple-quoted docstring's opener and closer,
+/// paired with the source range that slice covers.
+pub(crate) struct DocstringBody<'a> {
+    pub(crate) range: TextRange,
+    pub(crate) text: &'a str,
+}
+
+/// Receiver for the docstring walker. Implementors handle each
+/// docstring `StringLiteral` reached in source order. Call `walk`
+/// to drive the receiver across `source`'s module body.
+pub(crate) trait DocstringHandler {
+    fn handle(&mut self, lit: &StringLiteral);
+
+    fn walk(&mut self, source: &Source)
+    where
+        Self: Sized,
+    {
+        let mut visitor = Visitor { handler: self };
+        let body = &source.ast().body;
+        visitor.consider(body);
+        visitor.visit_body(body);
+    }
+}
+
+struct Visitor<'a, H: DocstringHandler + ?Sized> {
+    handler: &'a mut H,
+}
+
+impl<H: DocstringHandler + ?Sized> Visitor<'_, H> {
+    fn consider(&mut self, body: &[Stmt]) {
+        let docstring = body
+            .first()
+            .filter(|s| is_docstring_stmt(s))
+            .and_then(|s| s.as_expr_stmt())
+            .and_then(|e| e.value.as_string_literal_expr())
+            .filter(|v| !v.value.is_implicit_concatenated())
+            .and_then(|v| v.value.iter().next());
+        if let Some(lit) = docstring {
+            self.handler.handle(lit);
+        }
+    }
+}
+
+impl<'a, H: DocstringHandler + ?Sized> StatementVisitor<'a> for Visitor<'_, H> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::ClassDef(c) => self.consider(&c.body),
+            Stmt::FunctionDef(f) => self.consider(&f.body),
+            _ => {}
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+/// Returns the line indent prefix of the docstring at `lit.start()`,
+/// preserving the source's mix of tabs and spaces verbatim.
+pub(crate) fn indent_prefix<'a>(source: &'a Source, lit: &StringLiteral) -> &'a str {
+    leading_indentation(source.text().line_str(lit.start()))
+}
+
+/// Returns the body slice and source range when `lit` is triple-quoted
+/// and sits at the start of its own line. Returns `None` for
+/// non-triple-quoted literals and for inline `def f(): """..."""`
+/// shapes, where the rewrite shape is not defined.
+pub(crate) fn triple_quoted_body<'a>(
+    source: &'a Source,
+    lit: &StringLiteral,
+) -> Option<DocstringBody<'a>> {
+    if !lit.flags.is_triple_quoted() || has_leading_content(lit.start(), source.text()) {
+        return None;
+    }
+    let range = TextRange::new(
+        lit.start() + lit.flags.opener_len(),
+        lit.end() - lit.flags.closer_len(),
+    );
+    Some(DocstringBody {
+        range,
+        text: source.slice(range),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::parse;
+
+    #[derive(Default)]
+    struct Probe<'a> {
+        source: Option<&'a Source>,
+        values: Vec<String>,
+        bodies: Vec<String>,
+        indents: Vec<String>,
+    }
+
+    impl Probe<'_> {
+        fn run(source: &Source) -> Vec<String> {
+            let mut probe = Probe::default();
+            probe.walk(source);
+            probe.values
+        }
+    }
+
+    impl DocstringHandler for Probe<'_> {
+        fn handle(&mut self, lit: &StringLiteral) {
+            self.values.push(lit.value.to_string());
+            if let Some(source) = self.source {
+                self.indents.push(indent_prefix(source, lit).to_owned());
+                self.bodies
+                    .extend(triple_quoted_body(source, lit).map(|b| b.text.to_owned()));
+            }
+        }
+    }
+
+    fn probe_with_source(source: &Source) -> Probe<'_> {
+        let mut probe = Probe {
+            source: Some(source),
+            ..Probe::default()
+        };
+        probe.walk(source);
+        probe
+    }
+
+    #[test]
+    fn collects_class_function_and_method_docstrings_in_source_order() {
+        let s = parse(
+            "\"\"\"M\"\"\"\nclass C:\n    \"\"\"C\"\"\"\n    def m(self):\n        \"\"\"m\"\"\"\n        pass\n",
+        );
+        assert_eq!(Probe::run(&s), ["M", "C", "m"]);
+    }
+
+    #[test]
+    fn collects_nested_function_docstrings() {
+        let s = parse(
+            "def outer():\n    \"\"\"o\"\"\"\n    def inner():\n        \"\"\"i\"\"\"\n        pass\n",
+        );
+        assert_eq!(Probe::run(&s), ["o", "i"]);
+    }
+
+    #[test]
+    fn indent_prefix_preserves_source_indent_characters() {
+        let s = parse("class C:\n\t\"\"\"doc\"\"\"\n\tpass\n");
+        let probe = probe_with_source(&s);
+        assert_eq!(probe.indents, ["\t"]);
+    }
+
+    #[test]
+    fn returns_empty_for_module_with_no_docstrings() {
+        let s = parse("x = 1\ndef f():\n    return 1\n");
+        assert!(Probe::run(&s).is_empty());
+    }
+
+    #[test]
+    fn skips_implicitly_concatenated_docstring_expressions() {
+        let s = parse("\"\"\"a\"\"\" \"\"\"b\"\"\"\n");
+        assert!(Probe::run(&s).is_empty());
+    }
+
+    #[test]
+    fn skips_string_expression_that_is_not_first_statement() {
+        let s = parse("x = 1\n\"not a docstring\"\n");
+        assert!(Probe::run(&s).is_empty());
+    }
+
+    #[test]
+    fn triple_quoted_body_extracts_inner_body_text() {
+        let s = parse("'''hello'''\n");
+        let probe = probe_with_source(&s);
+        assert_eq!(probe.bodies, ["hello"]);
+    }
+
+    #[test]
+    fn triple_quoted_body_rejects_inline_with_def() {
+        let s = parse("def f(): \"\"\"doc\"\"\"\n");
+        let probe = probe_with_source(&s);
+        assert!(probe.bodies.is_empty());
+    }
+
+    #[test]
+    fn triple_quoted_body_rejects_non_triple_quoted_literal() {
+        let s = parse("\"hello\"\n");
+        let probe = probe_with_source(&s);
+        assert!(probe.bodies.is_empty());
+    }
+}

--- a/src/primitives/docstring.rs
+++ b/src/primitives/docstring.rs
@@ -1,13 +1,12 @@
 //! Shared walker for PEP 257 docstring statements, the first
 //! body-statement of the module, each class, and each function that
-//! satisfies `is_docstring_stmt`. Implementors of [`DocstringHandler`]
-//! receive every such docstring literal in source order via the
-//! trait's `walk` method. Implicitly concatenated docstring
-//! expressions are skipped, since their rewrite shape is not defined.
+//! holds a string literal as its first expression statement.
+//! Implementors of [`DocstringHandler`] receive every such docstring
+//! literal in source order via the trait's `walk` method. Implicitly
+//! concatenated docstring expressions are skipped.
 
-use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
-use ruff_python_ast::{Stmt, StringFlags, StringLiteral};
+use ruff_python_ast::{ExprStringLiteral, Stmt, StringFlags, StringLiteral};
 use ruff_python_trivia::{has_leading_content, leading_indentation};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
@@ -38,26 +37,24 @@ pub(crate) trait DocstringHandler {
     }
 }
 
-struct Visitor<'a, H: DocstringHandler + ?Sized> {
+struct Visitor<'a, H: DocstringHandler> {
     handler: &'a mut H,
 }
 
-impl<H: DocstringHandler + ?Sized> Visitor<'_, H> {
+impl<H: DocstringHandler> Visitor<'_, H> {
     fn consider(&mut self, body: &[Stmt]) {
         let docstring = body
             .first()
-            .filter(|s| is_docstring_stmt(s))
-            .and_then(|s| s.as_expr_stmt())
+            .and_then(Stmt::as_expr_stmt)
             .and_then(|e| e.value.as_string_literal_expr())
-            .filter(|v| !v.value.is_implicit_concatenated())
-            .and_then(|v| v.value.iter().next());
+            .and_then(ExprStringLiteral::as_single_part_string);
         if let Some(lit) = docstring {
             self.handler.handle(lit);
         }
     }
 }
 
-impl<'a, H: DocstringHandler + ?Sized> StatementVisitor<'a> for Visitor<'_, H> {
+impl<'a, H: DocstringHandler> StatementVisitor<'a> for Visitor<'_, H> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::ClassDef(c) => self.consider(&c.body),
@@ -76,8 +73,7 @@ pub(crate) fn indent_prefix<'a>(source: &'a Source, lit: &StringLiteral) -> &'a 
 
 /// Returns the body slice and source range when `lit` is triple-quoted
 /// and sits at the start of its own line. Returns `None` for
-/// non-triple-quoted literals and for inline `def f(): """..."""`
-/// shapes, where the rewrite shape is not defined.
+/// non-triple-quoted literals and inline `def f(): """..."""` shapes.
 pub(crate) fn triple_quoted_body<'a>(
     source: &'a Source,
     lit: &StringLiteral,

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,12 +1,15 @@
 //! Shared primitives used across rule implementations. `aligner`
 //! emits alignment edits for groups sharing a token. `colon_targets`
 //! constructs alignment members at every `:` context the alignment
-//! and singleton rules consume. `edit` shapes replacement text into
-//! minimal-range edits and folds inline edits into source slices.
-//! `orderer` reorders sibling AST nodes by a key function while
-//! preserving attached comments and inter-section content.
+//! and singleton rules consume. `docstring` collects every PEP 257
+//! docstring `StringLiteral` reachable from the module body. `edit`
+//! shapes replacement text into minimal-range edits and folds inline
+//! edits into source slices. `orderer` reorders sibling AST nodes by
+//! a key function while preserving attached comments and inter-section
+//! content.
 
 pub(crate) mod aligner;
 pub(crate) mod colon_targets;
+pub(crate) mod docstring;
 pub(crate) mod edit;
 pub(crate) mod orderer;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -23,6 +23,8 @@ use crate::rules::alphabetize::Alphabetize;
 use crate::rules::blank_lines::BlankLines;
 use crate::rules::collection_layout::CollectionLayout;
 use crate::rules::match_case_align::MatchCaseAlign;
+use crate::rules::multi_line_docstrings::MultiLineDocstrings;
+use crate::rules::no_single_line_docstrings::NoSingleLineDocstrings;
 use crate::rules::singleton_rule::SingletonRule;
 use crate::rules::strip_trailing_commas::StripTrailingCommas;
 use crate::source::Source;
@@ -192,15 +194,17 @@ macro_rules! register_rules {
 }
 
 register_rules! {
-    collection_layout:     CollectionLayoutConfig => CollectionLayout    => "expand collection to one entry per line",
-    alphabetize:           ToggleOnly             => Alphabetize         => "alphabetize this group",
-    strip_trailing_commas: ToggleOnly             => StripTrailingCommas => "strip trailing comma",
-    blank_lines:           ToggleOnly             => BlankLines          => "normalize blank-line spacing",
-    match_case_align:      AlignmentConfig        => MatchCaseAlign      => "align match-case arrows",
-    align_imports:         AlignmentConfig        => AlignImports        => "align consecutive `import`s",
-    align_colons:          AlignmentConfig        => AlignColons         => "align consecutive `:` separators",
-    align_equals:          AlignmentConfig        => AlignEquals         => "align consecutive `=` operators",
-    singleton_rule:        ToggleOnly             => SingletonRule       => "drop padding from singleton group",
+    collection_layout:          CollectionLayoutConfig => CollectionLayout      => "expand collection to one entry per line",
+    alphabetize:                ToggleOnly             => Alphabetize           => "alphabetize this group",
+    strip_trailing_commas:      ToggleOnly             => StripTrailingCommas   => "strip trailing comma",
+    no_single_line_docstrings:  ToggleOnly             => NoSingleLineDocstrings => "expand single-line docstring to multi-line form",
+    multi_line_docstrings:      ToggleOnly             => MultiLineDocstrings   => "place docstring opener and closer on their own lines",
+    blank_lines:                ToggleOnly             => BlankLines            => "normalize blank-line spacing",
+    match_case_align:           AlignmentConfig        => MatchCaseAlign        => "align match-case arrows",
+    align_imports:              AlignmentConfig        => AlignImports          => "align consecutive `import`s",
+    align_colons:               AlignmentConfig        => AlignColons           => "align consecutive `:` separators",
+    align_equals:               AlignmentConfig        => AlignEquals           => "align consecutive `=` operators",
+    singleton_rule:             ToggleOnly             => SingletonRule         => "drop padding from singleton group",
 }
 
 #[cfg(test)]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -10,5 +10,7 @@ pub(crate) mod alphabetize;
 pub(crate) mod blank_lines;
 pub(crate) mod collection_layout;
 pub(crate) mod match_case_align;
+pub(crate) mod multi_line_docstrings;
+pub(crate) mod no_single_line_docstrings;
 pub(crate) mod singleton_rule;
 pub(crate) mod strip_trailing_commas;

--- a/src/rules/multi_line_docstrings.rs
+++ b/src/rules/multi_line_docstrings.rs
@@ -1,0 +1,116 @@
+//! Enforces the canonical multi-line docstring shape: opening `"""`
+//! on its own line, body content, closing `"""` on its own line at
+//! the docstring's indent. Detects two violations and rewrites both
+//! with a single edit. Body content is preserved verbatim. Single-line
+//! docstrings belong to the companion rule `no-single-line-docstrings`
+//! and pass through this rule untouched.
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::StringLiteral;
+use ruff_python_trivia::has_leading_content;
+
+use crate::config::Config;
+use crate::primitives::docstring::{indent_prefix, triple_quoted_body, DocstringHandler};
+use crate::primitives::edit::narrowed_replacement;
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+pub(crate) struct MultiLineDocstrings;
+
+impl MultiLineDocstrings {
+    pub(crate) fn from_config(_: &Config) -> Self {
+        Self
+    }
+}
+
+impl Rule for MultiLineDocstrings {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let mut rewriter = Rewriter {
+            edits: Vec::new(),
+            source,
+        };
+        rewriter.walk(source);
+        rewriter.edits
+    }
+
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(MultiLineDocstrings))
+    }
+}
+
+struct Rewriter<'a> {
+    edits: Vec<Edit>,
+    source: &'a Source,
+}
+
+impl DocstringHandler for Rewriter<'_> {
+    fn handle(&mut self, lit: &StringLiteral) {
+        let Some(body) = triple_quoted_body(self.source, lit) else {
+            return;
+        };
+        if !body.text.contains('\n') {
+            return;
+        }
+        let leading_ok = body.text.starts_with('\n') || body.text.starts_with('\r');
+        let trailing_ok = !has_leading_content(body.range.end(), self.source.text());
+        if leading_ok && trailing_ok {
+            return;
+        }
+        let indent = indent_prefix(self.source, lit);
+        let newline = self.source.newline_str();
+        let mut new_body =
+            String::with_capacity(body.text.len() + (newline.len() + indent.len()) * 2);
+        if !leading_ok {
+            new_body.push_str(newline);
+            new_body.push_str(indent);
+        }
+        new_body.push_str(body.text);
+        if !trailing_ok {
+            new_body.push_str(newline);
+            new_body.push_str(indent);
+        }
+        self.edits
+            .extend(narrowed_replacement(self.source, body.range, new_body));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::Pipeline;
+    use crate::test_support::parse;
+
+    fn run(src: &str) -> String {
+        let source = parse(src);
+        let pipeline = Pipeline::for_rule("multi-line-docstrings", &Config::default())
+            .expect("rule registered");
+        pipeline
+            .run(source)
+            .expect("pipeline runs")
+            .0
+            .text()
+            .to_owned()
+    }
+
+    #[test]
+    fn preserves_body_content_verbatim_including_inner_whitespace() {
+        assert_eq!(
+            run("def f():\n    \"\"\"  Summary.\n        indented\n    \"\"\"\n"),
+            "def f():\n    \"\"\"\n      Summary.\n        indented\n    \"\"\"\n",
+        );
+    }
+
+    #[test]
+    fn single_line_docstring_is_left_alone() {
+        let src = "def f():\n    \"\"\"Summary.\"\"\"\n";
+        assert_eq!(run(src), src);
+    }
+
+    #[test]
+    fn triple_single_quoted_multi_line_normalizes_under_its_own_quote_style() {
+        assert_eq!(
+            run("def f():\n    '''Summary.\n    Trailing.\n    '''\n"),
+            "def f():\n    '''\n    Summary.\n    Trailing.\n    '''\n",
+        );
+    }
+}

--- a/src/rules/multi_line_docstrings.rs
+++ b/src/rules/multi_line_docstrings.rs
@@ -51,24 +51,17 @@ impl DocstringHandler for Rewriter<'_> {
         if !body.text.contains('\n') {
             return;
         }
-        let leading_ok = body.text.starts_with('\n') || body.text.starts_with('\r');
+        let leading_ok = body.text.starts_with(['\n', '\r']);
         let trailing_ok = !has_leading_content(body.range.end(), self.source.text());
         if leading_ok && trailing_ok {
             return;
         }
         let indent = indent_prefix(self.source, lit);
         let newline = self.source.newline_str();
-        let mut new_body =
-            String::with_capacity(body.text.len() + (newline.len() + indent.len()) * 2);
-        if !leading_ok {
-            new_body.push_str(newline);
-            new_body.push_str(indent);
-        }
-        new_body.push_str(body.text);
-        if !trailing_ok {
-            new_body.push_str(newline);
-            new_body.push_str(indent);
-        }
+        let pad = format!("{newline}{indent}");
+        let leading = if leading_ok { "" } else { pad.as_str() };
+        let trailing = if trailing_ok { "" } else { pad.as_str() };
+        let new_body = format!("{leading}{}{trailing}", body.text);
         self.edits
             .extend(narrowed_replacement(self.source, body.range, new_body));
     }

--- a/src/rules/no_single_line_docstrings.rs
+++ b/src/rules/no_single_line_docstrings.rs
@@ -1,0 +1,122 @@
+//! Rewrites a single-line triple-quoted docstring into the canonical
+//! multi-line shape: opening `"""` on its own line, trimmed body on
+//! its own line at the docstring's indent, closing `"""` on its own
+//! line. Skips non-triple-quoted strings, inline `def f(): """..."""`
+//! shapes, and bodies that trim to empty. The companion rule
+//! `multi-line-docstrings` enforces the multi-line layout produced
+//! here on every already-multi-line docstring.
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::StringLiteral;
+use ruff_python_trivia::PythonWhitespace;
+
+use crate::config::Config;
+use crate::primitives::docstring::{indent_prefix, triple_quoted_body, DocstringHandler};
+use crate::primitives::edit::narrowed_replacement;
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+pub(crate) struct NoSingleLineDocstrings;
+
+impl NoSingleLineDocstrings {
+    pub(crate) fn from_config(_: &Config) -> Self {
+        Self
+    }
+}
+
+impl Rule for NoSingleLineDocstrings {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let mut rewriter = Rewriter {
+            edits: Vec::new(),
+            source,
+        };
+        rewriter.walk(source);
+        rewriter.edits
+    }
+
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(NoSingleLineDocstrings))
+    }
+}
+
+struct Rewriter<'a> {
+    edits: Vec<Edit>,
+    source: &'a Source,
+}
+
+impl DocstringHandler for Rewriter<'_> {
+    fn handle(&mut self, lit: &StringLiteral) {
+        let Some(body) = triple_quoted_body(self.source, lit) else {
+            return;
+        };
+        if body.text.contains('\n') {
+            return;
+        }
+        let trimmed = body.text.trim_whitespace();
+        if trimmed.is_empty() {
+            return;
+        }
+        let indent = indent_prefix(self.source, lit);
+        let newline = self.source.newline_str();
+        let candidate = format!("{newline}{indent}{trimmed}{newline}{indent}");
+        self.edits
+            .extend(narrowed_replacement(self.source, body.range, candidate));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::Pipeline;
+    use crate::test_support::parse;
+
+    fn run(src: &str) -> String {
+        let source = parse(src);
+        let pipeline = Pipeline::for_rule("no-single-line-docstrings", &Config::default())
+            .expect("rule registered");
+        pipeline
+            .run(source)
+            .expect("pipeline runs")
+            .0
+            .text()
+            .to_owned()
+    }
+
+    #[test]
+    fn disabled_via_config_leaves_single_line_docstring_intact() {
+        let mut config = Config::default();
+        config.rules.no_single_line_docstrings.enabled = false;
+        let pipeline = Pipeline::with_defaults(&config);
+        let source = parse("def f():\n    \"\"\"doc\"\"\"\n");
+        let (out, _) = pipeline.run(source).expect("pipeline runs");
+        assert_eq!(out.text(), "def f():\n    \"\"\"doc\"\"\"\n");
+    }
+
+    #[test]
+    fn empty_body_after_trim_is_left_alone() {
+        let src = "def f():\n    \"\"\"   \"\"\"\n";
+        assert_eq!(run(src), src);
+    }
+
+    #[test]
+    fn non_triple_quoted_single_line_is_left_alone() {
+        let src = "def f():\n    \"summary\"\n";
+        assert_eq!(run(src), src);
+    }
+
+    #[test]
+    fn preserves_triple_single_quotes_in_rewrite() {
+        assert_eq!(
+            run("def f():\n    '''doc'''\n"),
+            "def f():\n    '''\n    doc\n    '''\n",
+        );
+    }
+
+    #[test]
+    fn trims_leading_and_trailing_whitespace_from_body() {
+        assert_eq!(
+            run("def f():\n    \"\"\"  Summary.  \"\"\"\n"),
+            "def f():\n    \"\"\"\n    Summary.\n    \"\"\"\n",
+        );
+    }
+}

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -26,6 +26,12 @@ max-atomics-per-line = 3
 [tool.prose.rules.match-case-align]
 enabled = false
 
+[tool.prose.rules.multi-line-docstrings]
+enabled = false
+
+[tool.prose.rules.no-single-line-docstrings]
+enabled = false
+
 [tool.prose.rules.singleton-rule]
 enabled = false
 

--- a/tests/fixtures/multi_line_docstrings/closing_inline_body.input.py
+++ b/tests/fixtures/multi_line_docstrings/closing_inline_body.input.py
@@ -1,0 +1,12 @@
+"""
+Closing triple-quote sharing a line with the last body line moves
+to the next line at the docstring's indent, leaving the body
+content verbatim.
+"""
+
+
+def greet():
+    """
+    Summary line on its own line.
+    Trailing line touches the closer."""
+    return 1

--- a/tests/fixtures/multi_line_docstrings/idempotent_multi.input.py
+++ b/tests/fixtures/multi_line_docstrings/idempotent_multi.input.py
@@ -1,0 +1,14 @@
+"""
+Already-canonical multi-line docstring with opener and closer each
+on their own line passes through unchanged. The rule fires only
+when one of the two boundaries shares a line with body content.
+"""
+
+
+def greet():
+    """
+    Summary line.
+
+    More detail across additional body lines.
+    """
+    return 1

--- a/tests/fixtures/multi_line_docstrings/opening_inline_body.input.py
+++ b/tests/fixtures/multi_line_docstrings/opening_inline_body.input.py
@@ -1,0 +1,12 @@
+"""
+Body content that starts on the opening line moves to the next line
+at the docstring's indent, leaving the opening triple-quote alone on
+its own line.
+"""
+
+
+def greet():
+    """Summary line starts inline with the opener.
+    Trailing line sits at the docstring's indent.
+    """
+    return 1

--- a/tests/fixtures/no_single_line_docstrings/class_docstring.input.py
+++ b/tests/fixtures/no_single_line_docstrings/class_docstring.input.py
@@ -1,0 +1,11 @@
+"""
+Class-level single-line docstring expands with the class-body indent,
+so the body line sits where any other class-scope statement would.
+"""
+
+
+class Bag:
+    """A simple bag."""
+
+    def __init__(self):
+        self.items = []

--- a/tests/fixtures/no_single_line_docstrings/method_docstring.input.py
+++ b/tests/fixtures/no_single_line_docstrings/method_docstring.input.py
@@ -1,0 +1,10 @@
+"""
+Method-level single-line docstring expands with the method-body
+indent, two indent steps deeper than the module column.
+"""
+
+
+class Bag:
+    def empty(self):
+        """Return whether the bag is empty."""
+        return not self.items

--- a/tests/fixtures/no_single_line_docstrings/module_docstring.input.py
+++ b/tests/fixtures/no_single_line_docstrings/module_docstring.input.py
@@ -1,0 +1,10 @@
+# This fixture pins module-level single-line docstring rewriting at
+# column 0. The fixture's module docstring is itself the rewrite
+# target, so the conventional triple-quoted claim-banner is replaced
+# by these `#` comments.
+
+
+"""Module summary on a single line."""
+
+
+x = 1

--- a/tests/fixtures/no_single_line_docstrings/nested_def_docstrings.input.py
+++ b/tests/fixtures/no_single_line_docstrings/nested_def_docstrings.input.py
@@ -1,0 +1,14 @@
+"""
+Nested function defs each carry their own docstring, and the
+rewrite fires at every level independently.
+"""
+
+
+def outer():
+    """Outer docstring."""
+
+    def inner():
+        """Inner docstring."""
+        return 1
+
+    return inner()

--- a/tests/fixtures/no_single_line_docstrings/single_to_multi.input.py
+++ b/tests/fixtures/no_single_line_docstrings/single_to_multi.input.py
@@ -1,0 +1,10 @@
+"""
+Single-line function docstring expands to the canonical three-line
+multi-line form, with opener on its own line, trimmed body on its
+own line at the def's indent, and closer on its own line.
+"""
+
+
+def greet():
+    """Hello, world."""
+    return 1

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -24,6 +24,12 @@ Config {
         strip_trailing_commas: ToggleOnly {
             enabled: false,
         },
+        no_single_line_docstrings: ToggleOnly {
+            enabled: false,
+        },
+        multi_line_docstrings: ToggleOnly {
+            enabled: false,
+        },
         blank_lines: ToggleOnly {
             enabled: false,
         },

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -24,6 +24,12 @@ Config {
         strip_trailing_commas: ToggleOnly {
             enabled: true,
         },
+        no_single_line_docstrings: ToggleOnly {
+            enabled: true,
+        },
+        multi_line_docstrings: ToggleOnly {
+            enabled: true,
+        },
         blank_lines: ToggleOnly {
             enabled: true,
         },

--- a/tests/snapshots/multi_line_docstrings/closing_inline_body.input.py.snap
+++ b/tests/snapshots/multi_line_docstrings/closing_inline_body.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/multi_line_docstrings/closing_inline_body.input.py
+---
+"""
+Closing triple-quote sharing a line with the last body line moves
+to the next line at the docstring's indent, leaving the body
+content verbatim.
+"""
+
+
+def greet():
+    """
+    Summary line on its own line.
+    Trailing line touches the closer.
+    """
+    return 1

--- a/tests/snapshots/multi_line_docstrings/diagnostics.snap
+++ b/tests/snapshots/multi_line_docstrings/diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+---
+multi-line-docstrings@247..247

--- a/tests/snapshots/multi_line_docstrings/idempotent_multi.input.py.snap
+++ b/tests/snapshots/multi_line_docstrings/idempotent_multi.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/multi_line_docstrings/idempotent_multi.input.py
+---
+"""
+Already-canonical multi-line docstring with opener and closer each
+on their own line passes through unchanged. The rule fires only
+when one of the two boundaries shares a line with body content.
+"""
+
+
+def greet():
+    """
+    Summary line.
+
+    More detail across additional body lines.
+    """
+    return 1

--- a/tests/snapshots/multi_line_docstrings/opening_inline_body.input.py.snap
+++ b/tests/snapshots/multi_line_docstrings/opening_inline_body.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/multi_line_docstrings/opening_inline_body.input.py
+---
+"""
+Body content that starts on the opening line moves to the next line
+at the docstring's indent, leaving the opening triple-quote alone on
+its own line.
+"""
+
+
+def greet():
+    """
+    Summary line starts inline with the opener.
+    Trailing line sits at the docstring's indent.
+    """
+    return 1

--- a/tests/snapshots/no_single_line_docstrings/class_docstring.input.py.snap
+++ b/tests/snapshots/no_single_line_docstrings/class_docstring.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/no_single_line_docstrings/class_docstring.input.py
+---
+"""
+Class-level single-line docstring expands with the class-body indent,
+so the body line sits where any other class-scope statement would.
+"""
+
+
+class Bag:
+    """
+    A simple bag.
+    """
+
+    def __init__(self):
+        self.items = []

--- a/tests/snapshots/no_single_line_docstrings/diagnostics.snap
+++ b/tests/snapshots/no_single_line_docstrings/diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+---
+no-single-line-docstrings@165..178

--- a/tests/snapshots/no_single_line_docstrings/method_docstring.input.py.snap
+++ b/tests/snapshots/no_single_line_docstrings/method_docstring.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/no_single_line_docstrings/method_docstring.input.py
+---
+"""
+Method-level single-line docstring expands with the method-body
+indent, two indent steps deeper than the module column.
+"""
+
+
+class Bag:
+    def empty(self):
+        """
+        Return whether the bag is empty.
+        """
+        return not self.items

--- a/tests/snapshots/no_single_line_docstrings/module_docstring.input.py.snap
+++ b/tests/snapshots/no_single_line_docstrings/module_docstring.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/no_single_line_docstrings/module_docstring.input.py
+---
+# This fixture pins module-level single-line docstring rewriting at
+# column 0. The fixture's module docstring is itself the rewrite
+# target, so the conventional triple-quoted claim-banner is replaced
+# by these `#` comments.
+
+
+"""
+Module summary on a single line.
+"""
+
+
+x = 1

--- a/tests/snapshots/no_single_line_docstrings/nested_def_docstrings.input.py.snap
+++ b/tests/snapshots/no_single_line_docstrings/nested_def_docstrings.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/no_single_line_docstrings/nested_def_docstrings.input.py
+---
+"""
+Nested function defs each carry their own docstring, and the
+rewrite fires at every level independently.
+"""
+
+
+def outer():
+    """
+    Outer docstring.
+    """
+
+    def inner():
+        """
+        Inner docstring.
+        """
+        return 1
+
+    return inner()

--- a/tests/snapshots/no_single_line_docstrings/single_to_multi.input.py.snap
+++ b/tests/snapshots/no_single_line_docstrings/single_to_multi.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/no_single_line_docstrings/single_to_multi.input.py
+---
+"""
+Single-line function docstring expands to the canonical three-line
+multi-line form, with opener on its own line, trimmed body on its
+own line at the def's indent, and closer on its own line.
+"""
+
+
+def greet():
+    """
+    Hello, world.
+    """
+    return 1


### PR DESCRIPTION
### 🪻 Quick Summary

Implements two companion docstring rules driven off a shared walker. `no-single-line-docstrings` rewrites `"""Summary."""` into the canonical three-line shape with opener, trimmed body, and closer each on their own line at the docstring's source indent. `multi-line-docstrings` enforces the same opener-on-own-line / closer-on-own-line shape on every already-multi-line docstring, leaving body content verbatim. The two rules share `primitives::docstring`, a new walker that mirrors `ColonEmitter`'s shape, traversing module, class, and function bodies via `StatementVisitor` and dispatching the first body-statement string literal to a rule-specific `Rewriter`.

Both rules consume `primitives::edit::narrowed_replacement` over the docstring body range, so already-conformant boundaries pass through as no-ops without spurious churn. Triple-quoted body extraction uses `lit.flags.opener_len()` and `closer_len()` for the inner span, and inline `def f(): """..."""` shapes skip the rewrite because `ruff_python_trivia::has_leading_content` reports content before the opener. The walker chains `Stmt::as_expr_stmt`, `ExprStringLiteral::as_string_literal_expr`, and `as_single_part_string` to walk past non-docstring statements and implicit concatenations in one typed sequence.

---

### 🗞️ Key Changes

- Adds `NoSingleLineDocstrings` rewriting `"""one-line"""` into `"""\n<trimmed body>\n"""` at the docstring's own line indent, with `ruff_python_trivia::PythonWhitespace::trim_whitespace` driving the trim and empty trimmed bodies passing through

- Adds `MultiLineDocstrings` enforcing opener and closer on their own lines for every already-multi-line docstring, with the candidate text built via `format!` from a `{newline}{indent}` pad and the body slice preserved verbatim

- Introduces `primitives::docstring::DocstringHandler` trait with a `walk` default method, traversing module / class / function bodies in source order and routing the first body-statement string literal to the implementor's `handle`

- Adds `primitives::docstring::indent_prefix` and `triple_quoted_body` helpers, the first reading the docstring line's leading whitespace via `ruff_python_trivia::leading_indentation`, the second returning the body slice plus range for triple-quoted literals at the start of their own line

- Chains `Stmt::as_expr_stmt`, `ExprStringLiteral::as_string_literal_expr`, and `as_single_part_string` in the walker to skip non-docstring statements and implicit concatenations without separate filter steps

- Wires both rules into `register_rules!` as `ToggleOnly` ahead of `blank-lines` (*#61*), so single-line shape normalizes to multi-line before vertical-spacing rules consider the surrounding pair

- Adds 8 fixtures across `tests/fixtures/no_single_line_docstrings/` and `tests/fixtures/multi_line_docstrings/`, covering module / class / method docstrings, nested-def docstrings, single-to-multi conversion, opening and closing inline-body shapes, and an idempotent multi case

- Adds inline `disabled_via_config_leaves_single_line_docstring_intact` test routing through `Pipeline::with_defaults`, since the fixture harness's single-rule path bypasses the `enabled` toggle and a fixture-level `enabled = false` sidecar would read as a no-op

- Extends `tests/fixtures/config/full_override.toml` and its snapshot with the two new rule toggles, anchoring the disabled-toggle assertion alongside the rest of the composed config

- Updates the `README.md` rule table with both rules and the toggle-only sentence to list `multi-line-docstrings` and `no-single-line-docstrings` alongside the existing toggles

---

### ☕ Implementation Notes

Two implementation choices diverge from the spec's literal phrasing (*indentation read from the docstring's own source line rather than computed from `Source::line_indent_width` plus `Config::indent_width`, and the `idempotent_single_disabled` fixture landing as an inline test*) and live in [this issue comment](https://github.com/Jybbs/prose/issues/64#issuecomment-4425503123).

The `docstring-wrap` rule lands downstream in #66 and consumes the multi-line shape this PR produces.

---

### 🧵 Related Issues

- Closes #64