### PR TITLE
[69] Implement `loose-constants` rule

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,23 @@ pub enum MaxAlignShiftPolicy {
     Split,
 }
 
+/// Configuration for the `loose_constants` rule.
+#[derive(Debug, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct LooseConstantsConfig {
+    pub allow: Vec<String>,
+    pub enabled: bool,
+}
+
+impl Default for LooseConstantsConfig {
+    fn default() -> Self {
+        Self {
+            allow: Vec::new(),
+            enabled: true,
+        }
+    }
+}
+
 /// Sub-table shape for rules whose only knob is `enabled`.
 #[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -59,12 +59,14 @@ impl Pipeline {
     ///
     /// Per rule, the pipeline calls `apply`, drops edits inside any
     /// `# fmt: off` span via the `SuppressionMap`, derives one
-    /// `Severity::Format` `Diagnostic` per surviving edit, then
-    /// splices the edits into the current text and reparses for the
-    /// next rule. After the rule chain finishes, every `Severity::Lint`
-    /// diagnostic whose line carries a matching `# prose: ignore`
-    /// directive is dropped. An empty pipeline collapses to the
-    /// identity transform and returns no diagnostics.
+    /// `Severity::Format` `Diagnostic` per surviving edit, collects
+    /// the `Severity::Lint` diagnostics `Rule::lint` returned through
+    /// the same fmt-suppression filter, then splices the edits into
+    /// the current text and reparses for the next rule. After the
+    /// rule chain finishes, every `Severity::Lint` diagnostic whose
+    /// line carries a matching `# prose: ignore` directive is
+    /// dropped. An empty pipeline collapses to the identity transform
+    /// and returns no diagnostics.
     ///
     /// # Errors
     ///
