### PR TITLE
[65] Implement `bare-import-allowlist` rule

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,23 @@ impl Default for AlignmentConfig {
     }
 }
 
+/// Configuration for the `bare_import_allowlist` rule.
+#[derive(Debug, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct BareImportAllowlistConfig {
+    pub allow: Vec<String>,
+    pub enabled: bool,
+}
+
+impl Default for BareImportAllowlistConfig {
+    fn default() -> Self {
+        Self {
+            allow: vec!["numpy".to_owned(), "pandas".to_owned()],
+            enabled: true,
+        }
+    }
+}
+
 /// Configuration for the `collection_layout` rule.
 #[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]

--- a/src/diagnostics/model.rs
+++ b/src/diagnostics/model.rs
@@ -40,6 +40,12 @@ impl Diagnostic {
     }
 }
 
+impl Ranged for Diagnostic {
+    fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Severity {
     Format,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -412,6 +412,7 @@ mod tests {
         config.rules.align_equals.enabled = false;
         config.rules.align_imports.enabled = false;
         config.rules.alphabetize.enabled = false;
+        config.rules.bare_import_allowlist.enabled = false;
         config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
         config.rules.loose_constants.enabled = false;
@@ -452,6 +453,7 @@ mod tests {
         config.rules.align_equals.enabled = false;
         config.rules.align_imports.enabled = false;
         config.rules.alphabetize.enabled = false;
+        config.rules.bare_import_allowlist.enabled = false;
         config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
         config.rules.loose_constants.enabled = false;

--- a/src/primitives/binding.rs
+++ b/src/primitives/binding.rs
@@ -479,7 +479,7 @@ impl<'a> Visitor<'a> for Builder {
 /// Returns the segment of `dotted` before the first `.`. Matches
 /// Python's `import a.b.c` shape, which binds `a` rather than the
 /// full dotted path.
-fn top_level_module(dotted: &str) -> &str {
+pub(crate) fn top_level_module(dotted: &str) -> &str {
     dotted.split_once('.').map_or(dotted, |(head, _)| head)
 }
 

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -15,7 +15,8 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use crate::config::{
-    AlignmentConfig, CollectionLayoutConfig, Config, LooseConstantsConfig, ToggleOnly,
+    AlignmentConfig, BareImportAllowlistConfig, CollectionLayoutConfig, Config,
+    LooseConstantsConfig, ToggleOnly,
 };
 use crate::diagnostics::Diagnostic;
 use crate::pipeline::Pipeline;
@@ -23,6 +24,7 @@ use crate::rules::align_colons::AlignColons;
 use crate::rules::align_equals::AlignEquals;
 use crate::rules::align_imports::AlignImports;
 use crate::rules::alphabetize::Alphabetize;
+use crate::rules::bare_import_allowlist::BareImportAllowlist;
 use crate::rules::blank_lines::BlankLines;
 use crate::rules::collection_layout::CollectionLayout;
 use crate::rules::loose_constants::LooseConstants;
@@ -207,19 +209,20 @@ macro_rules! register_rules {
 }
 
 register_rules! {
-    collection_layout:          CollectionLayoutConfig => CollectionLayout       => "expand collection to one entry per line",
-    alphabetize:                ToggleOnly             => Alphabetize            => "alphabetize this group",
-    strip_trailing_commas:      ToggleOnly             => StripTrailingCommas    => "strip trailing comma",
-    no_single_line_docstrings:  ToggleOnly             => NoSingleLineDocstrings => "expand single-line docstring to multi-line form",
-    multi_line_docstrings:      ToggleOnly             => MultiLineDocstrings    => "place docstring opener and closer on their own lines",
-    blank_lines:                ToggleOnly             => BlankLines             => "normalize blank-line spacing",
-    match_case_align:           AlignmentConfig        => MatchCaseAlign         => "align match-case arrows",
-    align_imports:              AlignmentConfig        => AlignImports           => "align consecutive `import`s",
-    align_colons:               AlignmentConfig        => AlignColons            => "align consecutive `:` separators",
-    align_equals:               AlignmentConfig        => AlignEquals            => "align consecutive `=` operators",
-    singleton_rule:             ToggleOnly             => SingletonRule          => "drop padding from singleton group",
-    loose_constants:            LooseConstantsConfig   => LooseConstants         => "consider moving this module-level constant",
-    no_step_narration:          ToggleOnly             => NoStepNarration        => "numbered-step comment found. Consider extracting each step as a named function",
+    collection_layout:          CollectionLayoutConfig    => CollectionLayout       => "expand collection to one entry per line",
+    alphabetize:                ToggleOnly                => Alphabetize            => "alphabetize this group",
+    strip_trailing_commas:      ToggleOnly                => StripTrailingCommas    => "strip trailing comma",
+    no_single_line_docstrings:  ToggleOnly                => NoSingleLineDocstrings => "expand single-line docstring to multi-line form",
+    multi_line_docstrings:      ToggleOnly                => MultiLineDocstrings    => "place docstring opener and closer on their own lines",
+    blank_lines:                ToggleOnly                => BlankLines             => "normalize blank-line spacing",
+    bare_import_allowlist:      BareImportAllowlistConfig => BareImportAllowlist    => "flag bare import outside allowlist",
+    match_case_align:           AlignmentConfig           => MatchCaseAlign         => "align match-case arrows",
+    align_imports:              AlignmentConfig           => AlignImports           => "align consecutive `import`s",
+    align_colons:               AlignmentConfig           => AlignColons            => "align consecutive `:` separators",
+    align_equals:               AlignmentConfig           => AlignEquals            => "align consecutive `=` operators",
+    singleton_rule:             ToggleOnly                => SingletonRule          => "drop padding from singleton group",
+    loose_constants:            LooseConstantsConfig      => LooseConstants         => "consider moving this module-level constant",
+    no_step_narration:          ToggleOnly                => NoStepNarration        => "numbered-step comment found. Consider extracting each step as a named function",
 }
 
 #[cfg(test)]

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -55,7 +55,9 @@ pub(crate) trait Rule: Send + Sync {
     /// Computes the edit list this rule would apply to `source`.
     /// Edits must not overlap after sorting, an invariant the
     /// pipeline's applicator debug-asserts.
-    fn apply(&self, source: &Source) -> Vec<Edit>;
+    fn apply(&self, _source: &Source) -> Vec<Edit> {
+        Vec::new()
+    }
 
     /// Stable, kebab-case identifier matching the rule's
     /// `[tool.prose.rules]` key. Surfaces in `--select`,

--- a/src/rules/bare_import_allowlist.rs
+++ b/src/rules/bare_import_allowlist.rs
@@ -1,0 +1,164 @@
+//! Flags every `import X` whose top-level segment is not in the
+//! configured allowlist. Lint-only, emits no edits.
+
+use std::collections::HashSet;
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::Stmt;
+
+use crate::config::Config;
+use crate::diagnostics::Diagnostic;
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+pub(crate) struct BareImportAllowlist {
+    allow: HashSet<String>,
+}
+
+impl BareImportAllowlist {
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            allow: config
+                .rules
+                .bare_import_allowlist
+                .allow
+                .iter()
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+impl Rule for BareImportAllowlist {
+    fn apply(&self, _source: &Source) -> Vec<Edit> {
+        Vec::new()
+    }
+
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(BareImportAllowlist))
+    }
+
+    fn lint(&self, source: &Source) -> Vec<Diagnostic> {
+        let mut visitor = Visitor {
+            allow: &self.allow,
+            diagnostics: Vec::new(),
+            rule: self.id(),
+        };
+        visitor.visit_body(&source.ast().body);
+        visitor.diagnostics
+    }
+}
+
+struct Visitor<'a> {
+    allow: &'a HashSet<String>,
+    diagnostics: Vec<Diagnostic>,
+    rule: RuleId,
+}
+
+impl<'a> StatementVisitor<'a> for Visitor<'_> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if let Stmt::Import(import) = stmt {
+            for alias in &import.names {
+                let name = alias.name.as_str();
+                if !self.allow.contains(top_level_segment(name)) {
+                    self.diagnostics.push(Diagnostic::lint(
+                        self.rule,
+                        alias.range,
+                        format!(
+                            "bare import `{name}` outside allowlist. Rewrite as `from {name} import ...` listing only the symbols this module uses",
+                        ),
+                    ));
+                }
+            }
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+/// Returns the substring of `name` preceding the first `.`, or all of
+/// `name` when no `.` is present. `numpy.linalg` resolves to `numpy`.
+fn top_level_segment(name: &str) -> &str {
+    name.split_once('.').map_or(name, |(top, _)| top)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::Severity;
+    use crate::test_support::parse;
+
+    fn lint_default(text: &str) -> Vec<Diagnostic> {
+        let rule = BareImportAllowlist::from_config(&Config::default());
+        rule.lint(&parse(text))
+    }
+
+    #[test]
+    fn aliased_import_is_flagged_on_the_top_level_segment() {
+        let diagnostics = lint_default("import os as o\n");
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("`os`"));
+    }
+
+    #[test]
+    fn allowlisted_top_level_imports_emit_no_diagnostic() {
+        assert!(lint_default("import numpy\nimport pandas\n").is_empty());
+    }
+
+    #[test]
+    fn diagnostic_carries_lint_severity_and_no_fix() {
+        let diagnostics = lint_default("import os\n");
+        let only = diagnostics.first().expect("one diagnostic");
+        assert_eq!(only.severity, Severity::Lint);
+        assert!(only.fix.is_none());
+    }
+
+    #[test]
+    fn dotted_path_inherits_top_level_allowlist_membership() {
+        assert!(lint_default("import numpy.linalg\n").is_empty());
+    }
+
+    #[test]
+    fn empty_allowlist_flags_every_bare_import() {
+        let mut config = Config::default();
+        config.rules.bare_import_allowlist.allow.clear();
+        let rule = BareImportAllowlist::from_config(&config);
+
+        let diagnostics = rule.lint(&parse("import numpy\nimport pandas\nimport os\n"));
+
+        assert_eq!(diagnostics.len(), 3);
+    }
+
+    #[test]
+    fn from_import_emits_no_diagnostic_for_a_non_allowlisted_module() {
+        assert!(lint_default("from os import path\n").is_empty());
+    }
+
+    #[test]
+    fn multi_alias_import_flags_each_non_allowlisted_segment() {
+        let text = "import os, sys, numpy\n";
+        let flagged: Vec<&str> = lint_default(text)
+            .iter()
+            .map(|d| &text[d.range])
+            .collect();
+        assert_eq!(flagged, ["os", "sys"]);
+    }
+
+    #[test]
+    fn non_allowlisted_bare_import_is_flagged() {
+        let diagnostics = lint_default("import os\n");
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("`os`"));
+        assert!(diagnostics[0].message.contains("from os import"));
+    }
+
+    #[test]
+    fn top_level_segment_returns_input_for_a_non_dotted_name() {
+        assert_eq!(top_level_segment("os"), "os");
+    }
+
+    #[test]
+    fn top_level_segment_returns_prefix_for_a_dotted_name() {
+        assert_eq!(top_level_segment("numpy.linalg"), "numpy");
+    }
+}

--- a/src/rules/bare_import_allowlist.rs
+++ b/src/rules/bare_import_allowlist.rs
@@ -52,7 +52,7 @@ struct Visitor<'a> {
     rule: RuleId,
 }
 
-impl<'a> StatementVisitor<'a> for Visitor<'_> {
+impl<'a> StatementVisitor<'a> for Visitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         if let Stmt::Import(import) = stmt {
             for alias in &import.names {

--- a/src/rules/bare_import_allowlist.rs
+++ b/src/rules/bare_import_allowlist.rs
@@ -88,68 +88,16 @@ mod tests {
     use crate::diagnostics::Severity;
     use crate::test_support::parse;
 
-    fn lint_default(text: &str) -> Vec<Diagnostic> {
+    #[test]
+    fn diagnostic_shape_pins_severity_no_fix_and_message_format() {
         let rule = BareImportAllowlist::from_config(&Config::default());
-        rule.lint(&parse(text))
-    }
-
-    #[test]
-    fn aliased_import_is_flagged_on_the_top_level_segment() {
-        let diagnostics = lint_default("import os as o\n");
-        assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].message.contains("`os`"));
-    }
-
-    #[test]
-    fn allowlisted_top_level_imports_emit_no_diagnostic() {
-        assert!(lint_default("import numpy\nimport pandas\n").is_empty());
-    }
-
-    #[test]
-    fn diagnostic_carries_lint_severity_and_no_fix() {
-        let diagnostics = lint_default("import os\n");
+        let diagnostics = rule.lint(&parse("import os\n"));
         let only = diagnostics.first().expect("one diagnostic");
+
         assert_eq!(only.severity, Severity::Lint);
         assert!(only.fix.is_none());
-    }
-
-    #[test]
-    fn dotted_path_inherits_top_level_allowlist_membership() {
-        assert!(lint_default("import numpy.linalg\n").is_empty());
-    }
-
-    #[test]
-    fn empty_allowlist_flags_every_bare_import() {
-        let mut config = Config::default();
-        config.rules.bare_import_allowlist.allow.clear();
-        let rule = BareImportAllowlist::from_config(&config);
-
-        let diagnostics = rule.lint(&parse("import numpy\nimport pandas\nimport os\n"));
-
-        assert_eq!(diagnostics.len(), 3);
-    }
-
-    #[test]
-    fn from_import_emits_no_diagnostic_for_a_non_allowlisted_module() {
-        assert!(lint_default("from os import path\n").is_empty());
-    }
-
-    #[test]
-    fn multi_alias_import_flags_each_non_allowlisted_segment() {
-        let text = "import os, sys, numpy\n";
-        let flagged: Vec<&str> = lint_default(text)
-            .iter()
-            .map(|d| &text[d.range])
-            .collect();
-        assert_eq!(flagged, ["os", "sys"]);
-    }
-
-    #[test]
-    fn non_allowlisted_bare_import_is_flagged() {
-        let diagnostics = lint_default("import os\n");
-        assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].message.contains("`os`"));
-        assert!(diagnostics[0].message.contains("from os import"));
+        assert!(only.message.contains("`os`"));
+        assert!(only.message.contains("from os import"));
     }
 
     #[test]

--- a/src/rules/bare_import_allowlist.rs
+++ b/src/rules/bare_import_allowlist.rs
@@ -3,12 +3,12 @@
 
 use std::collections::HashSet;
 
-use ruff_diagnostics::Edit;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::Stmt;
 
 use crate::config::Config;
 use crate::diagnostics::Diagnostic;
+use crate::primitives::binding::top_level_module;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
@@ -31,10 +31,6 @@ impl BareImportAllowlist {
 }
 
 impl Rule for BareImportAllowlist {
-    fn apply(&self, _source: &Source) -> Vec<Edit> {
-        Vec::new()
-    }
-
     fn id(&self) -> RuleId {
         RuleId::from(ruff_macros::kebab_case!(BareImportAllowlist))
     }
@@ -61,10 +57,10 @@ impl<'a> StatementVisitor<'a> for Visitor<'_> {
         if let Stmt::Import(import) = stmt {
             for alias in &import.names {
                 let name = alias.name.as_str();
-                if !self.allow.contains(top_level_segment(name)) {
+                if !self.allow.contains(top_level_module(name)) {
                     self.diagnostics.push(Diagnostic::lint(
                         self.rule,
-                        alias.range,
+                        alias.name.range,
                         format!(
                             "bare import `{name}` outside allowlist. Rewrite as `from {name} import ...` listing only the symbols this module uses",
                         ),
@@ -74,12 +70,6 @@ impl<'a> StatementVisitor<'a> for Visitor<'_> {
         }
         walk_stmt(self, stmt);
     }
-}
-
-/// Returns the substring of `name` preceding the first `.`, or all of
-/// `name` when no `.` is present. `numpy.linalg` resolves to `numpy`.
-fn top_level_segment(name: &str) -> &str {
-    name.split_once('.').map_or(name, |(top, _)| top)
 }
 
 #[cfg(test)]
@@ -98,15 +88,5 @@ mod tests {
         assert!(only.fix.is_none());
         assert!(only.message.contains("`os`"));
         assert!(only.message.contains("from os import"));
-    }
-
-    #[test]
-    fn top_level_segment_returns_input_for_a_non_dotted_name() {
-        assert_eq!(top_level_segment("os"), "os");
-    }
-
-    #[test]
-    fn top_level_segment_returns_prefix_for_a_dotted_name() {
-        assert_eq!(top_level_segment("numpy.linalg"), "numpy");
     }
 }

--- a/src/rules/loose_constants.rs
+++ b/src/rules/loose_constants.rs
@@ -5,7 +5,6 @@
 
 use std::collections::HashSet;
 
-use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::name::UnqualifiedName;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
@@ -30,10 +29,6 @@ impl LooseConstants {
 }
 
 impl Rule for LooseConstants {
-    fn apply(&self, _source: &Source) -> Vec<Edit> {
-        Vec::new()
-    }
-
     fn id(&self) -> RuleId {
         RuleId::from(ruff_macros::kebab_case!(LooseConstants))
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod align_colons;
 pub(crate) mod align_equals;
 pub(crate) mod align_imports;
 pub(crate) mod alphabetize;
+pub(crate) mod bare_import_allowlist;
 pub(crate) mod blank_lines;
 pub(crate) mod collection_layout;
 pub(crate) mod loose_constants;

--- a/src/rules/no_step_narration.rs
+++ b/src/rules/no_step_narration.rs
@@ -2,7 +2,6 @@
 //! (`# 1. text`, `# Step 2: text`, `# step 3. text`). Pragmas and
 //! decimal-version comments are excluded.
 
-use ruff_diagnostics::Edit;
 use ruff_python_trivia::{
     is_pragma_comment, is_python_whitespace, CommentRanges, Cursor, PythonWhitespace,
 };
@@ -21,10 +20,6 @@ impl NoStepNarration {
 }
 
 impl Rule for NoStepNarration {
-    fn apply(&self, _source: &Source) -> Vec<Edit> {
-        Vec::new()
-    }
-
     fn id(&self) -> RuleId {
         RuleId::from(ruff_macros::kebab_case!(NoStepNarration))
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,8 +3,11 @@
 #![allow(dead_code)]
 
 use std::ffi::OsStr;
+use std::io::ErrorKind;
 use std::path::Path;
 
+use prose::config::Config;
+use prose::pipeline::Pipeline;
 use serde::Deserialize;
 use similar::TextDiff;
 
@@ -22,10 +25,27 @@ struct Sidecar {
     harness: HarnessOptions,
 }
 
+pub(crate) fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
+    match directory {
+        "composition" | "suppression" => Pipeline::with_defaults(config),
+        "binding_analysis" | "identity" => Pipeline::empty(),
+        _ => Pipeline::for_rule(directory, config)
+            .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),
+    }
+}
+
 pub(crate) fn case_stem(path: &Path) -> &str {
     path.file_stem()
         .and_then(OsStr::to_str)
         .expect("fixture path has a stem")
+}
+
+pub(crate) fn fixture_config(path: &Path) -> Config {
+    sidecar_contents(path)
+        .map(|c| {
+            Config::from_pyproject_str(&c).unwrap_or_else(|e| panic!("parse sidecar config: {e}"))
+        })
+        .unwrap_or_default()
 }
 
 pub(crate) fn in_snapshot_dir(directory: &str, f: impl FnOnce()) {
@@ -42,6 +62,18 @@ pub(crate) fn parse_harness_options(contents: &str) -> HarnessOptions {
     toml::from_str::<Sidecar>(contents)
         .unwrap_or_else(|e| panic!("parse sidecar harness section: {e}"))
         .harness
+}
+
+pub(crate) fn sidecar_contents(path: &Path) -> Option<String> {
+    let stem = case_stem(path)
+        .strip_suffix(".input")
+        .expect("fixture path ends in .input.py");
+    let sidecar = path.with_file_name(format!("{stem}.config.toml"));
+    match fs_err::read_to_string(&sidecar) {
+        Ok(c) => Some(c),
+        Err(e) if e.kind() == ErrorKind::NotFound => None,
+        Err(e) => panic!("read sidecar: {e}"),
+    }
 }
 
 pub(crate) fn unified_diff(expected: &str, actual: &str) -> String {

--- a/tests/diagnostics.rs
+++ b/tests/diagnostics.rs
@@ -5,6 +5,8 @@
 mod common;
 
 use std::ffi::OsStr;
+use std::io::ErrorKind;
+use std::path::Path;
 
 use prose::config::Config;
 use prose::diagnostics::Diagnostic;
@@ -17,6 +19,20 @@ fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
         "binding_analysis" | "identity" => Pipeline::empty(),
         _ => Pipeline::for_rule(directory, config)
             .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),
+    }
+}
+
+fn fixture_config(path: &Path) -> Config {
+    let stem = common::case_stem(path)
+        .strip_suffix(".input")
+        .expect("fixture path ends in .input.py");
+    let sidecar = path.with_file_name(format!("{stem}.config.toml"));
+    match fs_err::read_to_string(&sidecar) {
+        Ok(c) => {
+            Config::from_pyproject_str(&c).unwrap_or_else(|e| panic!("parse sidecar config: {e}"))
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => Config::default(),
+        Err(e) => panic!("read sidecar: {e}"),
     }
 }
 
@@ -41,13 +57,14 @@ fn fixtures_emit_expected_diagnostics() {
     insta::glob!("fixtures/**/*.input.py", |path| {
         let directory = path
             .parent()
-            .and_then(|p| p.file_name())
+            .and_then(Path::file_name)
             .and_then(OsStr::to_str)
             .expect("fixture path has a parent directory name");
         let case = common::case_stem(path)
             .strip_suffix(".input")
             .expect("fixture path ends in .input.py");
-        let pipeline = build_pipeline(directory, &Config::default());
+        let config = fixture_config(path);
+        let pipeline = build_pipeline(directory, &config);
         let source = Source::from_path(path).expect("fixture input reads and parses as Python");
         let (_, diagnostics) = pipeline.run(source).expect("pipeline runs");
 

--- a/tests/diagnostics.rs
+++ b/tests/diagnostics.rs
@@ -5,36 +5,9 @@
 mod common;
 
 use std::ffi::OsStr;
-use std::io::ErrorKind;
-use std::path::Path;
 
-use prose::config::Config;
 use prose::diagnostics::Diagnostic;
-use prose::pipeline::Pipeline;
 use prose::source::Source;
-
-fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
-    match directory {
-        "composition" | "suppression" => Pipeline::with_defaults(config),
-        "binding_analysis" | "identity" => Pipeline::empty(),
-        _ => Pipeline::for_rule(directory, config)
-            .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),
-    }
-}
-
-fn fixture_config(path: &Path) -> Config {
-    let stem = common::case_stem(path)
-        .strip_suffix(".input")
-        .expect("fixture path ends in .input.py");
-    let sidecar = path.with_file_name(format!("{stem}.config.toml"));
-    match fs_err::read_to_string(&sidecar) {
-        Ok(c) => {
-            Config::from_pyproject_str(&c).unwrap_or_else(|e| panic!("parse sidecar config: {e}"))
-        }
-        Err(e) if e.kind() == ErrorKind::NotFound => Config::default(),
-        Err(e) => panic!("read sidecar: {e}"),
-    }
-}
 
 fn render(diagnostics: &[Diagnostic]) -> String {
     let mut lines: Vec<String> = diagnostics
@@ -63,8 +36,8 @@ fn fixtures_emit_expected_diagnostics() {
         let case = common::case_stem(path)
             .strip_suffix(".input")
             .expect("fixture path ends in .input.py");
-        let config = fixture_config(path);
-        let pipeline = build_pipeline(directory, &config);
+        let config = common::fixture_config(path);
+        let pipeline = common::build_pipeline(directory, &config);
         let source = Source::from_path(path).expect("fixture input reads and parses as Python");
         let (_, diagnostics) = pipeline.run(source).expect("pipeline runs");
 

--- a/tests/fixtures/bare_import_allowlist/aliased_flag.input.py
+++ b/tests/fixtures/bare_import_allowlist/aliased_flag.input.py
@@ -1,0 +1,7 @@
+"""
+A bare `import os as o` is flagged on the top-level segment `os`.
+The alias `o` does not affect the lookup because the allowlist
+matches the imported module name, not its local binding.
+"""
+
+import os as o

--- a/tests/fixtures/bare_import_allowlist/allowlisted_preserved.input.py
+++ b/tests/fixtures/bare_import_allowlist/allowlisted_preserved.input.py
@@ -1,0 +1,7 @@
+"""
+A bare `import numpy` or `import pandas` is preserved because both
+segments sit in the default allowlist. No diagnostic is emitted.
+"""
+
+import numpy
+import pandas

--- a/tests/fixtures/bare_import_allowlist/custom_allowlist.config.toml
+++ b/tests/fixtures/bare_import_allowlist/custom_allowlist.config.toml
@@ -1,0 +1,2 @@
+[tool.prose.rules.bare-import-allowlist]
+allow = ["torch"]

--- a/tests/fixtures/bare_import_allowlist/custom_allowlist.input.py
+++ b/tests/fixtures/bare_import_allowlist/custom_allowlist.input.py
@@ -1,0 +1,8 @@
+"""
+A sidecar config replaces the default allowlist with `["torch"]`.
+The default-allowlisted `numpy` is now flagged while `torch` is
+preserved.
+"""
+
+import numpy
+import torch

--- a/tests/fixtures/bare_import_allowlist/dotted_allowlisted.input.py
+++ b/tests/fixtures/bare_import_allowlist/dotted_allowlisted.input.py
@@ -1,0 +1,7 @@
+"""
+A dotted bare `import numpy.linalg` is preserved because the top-level
+segment `numpy` sits in the allowlist. Submodule access inherits the
+parent's allowlist membership.
+"""
+
+import numpy.linalg

--- a/tests/fixtures/bare_import_allowlist/empty_allowlist.config.toml
+++ b/tests/fixtures/bare_import_allowlist/empty_allowlist.config.toml
@@ -1,0 +1,2 @@
+[tool.prose.rules.bare-import-allowlist]
+allow = []

--- a/tests/fixtures/bare_import_allowlist/empty_allowlist.input.py
+++ b/tests/fixtures/bare_import_allowlist/empty_allowlist.input.py
@@ -1,0 +1,8 @@
+"""
+An empty allowlist flags every bare import in the file. The default
+`["numpy", "pandas"]` carve-out vanishes when the user clears `allow`.
+"""
+
+import numpy
+import pandas
+import os

--- a/tests/fixtures/bare_import_allowlist/fmt_off_suppresses.input.py
+++ b/tests/fixtures/bare_import_allowlist/fmt_off_suppresses.input.py
@@ -1,0 +1,9 @@
+"""
+A `# fmt: off` block drops the rule's diagnostic for any bare import
+inside the suppressed span. The pipeline filters `Severity::Lint`
+diagnostics by range alongside edits.
+"""
+
+# fmt: off
+import os
+# fmt: on

--- a/tests/fixtures/bare_import_allowlist/from_import_unaffected.input.py
+++ b/tests/fixtures/bare_import_allowlist/from_import_unaffected.input.py
@@ -1,0 +1,7 @@
+"""
+A `from os import path` carries no diagnostic because the rule
+targets `Stmt::Import` rather than `Stmt::ImportFrom`. The explicit
+shape the rule recommends is already in use.
+"""
+
+from os import path

--- a/tests/fixtures/bare_import_allowlist/idempotent.input.py
+++ b/tests/fixtures/bare_import_allowlist/idempotent.input.py
@@ -1,0 +1,9 @@
+"""
+The rule emits no edits, so every pass leaves the source byte-for-byte
+identical. A mix of flagged and preserved imports stays as written.
+"""
+
+import os
+import numpy
+import pandas
+from os import path

--- a/tests/fixtures/bare_import_allowlist/multi_alias_mixed.input.py
+++ b/tests/fixtures/bare_import_allowlist/multi_alias_mixed.input.py
@@ -1,0 +1,7 @@
+"""
+A compound `import` flags every segment outside the allowlist while
+leaving the allowlisted ones alone. `os` and `sys` fire, `numpy` is
+preserved, all on the same statement.
+"""
+
+import os, sys, numpy

--- a/tests/fixtures/bare_import_allowlist/nested_in_function.input.py
+++ b/tests/fixtures/bare_import_allowlist/nested_in_function.input.py
@@ -1,0 +1,11 @@
+"""
+The rule recurses into function bodies through `walk_stmt`, flagging
+a non-allowlisted bare import nested inside `def` the same as a
+module-level one.
+"""
+
+
+def show_version():
+    import sys
+
+    return sys.version

--- a/tests/fixtures/bare_import_allowlist/non_allowlisted_flag.input.py
+++ b/tests/fixtures/bare_import_allowlist/non_allowlisted_flag.input.py
@@ -1,0 +1,7 @@
+"""
+A bare `import os` is flagged because `os` is not in the default
+allowlist of `numpy` and `pandas`. The rule emits a `Severity::Lint`
+diagnostic and leaves the source text untouched.
+"""
+
+import os

--- a/tests/fixtures/bare_import_allowlist/prose_ignore_suppresses.input.py
+++ b/tests/fixtures/bare_import_allowlist/prose_ignore_suppresses.input.py
@@ -1,0 +1,7 @@
+"""
+A `# prose: ignore[bare-import-allowlist]` trailing comment suppresses
+the diagnostic for that line. The pipeline's lint-suppression pass
+drops the entry by `(line, rule)`.
+"""
+
+import os  # prose: ignore[bare-import-allowlist]

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -16,6 +16,10 @@ enabled = false
 [tool.prose.rules.alphabetize]
 enabled = false
 
+[tool.prose.rules.bare-import-allowlist]
+allow = ["scipy", "torch"]
+enabled = false
+
 [tool.prose.rules.blank-lines]
 enabled = false
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,22 +3,12 @@
 mod common;
 
 use std::ffi::OsStr;
-use std::io::ErrorKind;
 use std::path::Path;
 
 use prose::config::Config;
 use prose::pipeline::Pipeline;
 use prose::source::Source;
 use ruff_python_formatter::{format_module_source, PyFormatOptions};
-
-fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
-    match directory {
-        "composition" | "suppression" => Pipeline::with_defaults(config),
-        "binding_analysis" | "identity" => Pipeline::empty(),
-        _ => Pipeline::for_rule(directory, config)
-            .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),
-    }
-}
 
 struct FixturePath<'a>(&'a Path);
 
@@ -30,6 +20,10 @@ impl<'a> FixturePath<'a> {
             .expect("fixture path has a file name")
     }
 
+    fn config(&self) -> Config {
+        common::fixture_config(self.0)
+    }
+
     fn directory(&self) -> &'a str {
         self.0
             .parent()
@@ -38,32 +32,11 @@ impl<'a> FixturePath<'a> {
             .expect("fixture path has a parent directory name")
     }
 
-    fn config(&self) -> Config {
-        self.sidecar_contents()
-            .map(|c| {
-                Config::from_pyproject_str(&c)
-                    .unwrap_or_else(|e| panic!("parse sidecar config: {e}"))
-            })
-            .unwrap_or_default()
-    }
-
     fn harness_options(&self) -> common::HarnessOptions {
-        self.sidecar_contents()
+        common::sidecar_contents(self.0)
             .as_deref()
             .map(common::parse_harness_options)
             .unwrap_or_default()
-    }
-
-    fn sidecar_contents(&self) -> Option<String> {
-        let stem = common::case_stem(self.0)
-            .strip_suffix(".input")
-            .expect("fixture path ends in .input.py");
-        let sidecar = self.0.with_file_name(format!("{stem}.config.toml"));
-        match fs_err::read_to_string(&sidecar) {
-            Ok(c) => Some(c),
-            Err(e) if e.kind() == ErrorKind::NotFound => None,
-            Err(e) => panic!("read sidecar: {e}"),
-        }
     }
 }
 
@@ -78,7 +51,7 @@ fn fixtures() {
         }
 
         let config = fixture.config();
-        let pipeline = build_pipeline(directory, &config);
+        let pipeline = common::build_pipeline(directory, &config);
         let source = Source::from_path(path).expect("fixture input reads and parses as Python");
 
         let (formatted, _) = pipeline
@@ -102,7 +75,7 @@ fn fixtures() {
 
         let fresh_source =
             Source::from_path(path).expect("fixture input re-reads for determinism check");
-        let (fresh_formatted, _) = build_pipeline(directory, &config)
+        let (fresh_formatted, _) = common::build_pipeline(directory, &config)
             .run(fresh_source)
             .expect("fresh pipeline run succeeds");
         assert!(

--- a/tests/snapshots/align_colons/shift_limit_skip.diagnostics.snap
+++ b/tests/snapshots/align_colons/shift_limit_skip.diagnostics.snap
@@ -1,9 +1,7 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_colons/shift_limit_skip.input.py
 ---
-align-colons@223..223
-align-colons@244..244
-align-colons@296..296
-align-colons@310..310
+

--- a/tests/snapshots/align_imports/aliased_shift_limit_drop.diagnostics.snap
+++ b/tests/snapshots/align_imports/aliased_shift_limit_drop.diagnostics.snap
@@ -1,7 +1,9 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/aliased_shift_limit_drop.input.py
 ---
 align-imports@284..285
 align-imports@299..300
+align-imports@372..373

--- a/tests/snapshots/align_imports/aliased_shift_limit_skip.diagnostics.snap
+++ b/tests/snapshots/align_imports/aliased_shift_limit_skip.diagnostics.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/aliased_shift_limit_skip.input.py
 ---
-align-imports@185..186
-align-imports@200..201
+

--- a/tests/snapshots/align_imports/shift_limit_drop.diagnostics.snap
+++ b/tests/snapshots/align_imports/shift_limit_drop.diagnostics.snap
@@ -1,6 +1,10 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/shift_limit_drop.input.py
 ---
+align-imports@253..254
+align-imports@276..277
+align-imports@295..296
 align-imports@385..386

--- a/tests/snapshots/align_imports/shift_limit_skip.diagnostics.snap
+++ b/tests/snapshots/align_imports/shift_limit_skip.diagnostics.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/shift_limit_skip.input.py
 ---
-align-imports@291..292
+

--- a/tests/snapshots/bare_import_allowlist/aliased_flag.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/aliased_flag.diagnostics.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/diagnostics.rs
 expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/aliased_flag.input.py
 ---
 bare-import-allowlist@202..209

--- a/tests/snapshots/bare_import_allowlist/aliased_flag.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/aliased_flag.diagnostics.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/bare_import_allowlist/aliased_flag.input.py
 ---
-bare-import-allowlist@202..209
+bare-import-allowlist@202..204

--- a/tests/snapshots/bare_import_allowlist/aliased_flag.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/aliased_flag.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/aliased_flag.input.py
+---
+"""
+A bare `import os as o` is flagged on the top-level segment `os`.
+The alias `o` does not affect the lookup because the allowlist
+matches the imported module name, not its local binding.
+"""
+
+import os as o

--- a/tests/snapshots/bare_import_allowlist/allowlisted_preserved.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/allowlisted_preserved.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/allowlisted_preserved.input.py
+---
+

--- a/tests/snapshots/bare_import_allowlist/allowlisted_preserved.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/allowlisted_preserved.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/allowlisted_preserved.input.py
+---
+"""
+A bare `import numpy` or `import pandas` is preserved because both
+segments sit in the default allowlist. No diagnostic is emitted.
+"""
+
+import numpy
+import pandas

--- a/tests/snapshots/bare_import_allowlist/custom_allowlist.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/custom_allowlist.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/custom_allowlist.input.py
+---
+bare-import-allowlist@157..162

--- a/tests/snapshots/bare_import_allowlist/custom_allowlist.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/custom_allowlist.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/custom_allowlist.input.py
+---
+"""
+A sidecar config replaces the default allowlist with `["torch"]`.
+The default-allowlisted `numpy` is now flagged while `torch` is
+preserved.
+"""
+
+import numpy
+import torch

--- a/tests/snapshots/bare_import_allowlist/diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+---
+bare-import-allowlist@202..209

--- a/tests/snapshots/bare_import_allowlist/dotted_allowlisted.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/dotted_allowlisted.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/dotted_allowlisted.input.py
+---
+

--- a/tests/snapshots/bare_import_allowlist/dotted_allowlisted.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/dotted_allowlisted.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/dotted_allowlisted.input.py
+---
+"""
+A dotted bare `import numpy.linalg` is preserved because the top-level
+segment `numpy` sits in the allowlist. Submodule access inherits the
+parent's allowlist membership.
+"""
+
+import numpy.linalg

--- a/tests/snapshots/bare_import_allowlist/empty_allowlist.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/empty_allowlist.diagnostics.snap
@@ -1,0 +1,8 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/empty_allowlist.input.py
+---
+bare-import-allowlist@155..160
+bare-import-allowlist@168..174
+bare-import-allowlist@182..184

--- a/tests/snapshots/bare_import_allowlist/empty_allowlist.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/empty_allowlist.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/empty_allowlist.input.py
+---
+"""
+An empty allowlist flags every bare import in the file. The default
+`["numpy", "pandas"]` carve-out vanishes when the user clears `allow`.
+"""
+
+import numpy
+import pandas
+import os

--- a/tests/snapshots/bare_import_allowlist/fmt_off_suppresses.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/fmt_off_suppresses.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/fmt_off_suppresses.input.py
+---
+

--- a/tests/snapshots/bare_import_allowlist/fmt_off_suppresses.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/fmt_off_suppresses.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/fmt_off_suppresses.input.py
+---
+"""
+A `# fmt: off` block drops the rule's diagnostic for any bare import
+inside the suppressed span. The pipeline filters `Severity::Lint`
+diagnostics by range alongside edits.
+"""
+
+# fmt: off
+import os
+# fmt: on

--- a/tests/snapshots/bare_import_allowlist/from_import_unaffected.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/from_import_unaffected.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/from_import_unaffected.input.py
+---
+

--- a/tests/snapshots/bare_import_allowlist/from_import_unaffected.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/from_import_unaffected.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/from_import_unaffected.input.py
+---
+"""
+A `from os import path` carries no diagnostic because the rule
+targets `Stmt::Import` rather than `Stmt::ImportFrom`. The explicit
+shape the rule recommends is already in use.
+"""
+
+from os import path

--- a/tests/snapshots/bare_import_allowlist/idempotent.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/idempotent.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/idempotent.input.py
+---
+bare-import-allowlist@155..157

--- a/tests/snapshots/bare_import_allowlist/idempotent.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/idempotent.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/idempotent.input.py
+---
+"""
+The rule emits no edits, so every pass leaves the source byte-for-byte
+identical. A mix of flagged and preserved imports stays as written.
+"""
+
+import os
+import numpy
+import pandas
+from os import path

--- a/tests/snapshots/bare_import_allowlist/multi_alias_mixed.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/multi_alias_mixed.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/multi_alias_mixed.input.py
+---
+bare-import-allowlist@190..192
+bare-import-allowlist@194..197

--- a/tests/snapshots/bare_import_allowlist/multi_alias_mixed.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/multi_alias_mixed.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/multi_alias_mixed.input.py
+---
+"""
+A compound `import` flags every segment outside the allowlist while
+leaving the allowlisted ones alone. `os` and `sys` fire, `numpy` is
+preserved, all on the same statement.
+"""
+
+import os, sys, numpy

--- a/tests/snapshots/bare_import_allowlist/nested_in_function.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/nested_in_function.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/nested_in_function.input.py
+---
+bare-import-allowlist@192..195

--- a/tests/snapshots/bare_import_allowlist/nested_in_function.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/nested_in_function.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/nested_in_function.input.py
+---
+"""
+The rule recurses into function bodies through `walk_stmt`, flagging
+a non-allowlisted bare import nested inside `def` the same as a
+module-level one.
+"""
+
+
+def show_version():
+    import sys
+
+    return sys.version

--- a/tests/snapshots/bare_import_allowlist/non_allowlisted_flag.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/non_allowlisted_flag.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/non_allowlisted_flag.input.py
+---
+bare-import-allowlist@199..201

--- a/tests/snapshots/bare_import_allowlist/non_allowlisted_flag.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/non_allowlisted_flag.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/non_allowlisted_flag.input.py
+---
+"""
+A bare `import os` is flagged because `os` is not in the default
+allowlist of `numpy` and `pandas`. The rule emits a `Severity::Lint`
+diagnostic and leaves the source text untouched.
+"""
+
+import os

--- a/tests/snapshots/bare_import_allowlist/prose_ignore_suppresses.diagnostics.snap
+++ b/tests/snapshots/bare_import_allowlist/prose_ignore_suppresses.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/bare_import_allowlist/prose_ignore_suppresses.input.py
+---
+

--- a/tests/snapshots/bare_import_allowlist/prose_ignore_suppresses.input.py.snap
+++ b/tests/snapshots/bare_import_allowlist/prose_ignore_suppresses.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/bare_import_allowlist/prose_ignore_suppresses.input.py
+---
+"""
+A `# prose: ignore[bare-import-allowlist]` trailing comment suppresses
+the diagnostic for that line. The pipeline's lint-suppression pass
+drops the entry by `(line, rule)`.
+"""
+
+import os  # prose: ignore[bare-import-allowlist]

--- a/tests/snapshots/composition/class_essentials.diagnostics.snap
+++ b/tests/snapshots/composition/class_essentials.diagnostics.snap
@@ -12,3 +12,5 @@ align-equals@531..532
 align-equals@588..589
 align-imports@424..425
 alphabetize@386..850
+bare-import-allowlist@444..446
+bare-import-allowlist@454..457

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -33,6 +33,13 @@ Config {
         blank_lines: ToggleOnly {
             enabled: false,
         },
+        bare_import_allowlist: BareImportAllowlistConfig {
+            allow: [
+                "scipy",
+                "torch",
+            ],
+            enabled: false,
+        },
         match_case_align: AlignmentConfig {
             enabled: false,
             max_shift: 8,

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/config_parsing.rs
+assertion_line: 30
 expression: config
 input_file: tests/fixtures/config/target_version_only.toml
 ---
@@ -31,6 +32,13 @@ Config {
             enabled: true,
         },
         blank_lines: ToggleOnly {
+            enabled: true,
+        },
+        bare_import_allowlist: BareImportAllowlistConfig {
+            allow: [
+                "numpy",
+                "pandas",
+            ],
             enabled: true,
         },
         match_case_align: AlignmentConfig {

--- a/tests/snapshots/loose_constants/configured_allow.diagnostics.snap
+++ b/tests/snapshots/loose_constants/configured_allow.diagnostics.snap
@@ -1,8 +1,7 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/loose_constants/configured_allow.input.py
 ---
-loose-constants@192..216
-loose-constants@217..237
 loose-constants@238..257

--- a/tests/snapshots/match_case_align/shift_limit_skip.diagnostics.snap
+++ b/tests/snapshots/match_case_align/shift_limit_skip.diagnostics.snap
@@ -1,10 +1,9 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 45
 expression: render(&diagnostics)
 input_file: tests/fixtures/match_case_align/shift_limit_skip.input.py
 ---
-match-case-align@290..290
 match-case-align@291..300
-match-case-align@329..329
 match-case-align@330..339
 match-case-align@408..417


### PR DESCRIPTION
### 🪻 Quick Summary

Implements `bare-import-allowlist` as a lint-only rule flagging every `import X` whose top-level segment is not in the configured allowlist. The default allowlist `["numpy", "pandas"]` preserves the modules that conventionally earn the bare-import idiom in scientific Python. The diagnostic carries `fix: None` because the auto-fix half (*rewriting `import os` into `from os import getcwd, path` after rewriting every `os.attr` usage in the file*) requires a multi-stage edit pipeline that does not exist yet, so the rule ships in lint-only form for `0.2.0` and validates the allowlist semantics ahead of the auto-fix promotion.

The rule overrides `Rule::lint`, returning per-import diagnostics via `Diagnostic::lint`, and reuses `binding::top_level_module` so the dotted-prefix logic lives in one place. Each diagnostic points at `alias.name.range`, the imported segment, so an alias's `as X` trailer never crosses into the highlighted span. `Rule::apply` gains a `Vec::new()` default in this PR, turning the empty-apply override into dead weight for every lint-only rule.

---

### 🗞️ Key Changes

- Adds `src/rules/bare_import_allowlist.rs` with `BareImportAllowlist` and a private `Visitor` that walks every `Stmt::Import` recursively through `ruff_python_ast::statement_visitor::walk_stmt`, dispatching each `alias.name.as_str()` against a `HashSet<String>` allowlist via the shared `binding::top_level_module` helper

- Defaults `Rule::apply` to `Vec::new()` so lint-only rules implement only the half they emit

- Promotes `binding::top_level_module` to `pub(crate)` so consumer rules reuse the dotted-prefix helper rather than re-rolling it

- Adds `BareImportAllowlistConfig` to `src/config.rs` with `allow: Vec<String>` defaulting to `["numpy", "pandas"]` and the `enabled: bool` toggle, registered through `register_rules!` between `blank_lines` and `match_case_align`

- Implements `Ranged` for `Diagnostic` so the pipeline passes diagnostics directly to `SuppressionMap::intersects`

- Hoists `build_pipeline`, `fixture_config`, and `sidecar_contents` into `tests/common/mod.rs`, with `tests/diagnostics.rs` and `tests/integration.rs` routing through the shared helpers rather than carrying near-identical local copies

- Adds 12 fixtures under `tests/fixtures/bare_import_allowlist/` spanning the spec's six canonical cases (*`non_allowlisted_flag`, `allowlisted_preserved`, `aliased_flag`, `dotted_allowlisted`, `from_import_unaffected`, `idempotent`*) plus six defense-in-depth scenarios (*`custom_allowlist` and `empty_allowlist` exercising sidecar config overrides, `fmt_off_suppresses` and `prose_ignore_suppresses` pinning both suppression paths, `multi_alias_mixed` for compound `import` statements, `nested_in_function` for the walker's recursion*)

- Pins the existing `tests/fixtures/config/full_override.toml` and its snapshot with `[tool.prose.rules.bare-import-allowlist]` carrying a custom `allow = ["scipy", "torch"]`, anchoring the explicit-override assertion alongside the rest of the composed config

---

### 🧵 Related Issues

- Closes #65