@@ -80,6 +82,11 @@ impl Pipeline {
                 if suppression.has_format_suppression() {
                     edits.retain(|edit| !suppression.intersects(edit));
                 }
+                diagnostics.extend(
+                    rule.lint(&source)
+                        .into_iter()
+                        .filter(|d| !suppression.intersects(d.range)),
+                );
                 if edits.is_empty() {
                     return Ok((source, diagnostics));
                 }
@@ -358,6 +365,7 @@ mod tests {
         config.rules.alphabetize.enabled = false;
         config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
+        config.rules.loose_constants.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.multi_line_docstrings.enabled = false;
         config.rules.no_single_line_docstrings.enabled = false;
@@ -369,13 +377,10 @@ mod tests {
 
     #[test]
     fn with_filters_ignore_subtracts_from_configured_set() {
-        let pipeline = Pipeline::with_filters(
-            &Config::default(),
-            &[],
-            &[RuleId::from("align-equals"), RuleId::from("alphabetize")],
-        );
+        let ignore = [RuleId::from("align-equals"), RuleId::from("alphabetize")];
+        let pipeline = Pipeline::with_filters(&Config::default(), &[], &ignore);
         let slugs = registered_slugs(&pipeline);
-        assert_eq!(slugs.len(), Pipeline::known_ids().len() - 2);
+        assert_eq!(slugs.len(), Pipeline::known_ids().len() - ignore.len());
         assert!(!slugs.contains(&"align-equals"));
         assert!(!slugs.contains(&"alphabetize"));
     }
@@ -399,6 +404,7 @@ mod tests {
         config.rules.alphabetize.enabled = false;
         config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
+        config.rules.loose_constants.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.singleton_rule.enabled = false;
         config.rules.strip_trailing_commas.enabled = false;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -14,7 +14,10 @@ use ruff_diagnostics::Edit;
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::config::{AlignmentConfig, CollectionLayoutConfig, Config, ToggleOnly};
+use crate::config::{
+    AlignmentConfig, CollectionLayoutConfig, Config, LooseConstantsConfig, ToggleOnly,
+};
+use crate::diagnostics::Diagnostic;
 use crate::pipeline::Pipeline;
 use crate::rules::align_colons::AlignColons;
 use crate::rules::align_equals::AlignEquals;
@@ -22,6 +25,7 @@ use crate::rules::align_imports::AlignImports;
 use crate::rules::alphabetize::Alphabetize;
 use crate::rules::blank_lines::BlankLines;
 use crate::rules::collection_layout::CollectionLayout;
+use crate::rules::loose_constants::LooseConstants;
 use crate::rules::match_case_align::MatchCaseAlign;
 use crate::rules::multi_line_docstrings::MultiLineDocstrings;
 use crate::rules::no_single_line_docstrings::NoSingleLineDocstrings;
@@ -38,8 +42,9 @@ pub struct ParseRuleIdError(pub String);
 /// Every rule in Prose implements this trait and nothing more.
 ///
 /// Implementations inspect `source` and return the edits that would
-/// bring it into conformance. An empty `Vec<Edit>` means the rule has
-/// nothing to say, and the pipeline skips the reparse for that rule.
+/// bring it into conformance, the `Severity::Lint` diagnostics they
+/// surface without an edit, or both. An empty `Vec<Edit>` from
+/// `apply` skips the reparse for that rule.
 ///
 /// Rules must be `Send + Sync` so that the pipeline can run across
 /// files in parallel without moving the rule list per worker.
@@ -53,6 +58,13 @@ pub(crate) trait Rule: Send + Sync {
     /// `[tool.prose.rules]` key. Surfaces in `--select`,
     /// `# prose: ignore`, and diagnostic output.
     fn id(&self) -> RuleId;
+
+    /// Lint-only side channel emitting `Severity::Lint` diagnostics
+    /// the pipeline cannot derive from an edit. The default returns
+    /// no diagnostics, so auto-fix rules need not override.
+    fn lint(&self, _source: &Source) -> Vec<Diagnostic> {
+        Vec::new()
+    }
 
     /// One-line imperative carried as `Diagnostic.message`. Defaults
     /// to the registry-supplied string for `self.id()`.
@@ -194,17 +206,18 @@ macro_rules! register_rules {
 }
 
 register_rules! {
-    collection_layout:          CollectionLayoutConfig => CollectionLayout      => "expand collection to one entry per line",
-    alphabetize:                ToggleOnly             => Alphabetize           => "alphabetize this group",
-    strip_trailing_commas:      ToggleOnly             => StripTrailingCommas   => "strip trailing comma",
+    collection_layout:          CollectionLayoutConfig => CollectionLayout       => "expand collection to one entry per line",
+    alphabetize:                ToggleOnly             => Alphabetize            => "alphabetize this group",
+    strip_trailing_commas:      ToggleOnly             => StripTrailingCommas    => "strip trailing comma",
     no_single_line_docstrings:  ToggleOnly             => NoSingleLineDocstrings => "expand single-line docstring to multi-line form",
-    multi_line_docstrings:      ToggleOnly             => MultiLineDocstrings   => "place docstring opener and closer on their own lines",
-    blank_lines:                ToggleOnly             => BlankLines            => "normalize blank-line spacing",
-    match_case_align:           AlignmentConfig        => MatchCaseAlign        => "align match-case arrows",
-    align_imports:              AlignmentConfig        => AlignImports          => "align consecutive `import`s",
-    align_colons:               AlignmentConfig        => AlignColons           => "align consecutive `:` separators",
-    align_equals:               AlignmentConfig        => AlignEquals           => "align consecutive `=` operators",
-    singleton_rule:             ToggleOnly             => SingletonRule         => "drop padding from singleton group",
+    multi_line_docstrings:      ToggleOnly             => MultiLineDocstrings    => "place docstring opener and closer on their own lines",
+    blank_lines:                ToggleOnly             => BlankLines             => "normalize blank-line spacing",
+    match_case_align:           AlignmentConfig        => MatchCaseAlign         => "align match-case arrows",
+    align_imports:              AlignmentConfig        => AlignImports           => "align consecutive `import`s",
+    align_colons:               AlignmentConfig        => AlignColons            => "align consecutive `:` separators",
+    align_equals:               AlignmentConfig        => AlignEquals            => "align consecutive `=` operators",
+    singleton_rule:             ToggleOnly             => SingletonRule          => "drop padding from singleton group",
+    loose_constants:            LooseConstantsConfig   => LooseConstants         => "consider moving this module-level constant",
 }
 
 #[cfg(test)]

--- a/src/rules/loose_constants.rs
+++ b/src/rules/loose_constants.rs
@@ -147,20 +147,6 @@ fn is_type_checking_block(stmt: &StmtIf) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::parse;
-
-    fn rule() -> LooseConstants {
-        LooseConstants {
-            allow: HashSet::new(),
-        }
-    }
-
-    fn lint(rule: &LooseConstants, src: &str) -> Vec<String> {
-        rule.lint(&parse(src))
-            .into_iter()
-            .map(|d| d.message)
-            .collect()
-    }
 
     #[test]
     fn is_screaming_case_accepts_canonical_constants() {
@@ -174,84 +160,5 @@ mod tests {
         for id in ["", "pi", "Pi", "pI", "_HIDDEN", "1ABC", "MAX_retries"] {
             assert!(!is_screaming_case(id), "expected not screaming for {id}");
         }
-    }
-
-    #[test]
-    fn lint_flags_bare_screaming_case_assignment() {
-        let messages = lint(&rule(), "PI = 3.14\n");
-        assert_eq!(messages.len(), 1);
-        assert!(messages[0].contains("`PI`"));
-    }
-
-    #[test]
-    fn lint_flags_screaming_case_ann_assign_with_and_without_value() {
-        for src in ["X: int\n", "X: int = 1\n"] {
-            assert_eq!(lint(&rule(), src).len(), 1, "source = {src:?}");
-        }
-    }
-
-    #[test]
-    fn lint_ignores_chained_and_tuple_targets() {
-        for src in ["A = B = 1\n", "A, B = 1, 2\n", "FOO.bar = 1\n"] {
-            assert!(
-                lint(&rule(), src).is_empty(),
-                "expected silence for {src:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn lint_respects_allowlist_entries() {
-        let rule = LooseConstants {
-            allow: HashSet::from(["LOG_LEVEL".to_owned()]),
-        };
-        assert!(lint(&rule, "LOG_LEVEL = 1\n").is_empty());
-        assert_eq!(lint(&rule, "OTHER = 1\n").len(), 1);
-    }
-
-    #[test]
-    fn lint_skips_assignments_inside_a_type_checking_block() {
-        let src = "if TYPE_CHECKING:\n    PI = 3.14\n";
-        assert!(lint(&rule(), src).is_empty());
-    }
-
-    #[test]
-    fn lint_skips_assignments_inside_a_typing_dot_type_checking_block() {
-        let src = "if typing.TYPE_CHECKING:\n    PI = 3.14\n";
-        assert!(lint(&rule(), src).is_empty());
-    }
-
-    #[test]
-    fn lint_skips_dunder_assignments() {
-        for id in ["__version__", "__all__", "__author__"] {
-            let src = format!("{id} = 1\n");
-            assert!(lint(&rule(), &src).is_empty(), "source = {src:?}");
-        }
-    }
-
-    #[test]
-    fn lint_skips_function_local_screaming_case() {
-        let src = "def f():\n    PI = 3.14\n    return PI\n";
-        assert!(lint(&rule(), src).is_empty());
-    }
-
-    #[test]
-    fn lint_skips_typing_constructor_calls() {
-        for src in [
-            "T = TypeVar(\"T\")\n",
-            "P = ParamSpec(\"P\")\n",
-            "UserId = NewType(\"UserId\", int)\n",
-            "Vec = TypeAliasType(\"Vec\", list[int])\n",
-            "T = typing.TypeVar(\"T\")\n",
-        ] {
-            assert!(lint(&rule(), src).is_empty(), "source = {src:?}");
-        }
-    }
-
-    #[test]
-    fn lint_walks_into_module_level_if_branches() {
-        let src = "if sys.platform == \"win32\":\n    PI = 3.14\n";
-        let messages = lint(&rule(), src);
-        assert_eq!(messages.len(), 1, "messages = {messages:?}");
     }
 }

--- a/src/rules/loose_constants.rs
+++ b/src/rules/loose_constants.rs
@@ -1,0 +1,257 @@
+//! Flags module-level `SCREAMING_CASE` assignments outside the
+//! recognized structural-home carve-outs (dunder names, `TypeVar` /
+//! `ParamSpec` / `NewType` / `TypeAliasType` constructors, the
+//! `if TYPE_CHECKING:` block, and the per-project `allow` list).
+
+use std::collections::HashSet;
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::helpers::is_dunder;
+use ruff_python_ast::name::UnqualifiedName;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::{Expr, ExprName, Stmt, StmtIf};
+use ruff_text_size::Ranged;
+
+use crate::config::Config;
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+pub(crate) struct LooseConstants {
+    allow: HashSet<String>,
+}
+
+impl LooseConstants {
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            allow: config.rules.loose_constants.allow.iter().cloned().collect(),
+        }
+    }
+}
+
+impl Rule for LooseConstants {
+    fn apply(&self, _source: &Source) -> Vec<Edit> {
+        Vec::new()
+    }
+
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(LooseConstants))
+    }
+
+    fn lint(&self, source: &Source) -> Vec<Diagnostic> {
+        let mut walker = Walker {
+            allow: &self.allow,
+            diagnostics: Vec::new(),
+            rule: self.id(),
+        };
+        walker.visit_body(&source.ast().body);
+        walker.diagnostics
+    }
+}
+
+struct Walker<'a> {
+    allow: &'a HashSet<String>,
+    diagnostics: Vec<Diagnostic>,
+    rule: RuleId,
+}
+
+impl Walker<'_> {
+    fn emit(&mut self, stmt: &Stmt, name: &str) {
+        self.diagnostics.push(Diagnostic {
+            fix: None,
+            message: format!(
+                "module-level constant `{name}` found. \
+                 Consider an enum member, a class field, or a function-local",
+            ),
+            range: stmt.range(),
+            rule: self.rule,
+            severity: Severity::Lint,
+        });
+    }
+}
+
+impl<'a> StatementVisitor<'a> for Walker<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::FunctionDef(_) | Stmt::ClassDef(_) => return,
+            Stmt::If(if_stmt) if is_type_checking_block(if_stmt) => return,
+            Stmt::Assign(a) => {
+                if let [Expr::Name(target)] = a.targets.as_slice() {
+                    if is_loose_constant_target(target, Some(a.value.as_ref()), self.allow) {
+                        self.emit(stmt, &target.id);
+                    }
+                }
+            }
+            Stmt::AnnAssign(a) => {
+                if let Expr::Name(target) = a.target.as_ref() {
+                    if is_loose_constant_target(target, a.value.as_deref(), self.allow) {
+                        self.emit(stmt, &target.id);
+                    }
+                }
+            }
+            _ => {}
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+/// Returns `true` when `value` is a call whose callable resolves to
+/// `TypeVar`, `ParamSpec`, `NewType`, or `TypeAliasType`, either bare
+/// (*`TypeVar(...)`*) or attribute-qualified (*`typing.TypeVar(...)`*).
+fn is_typing_constructor_call(value: &Expr) -> bool {
+    let last = value
+        .as_call_expr()
+        .and_then(|call| UnqualifiedName::from_expr(&call.func))
+        .and_then(|q| q.segments().last().copied());
+    matches!(
+        last,
+        Some("NewType" | "ParamSpec" | "TypeAliasType" | "TypeVar"),
+    )
+}
+
+/// Returns `true` when `target.id` matches `SCREAMING_CASE`, is not a
+/// dunder, is not in the per-project allowlist, and (when present) the
+/// right-hand side is not a `TypeVar` / `ParamSpec` / `NewType` /
+/// `TypeAliasType` constructor. `value = None` covers the bare
+/// annotation form `X: int`.
+fn is_loose_constant_target(
+    target: &ExprName,
+    value: Option<&Expr>,
+    allow: &HashSet<String>,
+) -> bool {
+    is_screaming_case(&target.id)
+        && !is_dunder(&target.id)
+        && !allow.contains(target.id.as_str())
+        && !value.is_some_and(is_typing_constructor_call)
+}
+
+/// Returns `true` when `id` begins with an ASCII uppercase letter and
+/// every remaining character is an ASCII uppercase letter, digit, or
+/// underscore.
+fn is_screaming_case(id: &str) -> bool {
+    let mut chars = id.chars();
+    chars.next().is_some_and(|c| c.is_ascii_uppercase())
+        && chars.all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Returns `true` when `stmt.test` matches the bare `TYPE_CHECKING`
+/// name or any `<...>.TYPE_CHECKING` attribute access.
+fn is_type_checking_block(stmt: &StmtIf) -> bool {
+    match stmt.test.as_ref() {
+        Expr::Name(name) => name.id == "TYPE_CHECKING",
+        Expr::Attribute(attr) => attr.attr.as_str() == "TYPE_CHECKING",
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::parse;
+
+    fn rule() -> LooseConstants {
+        LooseConstants {
+            allow: HashSet::new(),
+        }
+    }
+
+    fn lint(rule: &LooseConstants, src: &str) -> Vec<String> {
+        rule.lint(&parse(src))
+            .into_iter()
+            .map(|d| d.message)
+            .collect()
+    }
+
+    #[test]
+    fn is_screaming_case_accepts_canonical_constants() {
+        for id in ["PI", "MAX_RETRIES", "X1", "LOG_LEVEL_2"] {
+            assert!(is_screaming_case(id), "expected screaming for {id}");
+        }
+    }
+
+    #[test]
+    fn is_screaming_case_rejects_mixed_and_lowercase_names() {
+        for id in ["", "pi", "Pi", "pI", "_HIDDEN", "1ABC", "MAX_retries"] {
+            assert!(!is_screaming_case(id), "expected not screaming for {id}");
+        }
+    }
+
+    #[test]
+    fn lint_flags_bare_screaming_case_assignment() {
+        let messages = lint(&rule(), "PI = 3.14\n");
+        assert_eq!(messages.len(), 1);
+        assert!(messages[0].contains("`PI`"));
+    }
+
+    #[test]
+    fn lint_flags_screaming_case_ann_assign_with_and_without_value() {
+        for src in ["X: int\n", "X: int = 1\n"] {
+            assert_eq!(lint(&rule(), src).len(), 1, "source = {src:?}");
+        }
+    }
+
+    #[test]
+    fn lint_ignores_chained_and_tuple_targets() {
+        for src in ["A = B = 1\n", "A, B = 1, 2\n", "FOO.bar = 1\n"] {
+            assert!(
+                lint(&rule(), src).is_empty(),
+                "expected silence for {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn lint_respects_allowlist_entries() {
+        let rule = LooseConstants {
+            allow: HashSet::from(["LOG_LEVEL".to_owned()]),
+        };
+        assert!(lint(&rule, "LOG_LEVEL = 1\n").is_empty());
+        assert_eq!(lint(&rule, "OTHER = 1\n").len(), 1);
+    }
+
+    #[test]
+    fn lint_skips_assignments_inside_a_type_checking_block() {
+        let src = "if TYPE_CHECKING:\n    PI = 3.14\n";
+        assert!(lint(&rule(), src).is_empty());
+    }
+
+    #[test]
+    fn lint_skips_assignments_inside_a_typing_dot_type_checking_block() {
+        let src = "if typing.TYPE_CHECKING:\n    PI = 3.14\n";
+        assert!(lint(&rule(), src).is_empty());
+    }
+
+    #[test]
+    fn lint_skips_dunder_assignments() {
+        for id in ["__version__", "__all__", "__author__"] {
+            let src = format!("{id} = 1\n");
+            assert!(lint(&rule(), &src).is_empty(), "source = {src:?}");
+        }
+    }
+
+    #[test]
+    fn lint_skips_function_local_screaming_case() {
+        let src = "def f():\n    PI = 3.14\n    return PI\n";
+        assert!(lint(&rule(), src).is_empty());
+    }
+
+    #[test]
+    fn lint_skips_typing_constructor_calls() {
+        for src in [
+            "T = TypeVar(\"T\")\n",
+            "P = ParamSpec(\"P\")\n",
+            "UserId = NewType(\"UserId\", int)\n",
+            "Vec = TypeAliasType(\"Vec\", list[int])\n",
+            "T = typing.TypeVar(\"T\")\n",
+        ] {
+            assert!(lint(&rule(), src).is_empty(), "source = {src:?}");
+        }
+    }
+
+    #[test]
+    fn lint_walks_into_module_level_if_branches() {
+        let src = "if sys.platform == \"win32\":\n    PI = 3.14\n";
+        let messages = lint(&rule(), src);
+        assert_eq!(messages.len(), 1, "messages = {messages:?}");
+    }
+}

--- a/src/rules/loose_constants.rs
+++ b/src/rules/loose_constants.rs
@@ -95,20 +95,6 @@ impl<'a> StatementVisitor<'a> for Walker<'a> {
     }
 }
 
-/// Returns `true` when `value` is a call whose callable resolves to
-/// `TypeVar`, `ParamSpec`, `NewType`, or `TypeAliasType`, either bare
-/// (*`TypeVar(...)`*) or attribute-qualified (*`typing.TypeVar(...)`*).
-fn is_typing_constructor_call(value: &Expr) -> bool {
-    let last = value
-        .as_call_expr()
-        .and_then(|call| UnqualifiedName::from_expr(&call.func))
-        .and_then(|q| q.segments().last().copied());
-    matches!(
-        last,
-        Some("NewType" | "ParamSpec" | "TypeAliasType" | "TypeVar"),
-    )
-}
-
 /// Returns `true` when `target.id` matches `SCREAMING_CASE`, is not a
 /// dunder, is not in the per-project allowlist, and (when present) the
 /// right-hand side is not a `TypeVar` / `ParamSpec` / `NewType` /
@@ -142,6 +128,20 @@ fn is_type_checking_block(stmt: &StmtIf) -> bool {
         Expr::Attribute(attr) => attr.attr.as_str() == "TYPE_CHECKING",
         _ => false,
     }
+}
+
+/// Returns `true` when `value` is a call whose callable resolves to
+/// `TypeVar`, `ParamSpec`, `NewType`, or `TypeAliasType`, either bare
+/// (`TypeVar(...)`) or attribute-qualified (`typing.TypeVar(...)`).
+fn is_typing_constructor_call(value: &Expr) -> bool {
+    let last = value
+        .as_call_expr()
+        .and_then(|call| UnqualifiedName::from_expr(&call.func))
+        .and_then(|q| q.segments().last().copied());
+    matches!(
+        last,
+        Some("NewType" | "ParamSpec" | "TypeAliasType" | "TypeVar"),
+    )
 }
 
 #[cfg(test)]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod align_imports;
 pub(crate) mod alphabetize;
 pub(crate) mod blank_lines;
 pub(crate) mod collection_layout;
+pub(crate) mod loose_constants;
 pub(crate) mod match_case_align;
 pub(crate) mod multi_line_docstrings;
 pub(crate) mod no_single_line_docstrings;

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -23,6 +23,10 @@ enabled = false
 enabled = false
 max-atomics-per-line = 3
 
+[tool.prose.rules.loose-constants]
+allow = ["LOG_LEVEL"]
+enabled = false
+
 [tool.prose.rules.match-case-align]
 enabled = false
 

--- a/tests/fixtures/loose_constants/ann_assign.input.py
+++ b/tests/fixtures/loose_constants/ann_assign.input.py
@@ -1,0 +1,9 @@
+"""
+A module-level annotated assignment in `SCREAMING_CASE` draws the
+diagnostic regardless of whether a value follows the annotation.
+Both `X: int` and `Y: int = 1` shapes pin the `Stmt::AnnAssign`
+code path through the pipeline.
+"""
+
+X: int
+Y: int = 1

--- a/tests/fixtures/loose_constants/basic_flag.input.py
+++ b/tests/fixtures/loose_constants/basic_flag.input.py
@@ -1,0 +1,7 @@
+"""
+A bare module-level SCREAMING_CASE assignment draws the canonical
+loose-constants diagnostic, with the message naming candidate
+structural homes for the constant.
+"""
+
+PI = 3.14

--- a/tests/fixtures/loose_constants/chained_and_tuple_targets.input.py
+++ b/tests/fixtures/loose_constants/chained_and_tuple_targets.input.py
@@ -1,0 +1,9 @@
+"""
+Chained assignment, tuple unpacking, and attribute targets all
+fall outside the `[Expr::Name(target)]` single-target shape the
+rule flags. Each line passes through silently.
+"""
+
+A = B = 1
+A, B = 1, 2
+FOO.bar = 1

--- a/tests/fixtures/loose_constants/configured_allow.config.toml
+++ b/tests/fixtures/loose_constants/configured_allow.config.toml
@@ -1,0 +1,2 @@
+[tool.prose.rules.loose-constants]
+allow = ["LOG_LEVEL", "DEFAULT_TIMEOUT"]

--- a/tests/fixtures/loose_constants/configured_allow.input.py
+++ b/tests/fixtures/loose_constants/configured_allow.input.py
@@ -1,0 +1,9 @@
+"""
+A name listed in `[tool.prose.rules.loose-constants].allow` passes
+through silently, allowing project conventions like `LOG_LEVEL` or
+`DEFAULT_TIMEOUT` to publish at the module root.
+"""
+
+LOG_LEVEL       = "INFO"
+DEFAULT_TIMEOUT = 30
+OTHER           = 1

--- a/tests/fixtures/loose_constants/dotted_type_checking.input.py
+++ b/tests/fixtures/loose_constants/dotted_type_checking.input.py
@@ -1,0 +1,10 @@
+"""
+The attribute-qualified `typing.TYPE_CHECKING` form skips the
+block exactly as the bare `TYPE_CHECKING` name does, mirroring
+how `ruff_python_semantic` handles the same two shapes.
+"""
+
+import typing
+
+if typing.TYPE_CHECKING:
+    DEFAULT_BACKEND = "memory"

--- a/tests/fixtures/loose_constants/dunder_skipped.input.py
+++ b/tests/fixtures/loose_constants/dunder_skipped.input.py
@@ -1,0 +1,8 @@
+"""
+Dunder names like `__version__`, `__all__`, and `__author__` are
+module-level by convention and pass through the rule untouched.
+"""
+
+__version__ = "0.2.0"
+__all__     = ["public"]
+__author__  = "prose"

--- a/tests/fixtures/loose_constants/fmt_off_block.input.py
+++ b/tests/fixtures/loose_constants/fmt_off_block.input.py
@@ -1,0 +1,9 @@
+"""
+A `# fmt: off` block carries the same suppression weight against
+lint diagnostics as it does against edits. The constant inside
+the block escapes the rule's emission path.
+"""
+
+# fmt: off
+PI = 3.14
+# fmt: on

--- a/tests/fixtures/loose_constants/idempotent.input.py
+++ b/tests/fixtures/loose_constants/idempotent.input.py
@@ -1,0 +1,10 @@
+"""
+The rule emits no edits, so a clean file passes through unchanged on
+every pass. This fixture pins that lint-only shape.
+"""
+
+__version__ = "0.2.0"
+
+
+def main() -> None:
+    pass

--- a/tests/fixtures/loose_constants/newtype_skipped.input.py
+++ b/tests/fixtures/loose_constants/newtype_skipped.input.py
@@ -1,0 +1,9 @@
+"""
+A `NewType("UserId", int)` assignment is SCREAMING_CASE by Python
+convention and structural by definition, so it passes through the
+rule untouched.
+"""
+
+from typing import NewType
+
+UserId = NewType("UserId", int)

--- a/tests/fixtures/loose_constants/not_module_level.input.py
+++ b/tests/fixtures/loose_constants/not_module_level.input.py
@@ -1,0 +1,9 @@
+"""
+A function-local SCREAMING_CASE assignment is not module-level, so
+the rule leaves it alone. The walker stops at `def` and `class`
+boundaries by design.
+"""
+
+def compute(radius: float) -> float:
+    PI = 3.14
+    return PI * radius * radius

--- a/tests/fixtures/loose_constants/paramspec_skipped.input.py
+++ b/tests/fixtures/loose_constants/paramspec_skipped.input.py
@@ -1,0 +1,9 @@
+"""
+A `ParamSpec("P")` assignment is SCREAMING_CASE by Python convention
+and structural by definition, so it passes through the rule
+untouched.
+"""
+
+from typing import ParamSpec
+
+P = ParamSpec("P")

--- a/tests/fixtures/loose_constants/prose_ignore_suppression.input.py
+++ b/tests/fixtures/loose_constants/prose_ignore_suppression.input.py
@@ -1,0 +1,8 @@
+"""
+A trailing `# prose: ignore[loose-constants]` directive drops the
+diagnostic the rule would otherwise emit. The post-loop lint
+filter from per-line suppression runs against `Severity::Lint`
+output by `Rule::lint`.
+"""
+
+PI = 3.14  # prose: ignore[loose-constants]

--- a/tests/fixtures/loose_constants/type_checking_block_skipped.input.py
+++ b/tests/fixtures/loose_constants/type_checking_block_skipped.input.py
@@ -1,0 +1,10 @@
+"""
+An assignment inside `if TYPE_CHECKING:` is type-system-only, so the
+file's type-checker boundary already owns it and the rule leaves it
+alone.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    DEFAULT_BACKEND = "memory"

--- a/tests/fixtures/loose_constants/typevar_skipped.input.py
+++ b/tests/fixtures/loose_constants/typevar_skipped.input.py
@@ -1,0 +1,9 @@
+"""
+A `TypeVar("T")` assignment is SCREAMING_CASE by Python convention
+and structural by definition, so it passes through the rule
+untouched.
+"""
+
+from typing import TypeVar
+
+T = TypeVar("T")

--- a/tests/fixtures/loose_constants/walks_into_if_block.input.py
+++ b/tests/fixtures/loose_constants/walks_into_if_block.input.py
@@ -1,0 +1,11 @@
+"""
+The walker descends into top-level `if` / `for` / `try` bodies
+because those preserve module scope. A `SCREAMING_CASE`
+assignment guarded by `if sys.platform == ...` is still
+module-level and draws the diagnostic.
+"""
+
+import sys
+
+if sys.platform == "win32":
+    DEFAULT_BACKEND = "memory"

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -56,6 +56,12 @@ Config {
         singleton_rule: ToggleOnly {
             enabled: false,
         },
+        loose_constants: LooseConstantsConfig {
+            allow: [
+                "LOG_LEVEL",
+            ],
+            enabled: false,
+        },
     },
     target_version: Some(
         PythonVersion {

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -56,6 +56,10 @@ Config {
         singleton_rule: ToggleOnly {
             enabled: true,
         },
+        loose_constants: LooseConstantsConfig {
+            allow: [],
+            enabled: true,
+        },
     },
     target_version: Some(
         PythonVersion {

--- a/tests/snapshots/loose_constants/ann_assign.input.py.snap
+++ b/tests/snapshots/loose_constants/ann_assign.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/ann_assign.input.py
+---
+"""
+A module-level annotated assignment in `SCREAMING_CASE` draws the
+diagnostic regardless of whether a value follows the annotation.
+Both `X: int` and `Y: int = 1` shapes pin the `Stmt::AnnAssign`
+code path through the pipeline.
+"""
+
+X: int
+Y: int = 1

--- a/tests/snapshots/loose_constants/basic_flag.input.py.snap
+++ b/tests/snapshots/loose_constants/basic_flag.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/basic_flag.input.py
+---
+"""
+A bare module-level SCREAMING_CASE assignment draws the canonical
+loose-constants diagnostic, with the message naming candidate
+structural homes for the constant.
+"""
+
+PI = 3.14

--- a/tests/snapshots/loose_constants/chained_and_tuple_targets.input.py.snap
+++ b/tests/snapshots/loose_constants/chained_and_tuple_targets.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/chained_and_tuple_targets.input.py
+---
+"""
+Chained assignment, tuple unpacking, and attribute targets all
+fall outside the `[Expr::Name(target)]` single-target shape the
+rule flags. Each line passes through silently.
+"""
+
+A = B = 1
+A, B = 1, 2
+FOO.bar = 1

--- a/tests/snapshots/loose_constants/configured_allow.input.py.snap
+++ b/tests/snapshots/loose_constants/configured_allow.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/configured_allow.input.py
+---
+"""
+A name listed in `[tool.prose.rules.loose-constants].allow` passes
+through silently, allowing project conventions like `LOG_LEVEL` or
+`DEFAULT_TIMEOUT` to publish at the module root.
+"""
+
+LOG_LEVEL       = "INFO"
+DEFAULT_TIMEOUT = 30
+OTHER           = 1

--- a/tests/snapshots/loose_constants/diagnostics.snap
+++ b/tests/snapshots/loose_constants/diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+---
+loose-constants@172..181

--- a/tests/snapshots/loose_constants/diagnostics.snap
+++ b/tests/snapshots/loose_constants/diagnostics.snap
@@ -2,4 +2,5 @@
 source: tests/diagnostics.rs
 expression: render(&diagnostics)
 ---
-loose-constants@172..181
+loose-constants@236..242
+loose-constants@243..253

--- a/tests/snapshots/loose_constants/dotted_type_checking.input.py.snap
+++ b/tests/snapshots/loose_constants/dotted_type_checking.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/dotted_type_checking.input.py
+---
+"""
+The attribute-qualified `typing.TYPE_CHECKING` form skips the
+block exactly as the bare `TYPE_CHECKING` name does, mirroring
+how `ruff_python_semantic` handles the same two shapes.
+"""
+
+import typing
+
+if typing.TYPE_CHECKING:
+    DEFAULT_BACKEND = "memory"

--- a/tests/snapshots/loose_constants/dunder_skipped.input.py.snap
+++ b/tests/snapshots/loose_constants/dunder_skipped.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/dunder_skipped.input.py
+---
+"""
+Dunder names like `__version__`, `__all__`, and `__author__` are
+module-level by convention and pass through the rule untouched.
+"""
+
+__version__ = "0.2.0"
+__all__     = ["public"]
+__author__  = "prose"

--- a/tests/snapshots/loose_constants/fmt_off_block.input.py.snap
+++ b/tests/snapshots/loose_constants/fmt_off_block.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/fmt_off_block.input.py
+---
+"""
+A `# fmt: off` block carries the same suppression weight against
+lint diagnostics as it does against edits. The constant inside
+the block escapes the rule's emission path.
+"""
+
+# fmt: off
+PI = 3.14
+# fmt: on

--- a/tests/snapshots/loose_constants/idempotent.input.py.snap
+++ b/tests/snapshots/loose_constants/idempotent.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/idempotent.input.py
+---
+"""
+The rule emits no edits, so a clean file passes through unchanged on
+every pass. This fixture pins that lint-only shape.
+"""
+
+__version__ = "0.2.0"
+
+
+def main() -> None:
+    pass

--- a/tests/snapshots/loose_constants/newtype_skipped.input.py.snap
+++ b/tests/snapshots/loose_constants/newtype_skipped.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/newtype_skipped.input.py
+---
+"""
+A `NewType("UserId", int)` assignment is SCREAMING_CASE by Python
+convention and structural by definition, so it passes through the
+rule untouched.
+"""
+
+from typing import NewType
+
+UserId = NewType("UserId", int)

--- a/tests/snapshots/loose_constants/not_module_level.input.py.snap
+++ b/tests/snapshots/loose_constants/not_module_level.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/not_module_level.input.py
+---
+"""
+A function-local SCREAMING_CASE assignment is not module-level, so
+the rule leaves it alone. The walker stops at `def` and `class`
+boundaries by design.
+"""
+
+def compute(radius: float) -> float:
+    PI = 3.14
+    return PI * radius * radius

--- a/tests/snapshots/loose_constants/paramspec_skipped.input.py.snap
+++ b/tests/snapshots/loose_constants/paramspec_skipped.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/paramspec_skipped.input.py
+---
+"""
+A `ParamSpec("P")` assignment is SCREAMING_CASE by Python convention
+and structural by definition, so it passes through the rule
+untouched.
+"""
+
+from typing import ParamSpec
+
+P = ParamSpec("P")

--- a/tests/snapshots/loose_constants/prose_ignore_suppression.input.py.snap
+++ b/tests/snapshots/loose_constants/prose_ignore_suppression.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/prose_ignore_suppression.input.py
+---
+"""
+A trailing `# prose: ignore[loose-constants]` directive drops the
+diagnostic the rule would otherwise emit. The post-loop lint
+filter from per-line suppression runs against `Severity::Lint`
+output by `Rule::lint`.
+"""
+
+PI = 3.14  # prose: ignore[loose-constants]

--- a/tests/snapshots/loose_constants/type_checking_block_skipped.input.py.snap
+++ b/tests/snapshots/loose_constants/type_checking_block_skipped.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/type_checking_block_skipped.input.py
+---
+"""
+An assignment inside `if TYPE_CHECKING:` is type-system-only, so the
+file's type-checker boundary already owns it and the rule leaves it
+alone.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    DEFAULT_BACKEND = "memory"

--- a/tests/snapshots/loose_constants/typevar_skipped.input.py.snap
+++ b/tests/snapshots/loose_constants/typevar_skipped.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/typevar_skipped.input.py
+---
+"""
+A `TypeVar("T")` assignment is SCREAMING_CASE by Python convention
+and structural by definition, so it passes through the rule
+untouched.
+"""
+
+from typing import TypeVar
+
+T = TypeVar("T")

--- a/tests/snapshots/loose_constants/walks_into_if_block.input.py.snap
+++ b/tests/snapshots/loose_constants/walks_into_if_block.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/loose_constants/walks_into_if_block.input.py
+---
+"""
+The walker descends into top-level `if` / `for` / `try` bodies
+because those preserve module scope. A `SCREAMING_CASE`
+assignment guarded by `if sys.platform == ...` is still
+module-level and draws the diagnostic.
+"""
+
+import sys
+
+if sys.platform == "win32":
+    DEFAULT_BACKEND = "memory"


### PR DESCRIPTION
### 🪻 Quick Summary

Implements `loose-constants`, *Prose*'s first lint-only rule, flagging [module-level constant](https://peps.python.org/pep-0008/#constants) assignments in `SCREAMING_CASE` that should likely move into a structural home (*an `Enum` member, a class field, or a function-local*). The rule walks module scope via `StatementVisitor`, stopping at `def` and `class` boundaries so function-locals and class fields pass through silently, while descending into `if` / `for` / `try` bodies because those still produce module-level names. Single-`Name` targets matching `^[A-Z][A-Z0-9_]*$` draw a `Severity::Lint` diagnostic with the message recommending the candidate structural homes.

Four carve-outs keep the rule's surface honest. Dunder names like `__version__` and `__all__` pass through via `ruff_python_ast::helpers::is_dunder`. `TypeVar`, `ParamSpec`, `NewType`, and `TypeAliasType` constructors pass through, with the callable resolved through `UnqualifiedName::from_expr` so both bare (`TypeVar(...)`) and attribute-qualified (`typing.TypeVar(...)`) forms hit the same skip arm. [`if TYPE_CHECKING:`](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) blocks (*and the dotted `if typing.TYPE_CHECKING:` variant*) pass through because the file's type-checker boundary already owns them. A configurable per-project `allow` list under `[tool.prose.rules.loose-constants]` accommodates names a project explicitly publishes at the module root.

Because the rule emits diagnostics rather than edits, `Rule` gains a default `lint` method returning an empty `Vec<Diagnostic>`, and `Pipeline::run` threads each rule's `Rule::lint` output through the same `# fmt: off` suppression filter the edit list passes through, before the post-loop `# prose: ignore` pass.

---

### 🗞️ Key Changes

- Adds `LooseConstants` flagging module-level `SCREAMING_CASE` `Stmt::Assign` and `Stmt::AnnAssign` targets, dispatched via a `StatementVisitor` whose `visit_stmt` returns early on `FunctionDef`, `ClassDef`, and `if TYPE_CHECKING:` blocks, descending into other compound statements via `walk_stmt`

- Resolves typing constructors through `UnqualifiedName::from_expr` against the call's `func`, matching the last segment against `"TypeVar"`, `"ParamSpec"`, `"NewType"`, `"TypeAliasType"` so the bare and attribute-qualified forms share one skip arm

- Detects `TYPE_CHECKING` blocks against the bare `Name` case and the attribute-qualified `Attribute.attr == "TYPE_CHECKING"` case, mirroring how `ruff_python_semantic::analyze::typing::is_type_checking_block` reads the same two shapes without pulling the semantic crate

- Adds `LooseConstantsConfig` with `allow: Vec<String>` (*default empty*) and `enabled: bool` (*default `true`*) under `[tool.prose.rules.loose-constants]`, with the allowlist materialized into a `HashSet<String>` at rule construction for O(1) membership lookup

- Extends the `Rule` trait with a default `fn lint(&self, _source: &Source) -> Vec<Diagnostic>` returning an empty vector, so the eight existing auto-fix rules need no override and `LooseConstants` is the sole override today

- Threads `Rule::lint` through `Pipeline::run`, collecting each rule's lint diagnostics into the run's accumulator after the fmt-suppression filter on edits and before the per-rule reparse, so the post-loop `# prose: ignore` pass sees them

- Registers the rule via `register_rules!` with the `"consider moving this module-level constant"` message, and adds the toggle to `tests/fixtures/config/full_override.toml` plus the matching `tests/snapshots/config/full_override.snap`

- Adds 15 fixtures spanning the spec's nine canonical cases plus six additional scenarios (*`Stmt::AnnAssign` coverage, chained / tuple / attribute targets, `typing.TYPE_CHECKING` dotted form, `# fmt: off` suppression, `# prose: ignore[loose-constants]` per-line suppression, module-level `if` descent*)

- Rewrites two `Pipeline` tests to assert against `Pipeline::known_ids().len()` rather than hard-coded rule counts, so future rule additions stop touching those assertions

---

### 🧵 Related Issues

- Closes #69