### PR TITLE
[83] Build binding-analysis primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,13 +594,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -883,6 +910,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1097,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prose"
 version = "0.1.2"
 dependencies = [
@@ -1074,6 +1129,7 @@ dependencies = [
  "ignore",
  "indoc",
  "insta",
+ "proptest",
  "rayon",
  "ruff_diagnostics",
  "ruff_macros",
@@ -1093,6 +1149,12 @@ dependencies = [
  "toml",
  "unicode-width",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1127,6 +1189,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1138,8 +1206,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1164,6 +1242,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,9 +1262,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -1494,6 +1600,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1949,6 +2067,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ unicode-width      = "0.2"
 assert_cmd            = "2"
 indoc                 = "2"
 insta                 = { version = "1.39", features = ["glob", "yaml"] }
+proptest              = "1"
 ruff_python_formatter = { git = "https://github.com/astral-sh/ruff", tag = "0.15.10" }
 tempfile              = "3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,5 @@ pub(crate) mod suppression;
 #[cfg(test)]
 mod test_support;
 mod walker;
+
+pub use primitives::binding::BindingAnalysis;

--- a/src/primitives/binding.rs
+++ b/src/primitives/binding.rs
@@ -17,10 +17,10 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::visitor::{walk_arguments, walk_expr, walk_parameters, walk_stmt, Visitor};
 use ruff_python_ast::{
-    Expr, ExprContext, ExprDictComp, ExprGenerator, ExprLambda, ExprListComp, ExprNamed,
-    ExprSetComp, Identifier, ModModule, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtAugAssign,
+    Expr, ExprDictComp, ExprGenerator, ExprLambda, ExprList, ExprListComp, ExprNamed, ExprSetComp,
+    ExprTuple, Identifier, ModModule, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtAugAssign,
     StmtClassDef, StmtFor, StmtFunctionDef, StmtImport, StmtImportFrom, StmtTry, StmtWith,
 };
 use ruff_text_size::{Ranged, TextSize};
@@ -88,8 +88,6 @@ pub struct BindingAnalysis {
     scopes: Vec<Scope>,
 }
 
-const MODULE_SCOPE: ScopeId = ScopeId(0);
-
 #[allow(dead_code, reason = "consumer rules #62 and #70 land later in 0.2.0")]
 impl BindingAnalysis {
     /// Walks `module` once and returns the resulting binding table.
@@ -122,10 +120,11 @@ impl BindingAnalysis {
     /// Returns `true` when `name` has a module-scope write event at
     /// any offset strictly less than `offset`.
     pub(crate) fn is_defined_before(&self, name: &str, offset: TextSize) -> bool {
-        self.scopes[MODULE_SCOPE.0 as usize]
+        self.scopes[0]
             .bindings
             .get(name)
-            .is_some_and(|&id| self.binding(id).write_offsets.iter().any(|&o| o < offset))
+            .and_then(|&id| self.binding(id).write_offsets.first())
+            .is_some_and(|&first| first < offset)
     }
 
     /// Returns the number of read events recorded for `binding`.
@@ -165,7 +164,7 @@ impl Builder {
             self.visit_expr(&decorator.expression);
         }
         if let Some(arguments) = &class.arguments {
-            self.visit_arguments(arguments);
+            walk_arguments(self, arguments);
         }
         self.record_identifier(&class.name, BindingKind::ClassDef);
         let parent = Some(self.current_scope());
@@ -179,9 +178,11 @@ impl Builder {
         generators: &[ruff_python_ast::Comprehension],
         elements: &[&Expr],
     ) {
-        let (first, rest) = generators
-            .split_first()
-            .expect("invariant: comprehension carries at least one generator");
+        let Some((first, rest)) = generators.split_first() else {
+            unreachable!(
+                "invariant: comprehension carries at least one generator (parser guarantee)"
+            );
+        };
         self.visit_expr(&first.iter);
         let parent = Some(self.current_scope());
         self.push_scope(ScopeKind::Comprehension, parent);
@@ -206,12 +207,7 @@ impl Builder {
         for decorator in &function.decorator_list {
             self.visit_expr(&decorator.expression);
         }
-        self.walk_parameter_defaults(&function.parameters);
-        for parameter in function.parameters.iter_source_order() {
-            if let Some(annotation) = parameter.annotation() {
-                self.visit_expr(annotation);
-            }
-        }
+        walk_parameters(self, &function.parameters);
         if let Some(returns) = &function.returns {
             self.visit_expr(returns);
         }
@@ -226,7 +222,7 @@ impl Builder {
 
     fn enter_lambda(&mut self, lambda: &ExprLambda) {
         if let Some(parameters) = &lambda.parameters {
-            self.walk_parameter_defaults(parameters);
+            walk_parameters(self, parameters);
         }
         let parent = Some(self.current_scope());
         self.push_scope(ScopeKind::Function, parent);
@@ -290,32 +286,20 @@ impl Builder {
 
     fn record_target(&mut self, target: &Expr, kind: BindingKind) {
         match target {
-            Expr::Name(name) => {
-                self.record_write(name.id.as_str(), name.range().start(), kind);
-            }
-            Expr::Tuple(tuple) => {
-                for element in &tuple.elts {
-                    self.record_target(element, kind);
-                }
-            }
-            Expr::List(list) => {
-                for element in &list.elts {
+            Expr::Name(name) => self.record_write(name.id.as_str(), name.range().start(), kind),
+            Expr::Tuple(ExprTuple { elts, .. }) | Expr::List(ExprList { elts, .. }) => {
+                for element in elts {
                     self.record_target(element, kind);
                 }
             }
             Expr::Starred(starred) => self.record_target(&starred.value, kind),
-            Expr::Attribute(attribute) => self.visit_expr(&attribute.value),
-            Expr::Subscript(subscript) => {
-                self.visit_expr(&subscript.value);
-                self.visit_expr(&subscript.slice);
-            }
-            _ => {}
+            _ => walk_expr(self, target),
         }
     }
 
     fn record_walrus(&mut self, named: &ExprNamed) {
         self.visit_expr(&named.value);
-        let Expr::Name(name) = &*named.target else {
+        let Some(name) = named.target.as_name_expr() else {
             unreachable!("invariant: walrus target is always Expr::Name (parser guarantee)");
         };
         let scope = self
@@ -367,17 +351,8 @@ impl Builder {
         if let Some(value) = &node.value {
             self.visit_expr(value);
         }
-        if let Expr::Name(_) = &*node.target {
+        if node.target.is_name_expr() {
             self.record_target(&node.target, BindingKind::Assignment);
-        }
-    }
-
-    fn visit_arguments(&mut self, arguments: &ruff_python_ast::Arguments) {
-        for arg in &arguments.args {
-            self.visit_expr(arg);
-        }
-        for keyword in &arguments.keywords {
-            self.visit_expr(&keyword.value);
         }
     }
 
@@ -389,17 +364,16 @@ impl Builder {
     }
 
     fn visit_aug_assign(&mut self, node: &StmtAugAssign) {
-        if let Expr::Name(name) = &*node.target {
+        if let Some(name) = node.target.as_name_expr() {
             self.record_read(name.id.as_str(), name.range().start());
-        }
-        self.visit_expr(&node.value);
-        if let Expr::Name(name) = &*node.target {
+            self.visit_expr(&node.value);
             self.record_write(
                 name.id.as_str(),
                 name.range().start(),
                 BindingKind::AugAssign,
             );
         } else {
+            self.visit_expr(&node.value);
             walk_expr(self, &node.target);
         }
     }
@@ -453,21 +427,13 @@ impl Builder {
         }
         self.visit_body(&node.body);
     }
-
-    fn walk_parameter_defaults(&mut self, parameters: &Parameters) {
-        for parameter in parameters.iter_non_variadic_params() {
-            if let Some(default) = &parameter.default {
-                self.visit_expr(default);
-            }
-        }
-    }
 }
 
 impl<'a> Visitor<'a> for Builder {
     fn visit_expr(&mut self, expr: &'a Expr) {
         match expr {
             Expr::Name(name) => {
-                if matches!(name.ctx, ExprContext::Load) {
+                if name.ctx.is_load() {
                     self.record_read(name.id.as_str(), name.range().start());
                 }
             }

--- a/src/primitives/binding.rs
+++ b/src/primitives/binding.rs
@@ -538,21 +538,6 @@ mod tests {
     }
 
     #[test]
-    fn assignment_count_separates_initial_and_augmented() {
-        let analysis = analyze("x = 0\nx += 1\n");
-        let x = module_binding(&analysis, "x");
-        assert_eq!(analysis.assignment_count(x), 2);
-    }
-
-    #[test]
-    fn augmented_assignment_records_read_then_write() {
-        let analysis = analyze("x = 0\nx += 1\n");
-        let x = module_binding(&analysis, "x");
-        assert_eq!(analysis.usage_count(x), 1);
-        assert_eq!(analysis.assignment_count(x), 2);
-    }
-
-    #[test]
     fn bindings_in_scope_iterates_function_locals() {
         let source = parse("def f(a, b):\n    c = a + b\n    return c\n");
         let analysis = BindingAnalysis::new(source.ast());
@@ -570,64 +555,6 @@ mod tests {
         let analysis = BindingAnalysis::new(source.ast());
         let stmt = &source.ast().body[0];
         assert!(analysis.bindings_in_scope(stmt).next().is_none());
-    }
-
-    #[test]
-    fn class_scope_is_invisible_to_nested_function() {
-        let analysis = analyze("class C:\n    x = 1\n    def m(self):\n        return x\n");
-        let class_scope = analysis
-            .scopes
-            .iter()
-            .find(|s| matches!(s.kind, ScopeKind::Class))
-            .expect("class scope exists");
-        let x_in_class = *class_scope.bindings.get("x").expect("class binds x");
-        assert_eq!(analysis.usage_count(x_in_class), 0);
-    }
-
-    #[test]
-    fn closure_read_attributes_to_outer_binding() {
-        let analysis = analyze("def outer():\n    x = 1\n    def inner():\n        return x\n");
-        let outer_function_scope = &analysis.scopes[1];
-        let x = *outer_function_scope
-            .bindings
-            .get("x")
-            .expect("outer binds x");
-        assert_eq!(analysis.usage_count(x), 1);
-    }
-
-    #[test]
-    fn comprehension_target_stays_in_comprehension_scope() {
-        let analysis = analyze("total = [x for x in xs]\n");
-        let module = &analysis.scopes[0];
-        assert!(module.bindings.contains_key("total"));
-        assert!(!module.bindings.contains_key("x"));
-    }
-
-    #[test]
-    fn except_handler_binding_lives_in_enclosing_scope() {
-        let analysis = analyze("try:\n    f()\nexcept Exception as e:\n    print(e)\n");
-        let e = module_binding(&analysis, "e");
-        assert_eq!(analysis.usage_count(e), 1);
-        assert_eq!(
-            analysis.bindings[e.0 as usize].kinds,
-            vec![BindingKind::ExceptHandler]
-        );
-    }
-
-    #[test]
-    fn import_binds_top_level_module_segment() {
-        let analysis = analyze("import a.b.c\n");
-        let module = &analysis.scopes[0];
-        assert!(module.bindings.contains_key("a"));
-        assert!(!module.bindings.contains_key("a.b.c"));
-    }
-
-    #[test]
-    fn import_with_asname_binds_alias() {
-        let analysis = analyze("import a.b.c as abc\n");
-        let module = &analysis.scopes[0];
-        assert!(module.bindings.contains_key("abc"));
-        assert!(!module.bindings.contains_key("a"));
     }
 
     #[test]
@@ -649,55 +576,11 @@ mod tests {
     }
 
     #[test]
-    fn lambda_parameters_shadow_outer_binding() {
-        let analysis = analyze("x = 1\nf = lambda x: x\n");
-        let lambda_scope = analysis
-            .scopes
-            .iter()
-            .skip(1)
-            .find(|s| matches!(s.kind, ScopeKind::Function))
-            .expect("lambda creates function scope");
-        let inner = *lambda_scope.bindings.get("x").expect("lambda binds x");
-        assert_eq!(analysis.usage_count(inner), 1);
-    }
-
-    #[test]
-    fn nonlocal_and_global_statements_are_inert() {
-        let analysis = analyze("def f():\n    global x\n    x = 1\n");
-        let module = &analysis.scopes[0];
-        assert!(!module.bindings.contains_key("x"));
-        let function_scope = &analysis.scopes[1];
-        assert!(function_scope.bindings.contains_key("x"));
-    }
-
-    #[test]
     fn top_level_module_returns_first_segment() {
         assert_eq!(top_level_module("a"), "a");
         assert_eq!(top_level_module("a.b"), "a");
         assert_eq!(top_level_module("a.b.c"), "a");
         assert_eq!(top_level_module(""), "");
-    }
-
-    #[test]
-    fn tuple_target_records_each_element() {
-        let analysis = analyze("a, b = (1, 2)\n");
-        let module = &analysis.scopes[0];
-        assert!(module.bindings.contains_key("a"));
-        assert!(module.bindings.contains_key("b"));
-    }
-
-    #[test]
-    fn walrus_target_lifts_out_of_comprehension_scope() {
-        let analysis = analyze("xs = [1]\nvals = [y for x in xs if (y := x + 1) > 0]\n");
-        let module = &analysis.scopes[0];
-        let y = *module
-            .bindings
-            .get("y")
-            .expect("walrus binds y at module scope");
-        assert_eq!(
-            analysis.bindings[y.0 as usize].kinds,
-            vec![BindingKind::Walrus]
-        );
     }
 
     proptest! {

--- a/src/primitives/binding.rs
+++ b/src/primitives/binding.rs
@@ -1,0 +1,750 @@
+//! Per-`Source` binding-resolution table.
+//!
+//! Walks the module once and records, for every name introduced or
+//! shadowed in a lexical scope, the offsets of every write and read.
+//! Consuming rules query the table by `BindingId` or by `&Stmt`
+//! rather than driving their own walk.
+//!
+//! ## Scope model
+//!
+//! Each scope is one of `Module`, `Function`, `Class`, or
+//! `Comprehension`. The scope stack mirrors source-order nesting:
+//! every `function-def`, `lambda`, `class-def`, and comprehension
+//! pushes a frame, every comprehension's first generator iterable
+//! evaluates in the enclosing scope, every walrus target lifts to
+//! the nearest non-comprehension scope, and class-scope names are
+//! invisible to nested functions and comprehensions.
+
+use std::collections::{BTreeMap, HashMap};
+
+use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::{
+    Expr, ExprContext, ExprDictComp, ExprGenerator, ExprLambda, ExprListComp, ExprNamed,
+    ExprSetComp, Identifier, ModModule, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtAugAssign,
+    StmtClassDef, StmtFor, StmtFunctionDef, StmtImport, StmtImportFrom, StmtTry, StmtWith,
+};
+use ruff_text_size::{Ranged, TextSize};
+use serde::Serialize;
+
+/// Stable handle to a binding in `BindingAnalysis`. Cheap to copy.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub(crate) struct BindingId(u32);
+
+/// Stable handle to a scope in `BindingAnalysis`. Cheap to copy.
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ScopeId(u32);
+
+/// Categories of write event recorded against a binding.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) enum BindingKind {
+    Assignment,
+    AugAssign,
+    ClassDef,
+    Comprehension,
+    ExceptHandler,
+    For,
+    FunctionDef,
+    Import,
+    Parameter,
+    Walrus,
+    With,
+}
+
+/// Categories of lexical scope.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) enum ScopeKind {
+    Class,
+    Comprehension,
+    Function,
+    Module,
+}
+
+/// One named binding in some scope, with every observed write and read.
+#[derive(Debug, Serialize)]
+pub(crate) struct Binding {
+    kinds: Vec<BindingKind>,
+    name: String,
+    read_offsets: Vec<TextSize>,
+    scope: ScopeId,
+    write_offsets: Vec<TextSize>,
+}
+
+/// One lexical scope plus its binding table keyed by name.
+#[derive(Debug, Serialize)]
+pub(crate) struct Scope {
+    bindings: BTreeMap<String, BindingId>,
+    kind: ScopeKind,
+    parent: Option<ScopeId>,
+}
+
+/// Module-wide binding-resolution table.
+#[derive(Debug, Serialize)]
+pub struct BindingAnalysis {
+    bindings: Vec<Binding>,
+    #[serde(skip)]
+    function_scope_at: HashMap<TextSize, ScopeId>,
+    scopes: Vec<Scope>,
+}
+
+const MODULE_SCOPE: ScopeId = ScopeId(0);
+
+#[allow(dead_code, reason = "consumer rules #62 and #70 land later in 0.2.0")]
+impl BindingAnalysis {
+    /// Walks `module` once and returns the resulting binding table.
+    pub(crate) fn new(module: &ModModule) -> Self {
+        let mut builder = Builder::new();
+        builder.visit_body(&module.body);
+        builder.finish()
+    }
+
+    fn binding(&self, id: BindingId) -> &Binding {
+        &self.bindings[id.0 as usize]
+    }
+
+    /// Returns the number of write events recorded for `binding`.
+    pub(crate) fn assignment_count(&self, binding: BindingId) -> usize {
+        self.binding(binding).write_offsets.len()
+    }
+
+    /// Returns the binding ids declared directly inside the local
+    /// scope of `stmt`. `stmt` must be a `Stmt::FunctionDef`; any
+    /// other statement yields an empty iterator.
+    pub(crate) fn bindings_in_scope(&self, stmt: &Stmt) -> impl Iterator<Item = BindingId> + '_ {
+        self.function_scope_at
+            .get(&stmt.range().start())
+            .copied()
+            .into_iter()
+            .flat_map(move |s| self.scopes[s.0 as usize].bindings.values().copied())
+    }
+
+    /// Returns `true` when `name` has a module-scope write event at
+    /// any offset strictly less than `offset`.
+    pub(crate) fn is_defined_before(&self, name: &str, offset: TextSize) -> bool {
+        self.scopes[MODULE_SCOPE.0 as usize]
+            .bindings
+            .get(name)
+            .is_some_and(|&id| self.binding(id).write_offsets.iter().any(|&o| o < offset))
+    }
+
+    /// Returns the number of read events recorded for `binding`.
+    pub(crate) fn usage_count(&self, binding: BindingId) -> usize {
+        self.binding(binding).read_offsets.len()
+    }
+}
+
+struct Builder {
+    bindings: Vec<Binding>,
+    function_scope_at: HashMap<TextSize, ScopeId>,
+    scope_stack: Vec<ScopeId>,
+    scopes: Vec<Scope>,
+}
+
+impl Builder {
+    fn new() -> Self {
+        let mut builder = Self {
+            bindings: Vec::new(),
+            function_scope_at: HashMap::new(),
+            scope_stack: Vec::new(),
+            scopes: Vec::new(),
+        };
+        builder.push_scope(ScopeKind::Module, None);
+        builder
+    }
+
+    fn current_scope(&self) -> ScopeId {
+        *self
+            .scope_stack
+            .last()
+            .expect("invariant: module scope is always present")
+    }
+
+    fn enter_class(&mut self, class: &StmtClassDef) {
+        for decorator in &class.decorator_list {
+            self.visit_expr(&decorator.expression);
+        }
+        if let Some(arguments) = &class.arguments {
+            self.visit_arguments(arguments);
+        }
+        self.record_identifier(&class.name, BindingKind::ClassDef);
+        let parent = Some(self.current_scope());
+        self.push_scope(ScopeKind::Class, parent);
+        self.visit_body(&class.body);
+        self.pop_scope();
+    }
+
+    fn enter_comprehension(
+        &mut self,
+        generators: &[ruff_python_ast::Comprehension],
+        elements: &[&Expr],
+    ) {
+        let (first, rest) = generators
+            .split_first()
+            .expect("invariant: comprehension carries at least one generator");
+        self.visit_expr(&first.iter);
+        let parent = Some(self.current_scope());
+        self.push_scope(ScopeKind::Comprehension, parent);
+        self.record_target(&first.target, BindingKind::Comprehension);
+        for guard in &first.ifs {
+            self.visit_expr(guard);
+        }
+        for generator in rest {
+            self.visit_expr(&generator.iter);
+            self.record_target(&generator.target, BindingKind::Comprehension);
+            for guard in &generator.ifs {
+                self.visit_expr(guard);
+            }
+        }
+        for element in elements {
+            self.visit_expr(element);
+        }
+        self.pop_scope();
+    }
+
+    fn enter_function(&mut self, function: &StmtFunctionDef, stmt_start: TextSize) {
+        for decorator in &function.decorator_list {
+            self.visit_expr(&decorator.expression);
+        }
+        self.walk_parameter_defaults(&function.parameters);
+        for parameter in function.parameters.iter_source_order() {
+            if let Some(annotation) = parameter.annotation() {
+                self.visit_expr(annotation);
+            }
+        }
+        if let Some(returns) = &function.returns {
+            self.visit_expr(returns);
+        }
+        self.record_identifier(&function.name, BindingKind::FunctionDef);
+        let parent = Some(self.current_scope());
+        let function_scope = self.push_scope(ScopeKind::Function, parent);
+        self.function_scope_at.insert(stmt_start, function_scope);
+        self.record_parameters(&function.parameters);
+        self.visit_body(&function.body);
+        self.pop_scope();
+    }
+
+    fn enter_lambda(&mut self, lambda: &ExprLambda) {
+        if let Some(parameters) = &lambda.parameters {
+            self.walk_parameter_defaults(parameters);
+        }
+        let parent = Some(self.current_scope());
+        self.push_scope(ScopeKind::Function, parent);
+        if let Some(parameters) = &lambda.parameters {
+            self.record_parameters(parameters);
+        }
+        self.visit_expr(&lambda.body);
+        self.pop_scope();
+    }
+
+    fn finish(self) -> BindingAnalysis {
+        BindingAnalysis {
+            scopes: self.scopes,
+            bindings: self.bindings,
+            function_scope_at: self.function_scope_at,
+        }
+    }
+
+    fn pop_scope(&mut self) {
+        self.scope_stack
+            .pop()
+            .expect("invariant: pop balanced with push");
+    }
+
+    fn push_scope(&mut self, kind: ScopeKind, parent: Option<ScopeId>) -> ScopeId {
+        let id = ScopeId(u32::try_from(self.scopes.len()).expect("scope count fits in u32"));
+        self.scopes.push(Scope {
+            kind,
+            parent,
+            bindings: BTreeMap::new(),
+        });
+        self.scope_stack.push(id);
+        id
+    }
+
+    fn record_identifier(&mut self, identifier: &Identifier, kind: BindingKind) {
+        self.record_write(identifier.as_str(), identifier.range().start(), kind);
+    }
+
+    fn record_parameters(&mut self, parameters: &Parameters) {
+        for parameter in parameters.iter_source_order() {
+            self.record_identifier(parameter.name(), BindingKind::Parameter);
+        }
+    }
+
+    fn record_read(&mut self, name: &str, offset: TextSize) {
+        let innermost = self.current_scope();
+        for &scope_id in self.scope_stack.iter().rev() {
+            let scope = &self.scopes[scope_id.0 as usize];
+            if scope_id != innermost && matches!(scope.kind, ScopeKind::Class) {
+                continue;
+            }
+            if let Some(&binding_id) = scope.bindings.get(name) {
+                self.bindings[binding_id.0 as usize]
+                    .read_offsets
+                    .push(offset);
+                return;
+            }
+        }
+    }
+
+    fn record_target(&mut self, target: &Expr, kind: BindingKind) {
+        match target {
+            Expr::Name(name) => {
+                self.record_write(name.id.as_str(), name.range().start(), kind);
+            }
+            Expr::Tuple(tuple) => {
+                for element in &tuple.elts {
+                    self.record_target(element, kind);
+                }
+            }
+            Expr::List(list) => {
+                for element in &list.elts {
+                    self.record_target(element, kind);
+                }
+            }
+            Expr::Starred(starred) => self.record_target(&starred.value, kind),
+            Expr::Attribute(attribute) => self.visit_expr(&attribute.value),
+            Expr::Subscript(subscript) => {
+                self.visit_expr(&subscript.value);
+                self.visit_expr(&subscript.slice);
+            }
+            _ => {}
+        }
+    }
+
+    fn record_walrus(&mut self, named: &ExprNamed) {
+        self.visit_expr(&named.value);
+        let Expr::Name(name) = &*named.target else {
+            unreachable!("invariant: walrus target is always Expr::Name (parser guarantee)");
+        };
+        let scope = self
+            .scope_stack
+            .iter()
+            .rev()
+            .copied()
+            .find(|&id| !matches!(self.scopes[id.0 as usize].kind, ScopeKind::Comprehension))
+            .expect("invariant: module scope is always present");
+        self.record_write_in(
+            scope,
+            name.id.as_str(),
+            name.range().start(),
+            BindingKind::Walrus,
+        );
+    }
+
+    fn record_write(&mut self, name: &str, offset: TextSize, kind: BindingKind) {
+        let scope = self.current_scope();
+        self.record_write_in(scope, name, offset, kind);
+    }
+
+    fn record_write_in(&mut self, scope: ScopeId, name: &str, offset: TextSize, kind: BindingKind) {
+        let scope_data = &mut self.scopes[scope.0 as usize];
+        let binding_id = if let Some(&id) = scope_data.bindings.get(name) {
+            id
+        } else {
+            let id =
+                BindingId(u32::try_from(self.bindings.len()).expect("binding count fits in u32"));
+            scope_data.bindings.insert(name.to_owned(), id);
+            self.bindings.push(Binding {
+                name: name.to_owned(),
+                scope,
+                kinds: Vec::new(),
+                write_offsets: Vec::new(),
+                read_offsets: Vec::new(),
+            });
+            id
+        };
+        let binding = &mut self.bindings[binding_id.0 as usize];
+        if !binding.kinds.contains(&kind) {
+            binding.kinds.push(kind);
+        }
+        binding.write_offsets.push(offset);
+    }
+
+    fn visit_ann_assign(&mut self, node: &StmtAnnAssign) {
+        self.visit_expr(&node.annotation);
+        if let Some(value) = &node.value {
+            self.visit_expr(value);
+        }
+        if let Expr::Name(_) = &*node.target {
+            self.record_target(&node.target, BindingKind::Assignment);
+        }
+    }
+
+    fn visit_arguments(&mut self, arguments: &ruff_python_ast::Arguments) {
+        for arg in &arguments.args {
+            self.visit_expr(arg);
+        }
+        for keyword in &arguments.keywords {
+            self.visit_expr(&keyword.value);
+        }
+    }
+
+    fn visit_assign(&mut self, node: &StmtAssign) {
+        self.visit_expr(&node.value);
+        for target in &node.targets {
+            self.record_target(target, BindingKind::Assignment);
+        }
+    }
+
+    fn visit_aug_assign(&mut self, node: &StmtAugAssign) {
+        if let Expr::Name(name) = &*node.target {
+            self.record_read(name.id.as_str(), name.range().start());
+        }
+        self.visit_expr(&node.value);
+        if let Expr::Name(name) = &*node.target {
+            self.record_write(
+                name.id.as_str(),
+                name.range().start(),
+                BindingKind::AugAssign,
+            );
+        } else {
+            walk_expr(self, &node.target);
+        }
+    }
+
+    fn visit_for(&mut self, node: &StmtFor) {
+        self.visit_expr(&node.iter);
+        self.record_target(&node.target, BindingKind::For);
+        self.visit_body(&node.body);
+        self.visit_body(&node.orelse);
+    }
+
+    fn visit_import(&mut self, node: &StmtImport) {
+        for alias in &node.names {
+            let bound = alias
+                .asname
+                .as_ref()
+                .map_or_else(|| top_level_module(alias.name.as_str()), |id| id.as_str());
+            self.record_write(bound, alias.range().start(), BindingKind::Import);
+        }
+    }
+
+    fn visit_import_from(&mut self, node: &StmtImportFrom) {
+        for alias in &node.names {
+            let bound = alias.asname.as_ref().unwrap_or(&alias.name);
+            self.record_write(bound.as_str(), alias.range().start(), BindingKind::Import);
+        }
+    }
+
+    fn visit_try(&mut self, node: &StmtTry) {
+        self.visit_body(&node.body);
+        for handler in &node.handlers {
+            let ruff_python_ast::ExceptHandler::ExceptHandler(eh) = handler;
+            if let Some(type_) = &eh.type_ {
+                self.visit_expr(type_);
+            }
+            if let Some(name) = &eh.name {
+                self.record_identifier(name, BindingKind::ExceptHandler);
+            }
+            self.visit_body(&eh.body);
+        }
+        self.visit_body(&node.orelse);
+        self.visit_body(&node.finalbody);
+    }
+
+    fn visit_with(&mut self, node: &StmtWith) {
+        for item in &node.items {
+            self.visit_expr(&item.context_expr);
+            if let Some(target) = &item.optional_vars {
+                self.record_target(target, BindingKind::With);
+            }
+        }
+        self.visit_body(&node.body);
+    }
+
+    fn walk_parameter_defaults(&mut self, parameters: &Parameters) {
+        for parameter in parameters.iter_non_variadic_params() {
+            if let Some(default) = &parameter.default {
+                self.visit_expr(default);
+            }
+        }
+    }
+}
+
+impl<'a> Visitor<'a> for Builder {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        match expr {
+            Expr::Name(name) => {
+                if matches!(name.ctx, ExprContext::Load) {
+                    self.record_read(name.id.as_str(), name.range().start());
+                }
+            }
+            Expr::Named(named) => self.record_walrus(named),
+            Expr::Lambda(lambda) => self.enter_lambda(lambda),
+            Expr::ListComp(ExprListComp {
+                generators, elt, ..
+            })
+            | Expr::SetComp(ExprSetComp {
+                generators, elt, ..
+            })
+            | Expr::Generator(ExprGenerator {
+                generators, elt, ..
+            }) => self.enter_comprehension(generators, &[elt]),
+            Expr::DictComp(ExprDictComp {
+                generators,
+                key,
+                value,
+                ..
+            }) => self.enter_comprehension(generators, &[key, value]),
+            _ => walk_expr(self, expr),
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::AnnAssign(node) => self.visit_ann_assign(node),
+            Stmt::Assign(node) => self.visit_assign(node),
+            Stmt::AugAssign(node) => self.visit_aug_assign(node),
+            Stmt::ClassDef(node) => self.enter_class(node),
+            Stmt::For(node) => self.visit_for(node),
+            Stmt::FunctionDef(node) => self.enter_function(node, stmt.range().start()),
+            Stmt::Global(_) | Stmt::Nonlocal(_) => {}
+            Stmt::Import(node) => self.visit_import(node),
+            Stmt::ImportFrom(node) => self.visit_import_from(node),
+            Stmt::Try(node) => self.visit_try(node),
+            Stmt::With(node) => self.visit_with(node),
+            _ => walk_stmt(self, stmt),
+        }
+    }
+}
+
+/// Returns the segment of `dotted` before the first `.`. Matches
+/// Python's `import a.b.c` shape, which binds `a` rather than the
+/// full dotted path.
+fn top_level_module(dotted: &str) -> &str {
+    dotted.split_once('.').map_or(dotted, |(head, _)| head)
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use ruff_text_size::TextSize;
+
+    use super::*;
+    use crate::test_support::parse;
+
+    fn analyze(src: &str) -> BindingAnalysis {
+        BindingAnalysis::new(parse(src).ast())
+    }
+
+    fn module_binding(analysis: &BindingAnalysis, name: &str) -> BindingId {
+        analysis.scopes[0]
+            .bindings
+            .get(name)
+            .copied()
+            .unwrap_or_else(|| panic!("no module-scope binding for {name:?}"))
+    }
+
+    #[test]
+    fn assignment_count_separates_initial_and_augmented() {
+        let analysis = analyze("x = 0\nx += 1\n");
+        let x = module_binding(&analysis, "x");
+        assert_eq!(analysis.assignment_count(x), 2);
+    }
+
+    #[test]
+    fn augmented_assignment_records_read_then_write() {
+        let analysis = analyze("x = 0\nx += 1\n");
+        let x = module_binding(&analysis, "x");
+        assert_eq!(analysis.usage_count(x), 1);
+        assert_eq!(analysis.assignment_count(x), 2);
+    }
+
+    #[test]
+    fn bindings_in_scope_iterates_function_locals() {
+        let source = parse("def f(a, b):\n    c = a + b\n    return c\n");
+        let analysis = BindingAnalysis::new(source.ast());
+        let stmt = &source.ast().body[0];
+        let names: Vec<&str> = analysis
+            .bindings_in_scope(stmt)
+            .map(|id| analysis.bindings[id.0 as usize].name.as_str())
+            .collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn bindings_in_scope_returns_empty_for_non_function_stmt() {
+        let source = parse("x = 1\n");
+        let analysis = BindingAnalysis::new(source.ast());
+        let stmt = &source.ast().body[0];
+        assert!(analysis.bindings_in_scope(stmt).next().is_none());
+    }
+
+    #[test]
+    fn class_scope_is_invisible_to_nested_function() {
+        let analysis = analyze("class C:\n    x = 1\n    def m(self):\n        return x\n");
+        let class_scope = analysis
+            .scopes
+            .iter()
+            .find(|s| matches!(s.kind, ScopeKind::Class))
+            .expect("class scope exists");
+        let x_in_class = *class_scope.bindings.get("x").expect("class binds x");
+        assert_eq!(analysis.usage_count(x_in_class), 0);
+    }
+
+    #[test]
+    fn closure_read_attributes_to_outer_binding() {
+        let analysis = analyze("def outer():\n    x = 1\n    def inner():\n        return x\n");
+        let outer_function_scope = &analysis.scopes[1];
+        let x = *outer_function_scope
+            .bindings
+            .get("x")
+            .expect("outer binds x");
+        assert_eq!(analysis.usage_count(x), 1);
+    }
+
+    #[test]
+    fn comprehension_target_stays_in_comprehension_scope() {
+        let analysis = analyze("total = [x for x in xs]\n");
+        let module = &analysis.scopes[0];
+        assert!(module.bindings.contains_key("total"));
+        assert!(!module.bindings.contains_key("x"));
+    }
+
+    #[test]
+    fn except_handler_binding_lives_in_enclosing_scope() {
+        let analysis = analyze("try:\n    f()\nexcept Exception as e:\n    print(e)\n");
+        let e = module_binding(&analysis, "e");
+        assert_eq!(analysis.usage_count(e), 1);
+        assert_eq!(
+            analysis.bindings[e.0 as usize].kinds,
+            vec![BindingKind::ExceptHandler]
+        );
+    }
+
+    #[test]
+    fn import_binds_top_level_module_segment() {
+        let analysis = analyze("import a.b.c\n");
+        let module = &analysis.scopes[0];
+        assert!(module.bindings.contains_key("a"));
+        assert!(!module.bindings.contains_key("a.b.c"));
+    }
+
+    #[test]
+    fn import_with_asname_binds_alias() {
+        let analysis = analyze("import a.b.c as abc\n");
+        let module = &analysis.scopes[0];
+        assert!(module.bindings.contains_key("abc"));
+        assert!(!module.bindings.contains_key("a"));
+    }
+
+    #[test]
+    fn is_defined_before_returns_false_for_undefined_name() {
+        let analysis = analyze("x = 1\n");
+        assert!(!analysis.is_defined_before("y", TextSize::new(100)));
+    }
+
+    #[test]
+    fn is_defined_before_returns_false_when_only_write_is_after_offset() {
+        let analysis = analyze("x = 1\n");
+        assert!(!analysis.is_defined_before("x", TextSize::new(0)));
+    }
+
+    #[test]
+    fn is_defined_before_returns_true_for_prior_module_write() {
+        let analysis = analyze("x = 1\nprint(x)\n");
+        assert!(analysis.is_defined_before("x", TextSize::new(10)));
+    }
+
+    #[test]
+    fn lambda_parameters_shadow_outer_binding() {
+        let analysis = analyze("x = 1\nf = lambda x: x\n");
+        let lambda_scope = analysis
+            .scopes
+            .iter()
+            .skip(1)
+            .find(|s| matches!(s.kind, ScopeKind::Function))
+            .expect("lambda creates function scope");
+        let inner = *lambda_scope.bindings.get("x").expect("lambda binds x");
+        assert_eq!(analysis.usage_count(inner), 1);
+    }
+
+    #[test]
+    fn nonlocal_and_global_statements_are_inert() {
+        let analysis = analyze("def f():\n    global x\n    x = 1\n");
+        let module = &analysis.scopes[0];
+        assert!(!module.bindings.contains_key("x"));
+        let function_scope = &analysis.scopes[1];
+        assert!(function_scope.bindings.contains_key("x"));
+    }
+
+    #[test]
+    fn top_level_module_returns_first_segment() {
+        assert_eq!(top_level_module("a"), "a");
+        assert_eq!(top_level_module("a.b"), "a");
+        assert_eq!(top_level_module("a.b.c"), "a");
+        assert_eq!(top_level_module(""), "");
+    }
+
+    #[test]
+    fn tuple_target_records_each_element() {
+        let analysis = analyze("a, b = (1, 2)\n");
+        let module = &analysis.scopes[0];
+        assert!(module.bindings.contains_key("a"));
+        assert!(module.bindings.contains_key("b"));
+    }
+
+    #[test]
+    fn walrus_target_lifts_out_of_comprehension_scope() {
+        let analysis = analyze("xs = [1]\nvals = [y for x in xs if (y := x + 1) > 0]\n");
+        let module = &analysis.scopes[0];
+        let y = *module
+            .bindings
+            .get("y")
+            .expect("walrus binds y at module scope");
+        assert_eq!(
+            analysis.bindings[y.0 as usize].kinds,
+            vec![BindingKind::Walrus]
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn closure_binding_is_independent_of_outer_same_name(
+            tail in "[a-z0-9]{0,5}"
+        ) {
+            let name = format!("x{tail}");
+            let program = format!(
+                "{name} = 1\ndef inner():\n    {name} = 2\n    return {name}\n",
+            );
+            let analysis = analyze(&program);
+            let outer = module_binding(&analysis, &name);
+            let inner_scope = analysis
+                .scopes
+                .iter()
+                .find(|s| matches!(s.kind, ScopeKind::Function))
+                .expect("inner is a function scope");
+            let inner = *inner_scope
+                .bindings
+                .get(&name)
+                .expect("inner shadows name");
+            prop_assert_ne!(outer, inner);
+            prop_assert_eq!(analysis.usage_count(outer), 0);
+            prop_assert_eq!(analysis.usage_count(inner), 1);
+        }
+
+        #[test]
+        fn single_use_name_reports_usage_count_one(
+            tail in "[a-z0-9]{0,5}"
+        ) {
+            let name = format!("x{tail}");
+            let program = format!("{name} = 1\nprint({name})\n");
+            let analysis = analyze(&program);
+            let id = module_binding(&analysis, &name);
+            prop_assert_eq!(analysis.usage_count(id), 1);
+        }
+
+        #[test]
+        fn unread_name_reports_usage_count_zero(
+            tail in "[a-z0-9]{0,5}"
+        ) {
+            let name = format!("x{tail}");
+            let program = format!("{name} = 1\n");
+            let analysis = analyze(&program);
+            let id = module_binding(&analysis, &name);
+            prop_assert_eq!(analysis.usage_count(id), 0);
+        }
+    }
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,5 +1,7 @@
 //! Shared primitives used across rule implementations. `aligner`
-//! emits alignment edits for groups sharing a token. `colon_targets`
+//! emits alignment edits for groups sharing a token. `binding`
+//! walks the AST once and records every name's writes and reads for
+//! consumers that ask scope-aware questions. `colon_targets`
 //! constructs alignment members at every `:` context the alignment
 //! and singleton rules consume. `edit` shapes replacement text into
 //! minimal-range edits and folds inline edits into source slices.
@@ -7,6 +9,7 @@
 //! preserving attached comments and inter-section content.
 
 pub(crate) mod aligner;
+pub(crate) mod binding;
 pub(crate) mod colon_targets;
 pub(crate) mod edit;
 pub(crate) mod orderer;

--- a/src/source.rs
+++ b/src/source.rs
@@ -17,15 +17,19 @@ use ruff_source_file::{
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use thiserror::Error;
 
+use crate::primitives::binding::BindingAnalysis;
 use crate::suppression::SuppressionMap;
 
 /// Owned wrapper around a parsed Python source file.
 ///
 /// Holds the source text, the parsed AST, the token stream, a lazy
 /// line index, a `CommentRanges` index built during parsing, and a
-/// `SuppressionMap` of `# fmt: off` / `# fmt: skip` spans.
+/// `SuppressionMap` of `# fmt: off` / `# fmt: skip` spans, plus a
+/// `BindingAnalysis` table of every name's writes and reads.
 #[derive(Debug)]
 pub struct Source {
+    #[allow(dead_code, reason = "consumer rules #62 and #70 land later in 0.2.0")]
+    binding_analysis: Box<BindingAnalysis>,
     comment_ranges: CommentRanges,
     file: SourceFile,
     parsed: Parsed<ModModule>,
@@ -41,7 +45,9 @@ impl Source {
             &file.to_source_code(),
             &comment_ranges,
         ));
+        let binding_analysis = Box::new(BindingAnalysis::new(parsed.syntax()));
         Ok(Self {
+            binding_analysis,
             comment_ranges,
             file,
             parsed,
@@ -65,6 +71,11 @@ impl Source {
 
     pub fn ast(&self) -> &ModModule {
         self.parsed.syntax()
+    }
+
+    /// Returns the binding-analysis table built during parsing.
+    pub fn binding_analysis(&self) -> &BindingAnalysis {
+        &self.binding_analysis
     }
 
     /// Returns the zero-indexed character column of `offset` on its line.

--- a/src/source.rs
+++ b/src/source.rs
@@ -28,7 +28,6 @@ use crate::suppression::SuppressionMap;
 /// `BindingAnalysis` table of every name's writes and reads.
 #[derive(Debug)]
 pub struct Source {
-    #[allow(dead_code, reason = "consumer rules #62 and #70 land later in 0.2.0")]
     binding_analysis: Box<BindingAnalysis>,
     comment_ranges: CommentRanges,
     file: SourceFile,

--- a/tests/binding_analysis.rs
+++ b/tests/binding_analysis.rs
@@ -1,0 +1,23 @@
+//! Snapshot tests for the binding-analysis primitive. Each fixture
+//! parses, runs `BindingAnalysis::new` through `Source`, and dumps
+//! the resulting binding table as YAML for review.
+
+mod common;
+
+use std::ffi::OsStr;
+
+use prose::source::Source;
+
+#[test]
+fn binding_tables() {
+    insta::glob!("fixtures/binding_analysis/*.input.py", |path| {
+        let case = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("fixture path has a file name");
+        let source = Source::from_path(path).expect("fixture parses");
+        common::in_snapshot_dir("binding_analysis", || {
+            insta::assert_yaml_snapshot!(case, source.binding_analysis());
+        });
+    });
+}

--- a/tests/diagnostics.rs
+++ b/tests/diagnostics.rs
@@ -15,7 +15,7 @@ use prose::source::Source;
 fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
     match directory {
         "composition" | "suppression" => Pipeline::with_defaults(config),
-        "identity" => Pipeline::empty(),
+        "binding_analysis" | "identity" => Pipeline::empty(),
         _ => Pipeline::for_rule(directory, config)
             .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),
     }

--- a/tests/fixtures/binding_analysis/annotated_assignment.input.py
+++ b/tests/fixtures/binding_analysis/annotated_assignment.input.py
@@ -1,0 +1,10 @@
+"""
+Annotated assignment records a write at the target offset. The
+annotation expression is visited as a read, attributing a read to
+each name it references.
+"""
+
+
+Pair = tuple[int, int]
+x: int = 0
+y: Pair = (1, 2)

--- a/tests/fixtures/binding_analysis/augmented_assignment.input.py
+++ b/tests/fixtures/binding_analysis/augmented_assignment.input.py
@@ -1,0 +1,10 @@
+"""
+An augmented assignment counts as one read plus one write, so the
+target's `assignment_count` jumps and its kind list carries `AugAssign`
+alongside the initial `Assignment`.
+"""
+
+
+x  = 0
+x += 1
+x += 2

--- a/tests/fixtures/binding_analysis/class_method_lookup.input.py
+++ b/tests/fixtures/binding_analysis/class_method_lookup.input.py
@@ -1,0 +1,15 @@
+"""
+A class-body binding is invisible to a nested method's lookup
+chain. The method's reference to the same name walks past the class
+scope and resolves to the outer binding instead.
+"""
+
+
+x = "outer"
+
+
+class C:
+    x = "inner"
+
+    def get(self):
+        return x

--- a/tests/fixtures/binding_analysis/closure.input.py
+++ b/tests/fixtures/binding_analysis/closure.input.py
@@ -1,0 +1,13 @@
+"""
+A nested function reading an outer-scope name attributes one usage to
+the outer binding, leaving the inner scope free of a shadowing entry.
+"""
+
+
+def outer():
+    x = 1
+
+    def inner():
+        return x
+
+    return inner

--- a/tests/fixtures/binding_analysis/comprehension_scope.input.py
+++ b/tests/fixtures/binding_analysis/comprehension_scope.input.py
@@ -1,0 +1,9 @@
+"""
+A comprehension target sits in its own scope and never bleeds into the
+module table, even when its name matches an existing module binding.
+"""
+
+
+xs   = [1, 2, 3]
+x    = "outer"
+vals = [x for x in xs]

--- a/tests/fixtures/binding_analysis/conditional_rebind.input.py
+++ b/tests/fixtures/binding_analysis/conditional_rebind.input.py
@@ -1,0 +1,13 @@
+"""
+A name rebound across the arms of an `if` collapses into a single
+module-scope binding with two write offsets, regardless of which arm
+runs at runtime.
+"""
+
+
+cond = True
+if cond:
+    x = 1
+else:
+    x = 2
+print(x)

--- a/tests/fixtures/binding_analysis/dict_comp_and_generator.input.py
+++ b/tests/fixtures/binding_analysis/dict_comp_and_generator.input.py
@@ -1,0 +1,11 @@
+"""
+Non-list comprehension shapes (`{k: v for ...}`, `{x for ...}`,
+`(x for ...)`) push their own comprehension scope alongside the
+already-covered list-comprehension shape.
+"""
+
+
+pairs = [("a", 1), ("b", 2)]
+mapping = {k: v for k, v in pairs}
+keys = {k for k, _ in pairs}
+total = sum(v for _, v in pairs)

--- a/tests/fixtures/binding_analysis/dunder_private.input.py
+++ b/tests/fixtures/binding_analysis/dunder_private.input.py
@@ -1,0 +1,12 @@
+"""
+A class-body `__name` assignment lives in the class scope, invisible to
+nested methods, with its sibling method definition recording its own
+function-scope binding for `self`.
+"""
+
+
+class C:
+    __secret = 1
+
+    def get(self):
+        return self

--- a/tests/fixtures/binding_analysis/exception_binding.input.py
+++ b/tests/fixtures/binding_analysis/exception_binding.input.py
@@ -1,0 +1,11 @@
+"""
+An `except ... as` clause introduces a binding in the enclosing scope,
+classified as `ExceptHandler`, with reads inside the body counted.
+"""
+
+
+try:
+    open("missing")
+except FileNotFoundError as e:
+    print(e)
+    print(e)

--- a/tests/fixtures/binding_analysis/for_loop.input.py
+++ b/tests/fixtures/binding_analysis/for_loop.input.py
@@ -1,0 +1,11 @@
+"""
+A for-loop target binds in the enclosing scope and may be a single
+name or a tuple destructuring. The iter is visited as a read.
+"""
+
+
+xs = [(1, 2), (3, 4)]
+for i in xs:
+    print(i)
+for a, b in xs:
+    print(a + b)

--- a/tests/fixtures/binding_analysis/imports.input.py
+++ b/tests/fixtures/binding_analysis/imports.input.py
@@ -1,0 +1,13 @@
+"""
+`import` binds the top-level module segment by default and the
+explicit asname when present. `from ... import` binds each name
+(or its asname) without the dotted-path step.
+"""
+
+
+import a
+import b.c.d
+import e.f as g
+from h import i
+from j import k as l
+from __future__ import annotations

--- a/tests/fixtures/binding_analysis/lambda.input.py
+++ b/tests/fixtures/binding_analysis/lambda.input.py
@@ -1,0 +1,8 @@
+"""
+A lambda opens its own function scope. Parameters bind inside the
+lambda scope and shadow same-named outer bindings.
+"""
+
+
+x = 1
+f = lambda x: x

--- a/tests/fixtures/binding_analysis/non_name_targets.input.py
+++ b/tests/fixtures/binding_analysis/non_name_targets.input.py
@@ -1,0 +1,20 @@
+"""
+Assignment targets beyond plain `Expr::Name`. Attribute and
+subscript targets walk the receiver and index as reads without
+introducing a binding. Tuple, list, and starred targets recurse
+into their contained names.
+"""
+
+
+class Holder:
+    pass
+
+
+obj      = Holder()
+ix       = 0
+xs       = [1, 2, 3]
+obj.attr = 1
+obj[ix]  = 2
+a, b = (1, 2)
+*head, tail = xs
+[c, d] = (3, 4)

--- a/tests/fixtures/binding_analysis/nonlocal_global.input.py
+++ b/tests/fixtures/binding_analysis/nonlocal_global.input.py
@@ -1,0 +1,18 @@
+"""
+`global` and `nonlocal` declarations are ignored. Subsequent writes
+to the declared names bind in the local function scope without
+rewriting outward.
+"""
+
+
+def globalized():
+    global x
+    x = 1
+
+
+def nested():
+    y = 0
+    def inner():
+        nonlocal y
+        y = 1
+    inner()

--- a/tests/fixtures/binding_analysis/walrus.input.py
+++ b/tests/fixtures/binding_analysis/walrus.input.py
@@ -1,0 +1,10 @@
+"""
+A walrus inside a function-body conditional binds its target in the
+enclosing function scope, distinct from the iter-source name.
+"""
+
+
+def first_one(items):
+    if (n := len(items)) == 1:
+        return n
+    return None

--- a/tests/fixtures/binding_analysis/walrus_in_comprehension.input.py
+++ b/tests/fixtures/binding_analysis/walrus_in_comprehension.input.py
@@ -1,0 +1,9 @@
+"""
+A walrus target inside a comprehension lifts to the nearest
+non-comprehension scope. The comprehension target stays scope-local
+while the walrus target becomes a module-level binding.
+"""
+
+
+xs = [1, 2, 3]
+vals = [y for x in xs if (y := x * 2) > 0]

--- a/tests/fixtures/binding_analysis/with_statement.input.py
+++ b/tests/fixtures/binding_analysis/with_statement.input.py
@@ -1,0 +1,9 @@
+"""
+A `with ... as` clause binds the as-target in the enclosing scope.
+Reads of the binding inside the body resolve back to that target.
+"""
+
+
+def read_lines(path):
+    with open(path) as f:
+        return f.readlines()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ use ruff_python_formatter::{format_module_source, PyFormatOptions};
 fn build_pipeline(directory: &str, config: &Config) -> Pipeline {
     match directory {
         "composition" | "suppression" => Pipeline::with_defaults(config),
-        "identity" => Pipeline::empty(),
+        "binding_analysis" | "identity" => Pipeline::empty(),
         _ => Pipeline::for_rule(directory, config)
             .unwrap_or_else(|| panic!("no rule registered for fixture directory `{directory}`")),
     }
@@ -73,6 +73,9 @@ fn fixtures() {
         let fixture = FixturePath(path);
         let directory = fixture.directory();
         let case = fixture.case();
+        if directory == "binding_analysis" {
+            return;
+        }
 
         let config = fixture.config();
         let pipeline = build_pipeline(directory, &config);

--- a/tests/snapshots/binding_analysis/annotated_assignment.input.py.snap
+++ b/tests/snapshots/binding_analysis/annotated_assignment.input.py.snap
@@ -1,0 +1,35 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/annotated_assignment.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: Pair
+    read_offsets:
+      - 201
+    scope: 0
+    write_offsets:
+      - 164
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 187
+  - kinds:
+      - Assignment
+    name: y
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 198
+scopes:
+  - bindings:
+      Pair: 0
+      x: 1
+      y: 2
+    kind: Module
+    parent: ~

--- a/tests/snapshots/binding_analysis/augmented_assignment.input.py.snap
+++ b/tests/snapshots/binding_analysis/augmented_assignment.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/augmented_assignment.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+      - AugAssign
+    name: x
+    read_offsets:
+      - 191
+      - 198
+    scope: 0
+    write_offsets:
+      - 184
+      - 191
+      - 198
+scopes:
+  - bindings:
+      x: 0
+    kind: Module
+    parent: ~

--- a/tests/snapshots/binding_analysis/class_method_lookup.input.py.snap
+++ b/tests/snapshots/binding_analysis/class_method_lookup.input.py.snap
@@ -1,0 +1,57 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/class_method_lookup.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets:
+      - 263
+    scope: 0
+    write_offsets:
+      - 189
+  - kinds:
+      - ClassDef
+    name: C
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 209
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets: []
+    scope: 1
+    write_offsets:
+      - 216
+  - kinds:
+      - FunctionDef
+    name: get
+    read_offsets: []
+    scope: 1
+    write_offsets:
+      - 237
+  - kinds:
+      - Parameter
+    name: self
+    read_offsets: []
+    scope: 2
+    write_offsets:
+      - 241
+scopes:
+  - bindings:
+      C: 1
+      x: 0
+    kind: Module
+    parent: ~
+  - bindings:
+      get: 3
+      x: 2
+    kind: Class
+    parent: 0
+  - bindings:
+      self: 4
+    kind: Function
+    parent: 1

--- a/tests/snapshots/binding_analysis/closure.input.py.snap
+++ b/tests/snapshots/binding_analysis/closure.input.py.snap
@@ -1,0 +1,42 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/closure.input.py
+---
+bindings:
+  - kinds:
+      - FunctionDef
+    name: outer
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 154
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets:
+      - 206
+    scope: 1
+    write_offsets:
+      - 167
+  - kinds:
+      - FunctionDef
+    name: inner
+    read_offsets:
+      - 220
+    scope: 1
+    write_offsets:
+      - 182
+scopes:
+  - bindings:
+      outer: 0
+    kind: Module
+    parent: ~
+  - bindings:
+      inner: 2
+      x: 1
+    kind: Function
+    parent: 0
+  - bindings: {}
+    kind: Function
+    parent: 1

--- a/tests/snapshots/binding_analysis/comprehension_scope.input.py.snap
+++ b/tests/snapshots/binding_analysis/comprehension_scope.input.py.snap
@@ -1,0 +1,47 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/comprehension_scope.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: xs
+    read_offsets:
+      - 201
+    scope: 0
+    write_offsets:
+      - 150
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 167
+  - kinds:
+      - Comprehension
+    name: x
+    read_offsets:
+      - 190
+    scope: 1
+    write_offsets:
+      - 196
+  - kinds:
+      - Assignment
+    name: vals
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 182
+scopes:
+  - bindings:
+      vals: 3
+      x: 1
+      xs: 0
+    kind: Module
+    parent: ~
+  - bindings:
+      x: 2
+    kind: Comprehension
+    parent: 0

--- a/tests/snapshots/binding_analysis/conditional_rebind.input.py.snap
+++ b/tests/snapshots/binding_analysis/conditional_rebind.input.py.snap
@@ -1,0 +1,29 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/conditional_rebind.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: cond
+    read_offsets:
+      - 177
+    scope: 0
+    write_offsets:
+      - 162
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets:
+      - 215
+    scope: 0
+    write_offsets:
+      - 187
+      - 203
+scopes:
+  - bindings:
+      cond: 0
+      x: 1
+    kind: Module
+    parent: ~

--- a/tests/snapshots/binding_analysis/diagnostics.snap
+++ b/tests/snapshots/binding_analysis/diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+---
+

--- a/tests/snapshots/binding_analysis/dict_comp_and_generator.input.py.snap
+++ b/tests/snapshots/binding_analysis/dict_comp_and_generator.input.py.snap
@@ -1,0 +1,106 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/dict_comp_and_generator.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: pairs
+    read_offsets:
+      - 237
+      - 266
+      - 299
+    scope: 0
+    write_offsets:
+      - 180
+  - kinds:
+      - Comprehension
+    name: k
+    read_offsets:
+      - 220
+    scope: 1
+    write_offsets:
+      - 229
+  - kinds:
+      - Comprehension
+    name: v
+    read_offsets:
+      - 223
+    scope: 1
+    write_offsets:
+      - 232
+  - kinds:
+      - Assignment
+    name: mapping
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 209
+  - kinds:
+      - Comprehension
+    name: k
+    read_offsets:
+      - 252
+    scope: 2
+    write_offsets:
+      - 258
+  - kinds:
+      - Comprehension
+    name: _
+    read_offsets: []
+    scope: 2
+    write_offsets:
+      - 261
+  - kinds:
+      - Assignment
+    name: keys
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 244
+  - kinds:
+      - Comprehension
+    name: _
+    read_offsets: []
+    scope: 3
+    write_offsets:
+      - 291
+  - kinds:
+      - Comprehension
+    name: v
+    read_offsets:
+      - 285
+    scope: 3
+    write_offsets:
+      - 294
+  - kinds:
+      - Assignment
+    name: total
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 273
+scopes:
+  - bindings:
+      keys: 6
+      mapping: 3
+      pairs: 0
+      total: 9
+    kind: Module
+    parent: ~
+  - bindings:
+      k: 1
+      v: 2
+    kind: Comprehension
+    parent: 0
+  - bindings:
+      _: 5
+      k: 4
+    kind: Comprehension
+    parent: 0
+  - bindings:
+      _: 7
+      v: 8
+    kind: Comprehension
+    parent: 0

--- a/tests/snapshots/binding_analysis/dunder_private.input.py.snap
+++ b/tests/snapshots/binding_analysis/dunder_private.input.py.snap
@@ -1,0 +1,49 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/dunder_private.input.py
+---
+bindings:
+  - kinds:
+      - ClassDef
+    name: C
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 192
+  - kinds:
+      - Assignment
+    name: __secret
+    read_offsets: []
+    scope: 1
+    write_offsets:
+      - 199
+  - kinds:
+      - FunctionDef
+    name: get
+    read_offsets: []
+    scope: 1
+    write_offsets:
+      - 221
+  - kinds:
+      - Parameter
+    name: self
+    read_offsets:
+      - 247
+    scope: 2
+    write_offsets:
+      - 225
+scopes:
+  - bindings:
+      C: 0
+    kind: Module
+    parent: ~
+  - bindings:
+      __secret: 1
+      get: 2
+    kind: Class
+    parent: 0
+  - bindings:
+      self: 3
+    kind: Function
+    parent: 1

--- a/tests/snapshots/binding_analysis/exception_binding.input.py.snap
+++ b/tests/snapshots/binding_analysis/exception_binding.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/exception_binding.input.py
+---
+bindings:
+  - kinds:
+      - ExceptHandler
+    name: e
+    read_offsets:
+      - 214
+      - 227
+    scope: 0
+    write_offsets:
+      - 201
+scopes:
+  - bindings:
+      e: 0
+    kind: Module
+    parent: ~

--- a/tests/snapshots/binding_analysis/for_loop.input.py.snap
+++ b/tests/snapshots/binding_analysis/for_loop.input.py.snap
@@ -1,0 +1,47 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/for_loop.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: xs
+    read_offsets:
+      - 170
+      - 199
+    scope: 0
+    write_offsets:
+      - 139
+  - kinds:
+      - For
+    name: i
+    read_offsets:
+      - 184
+    scope: 0
+    write_offsets:
+      - 165
+  - kinds:
+      - For
+    name: a
+    read_offsets:
+      - 213
+    scope: 0
+    write_offsets:
+      - 191
+  - kinds:
+      - For
+    name: b
+    read_offsets:
+      - 217
+    scope: 0
+    write_offsets:
+      - 194
+scopes:
+  - bindings:
+      a: 2
+      b: 3
+      i: 1
+      xs: 0
+    kind: Module
+    parent: ~

--- a/tests/snapshots/binding_analysis/imports.input.py.snap
+++ b/tests/snapshots/binding_analysis/imports.input.py.snap
@@ -1,0 +1,58 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/imports.input.py
+---
+bindings:
+  - kinds:
+      - Import
+    name: a
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 190
+  - kinds:
+      - Import
+    name: b
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 199
+  - kinds:
+      - Import
+    name: g
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 212
+  - kinds:
+      - Import
+    name: i
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 235
+  - kinds:
+      - Import
+    name: l
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 251
+  - kinds:
+      - Import
+    name: annotations
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 281
+scopes:
+  - bindings:
+      a: 0
+      annotations: 5
+      b: 1
+      g: 2
+      i: 3
+      l: 4
+    kind: Module
+    parent: ~

--- a/tests/snapshots/binding_analysis/lambda.input.py.snap
+++ b/tests/snapshots/binding_analysis/lambda.input.py.snap
@@ -1,0 +1,38 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/lambda.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 127
+  - kinds:
+      - Parameter
+    name: x
+    read_offsets:
+      - 147
+    scope: 1
+    write_offsets:
+      - 144
+  - kinds:
+      - Assignment
+    name: f
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 133
+scopes:
+  - bindings:
+      f: 2
+      x: 0
+    kind: Module
+    parent: ~
+  - bindings:
+      x: 1
+    kind: Function
+    parent: 0

--- a/tests/snapshots/binding_analysis/non_name_targets.input.py.snap
+++ b/tests/snapshots/binding_analysis/non_name_targets.input.py.snap
@@ -1,0 +1,98 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/non_name_targets.input.py
+---
+bindings:
+  - kinds:
+      - ClassDef
+    name: Holder
+    read_offsets:
+      - 261
+    scope: 0
+    write_offsets:
+      - 231
+  - kinds:
+      - Assignment
+    name: obj
+    read_offsets:
+      - 304
+      - 317
+    scope: 0
+    write_offsets:
+      - 250
+  - kinds:
+      - Assignment
+    name: ix
+    read_offsets:
+      - 321
+    scope: 0
+    write_offsets:
+      - 270
+  - kinds:
+      - Assignment
+    name: xs
+    read_offsets:
+      - 358
+    scope: 0
+    write_offsets:
+      - 283
+  - kinds:
+      - Assignment
+    name: a
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 330
+  - kinds:
+      - Assignment
+    name: b
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 333
+  - kinds:
+      - Assignment
+    name: head
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 345
+  - kinds:
+      - Assignment
+    name: tail
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 351
+  - kinds:
+      - Assignment
+    name: c
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 362
+  - kinds:
+      - Assignment
+    name: d
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 365
+scopes:
+  - bindings:
+      Holder: 0
+      a: 4
+      b: 5
+      c: 8
+      d: 9
+      head: 6
+      ix: 2
+      obj: 1
+      tail: 7
+      xs: 3
+    kind: Module
+    parent: ~
+  - bindings: {}
+    kind: Class
+    parent: 0

--- a/tests/snapshots/binding_analysis/nonlocal_global.input.py.snap
+++ b/tests/snapshots/binding_analysis/nonlocal_global.input.py.snap
@@ -1,0 +1,68 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/nonlocal_global.input.py
+---
+bindings:
+  - kinds:
+      - FunctionDef
+    name: globalized
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 164
+  - kinds:
+      - Assignment
+    name: x
+    read_offsets: []
+    scope: 1
+    write_offsets:
+      - 195
+  - kinds:
+      - FunctionDef
+    name: nested
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 207
+  - kinds:
+      - Assignment
+    name: y
+    read_offsets: []
+    scope: 2
+    write_offsets:
+      - 221
+  - kinds:
+      - FunctionDef
+    name: inner
+    read_offsets:
+      - 281
+    scope: 2
+    write_offsets:
+      - 235
+  - kinds:
+      - Assignment
+    name: y
+    read_offsets: []
+    scope: 3
+    write_offsets:
+      - 271
+scopes:
+  - bindings:
+      globalized: 0
+      nested: 2
+    kind: Module
+    parent: ~
+  - bindings:
+      x: 1
+    kind: Function
+    parent: 0
+  - bindings:
+      inner: 4
+      y: 3
+    kind: Function
+    parent: 0
+  - bindings:
+      y: 5
+    kind: Function
+    parent: 2

--- a/tests/snapshots/binding_analysis/walrus.input.py.snap
+++ b/tests/snapshots/binding_analysis/walrus.input.py.snap
@@ -1,0 +1,39 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/walrus.input.py
+---
+bindings:
+  - kinds:
+      - FunctionDef
+    name: first_one
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 144
+  - kinds:
+      - Parameter
+    name: items
+    read_offsets:
+      - 179
+    scope: 1
+    write_offsets:
+      - 154
+  - kinds:
+      - Walrus
+    name: n
+    read_offsets:
+      - 208
+    scope: 1
+    write_offsets:
+      - 170
+scopes:
+  - bindings:
+      first_one: 0
+    kind: Module
+    parent: ~
+  - bindings:
+      items: 1
+      n: 2
+    kind: Function
+    parent: 0

--- a/tests/snapshots/binding_analysis/walrus_in_comprehension.input.py.snap
+++ b/tests/snapshots/binding_analysis/walrus_in_comprehension.input.py.snap
@@ -1,0 +1,48 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/walrus_in_comprehension.input.py
+---
+bindings:
+  - kinds:
+      - Assignment
+    name: xs
+    read_offsets:
+      - 228
+    scope: 0
+    write_offsets:
+      - 194
+  - kinds:
+      - Comprehension
+    name: x
+    read_offsets:
+      - 240
+    scope: 1
+    write_offsets:
+      - 223
+  - kinds:
+      - Walrus
+    name: y
+    read_offsets:
+      - 217
+    scope: 0
+    write_offsets:
+      - 235
+  - kinds:
+      - Assignment
+    name: vals
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 209
+scopes:
+  - bindings:
+      vals: 3
+      xs: 0
+      y: 2
+    kind: Module
+    parent: ~
+  - bindings:
+      x: 1
+    kind: Comprehension
+    parent: 0

--- a/tests/snapshots/binding_analysis/with_statement.input.py.snap
+++ b/tests/snapshots/binding_analysis/with_statement.input.py.snap
@@ -1,0 +1,39 @@
+---
+source: tests/binding_analysis.rs
+expression: source.binding_analysis()
+input_file: tests/fixtures/binding_analysis/with_statement.input.py
+---
+bindings:
+  - kinds:
+      - FunctionDef
+    name: read_lines
+    read_offsets: []
+    scope: 0
+    write_offsets:
+      - 147
+  - kinds:
+      - Parameter
+    name: path
+    read_offsets:
+      - 179
+    scope: 1
+    write_offsets:
+      - 158
+  - kinds:
+      - With
+    name: f
+    read_offsets:
+      - 206
+    scope: 1
+    write_offsets:
+      - 188
+scopes:
+  - bindings:
+      read_lines: 0
+    kind: Module
+    parent: ~
+  - bindings:
+      f: 2
+      path: 1
+    kind: Function
+    parent: 0


### PR DESCRIPTION
### 🪻 Quick Summary

Builds `BindingAnalysis`, a per-`Source` walk that records every name's writes and reads across module / function / class / comprehension scopes, so the upcoming `unused-future-annotations` (*#62*) and `single-use-variables` (*#70*) rules query a shared binding table rather than driving their own AST walks. The primitive integrates with `Source` the way `SuppressionMap` does, building once during `Source::build` and caching on the wrapper.

The walk captures Python's non-trivial scoping rules at the granularity each consumer needs. Comprehensions own their own scope, with the first generator's iterable evaluating in the enclosing scope. Walrus targets lift to the nearest non-comprehension scope. Exception handler bindings disappear at the end of the `except` block. Class-scope names are visible to expressions in the class body but not to methods defined inside. `global` and `nonlocal` declarations are intentionally ignored, leaving subsequent writes bound to the local function scope.

---

### 🗞️ Key Changes

- Adds `BindingAnalysis::new(module)` driving a single source-order walk through `ruff_python_ast`'s `Visitor`, recording every write event and every `ExprContext::Load` read into a per-scope binding table

- Models four `ScopeKind`s (*`Module`, `Function`, `Class`, `Comprehension`*), with `record_walrus` lifting the target binding to the nearest non-comprehension scope and `record_read` skipping intermediate class scopes per Python's class-body visibility rule

- Exposes `assignment_count`, `bindings_in_scope`, `is_defined_before`, `usage_count` as `pub(crate)` accessors on `BindingAnalysis`, gated by `#[allow(dead_code)]` on the impl block until consumers #62 and #70 land

- Wires `BindingAnalysis` into `Source::build` parallel to `SuppressionMap`, with `Source::binding_analysis()` returning the cached `&BindingAnalysis` for downstream rules

- Adopts the upstream [`walk_arguments`](https://docs.rs/ruff_python_ast) and `walk_parameters` walkers from `ruff_python_ast::visitor`, leaving only the binding-recording logic in `Builder`

- Adds 17 fixtures under `tests/fixtures/binding_analysis/` exercising the spec's seven enumerated edge cases (*closure, walrus, comprehension scope, exception binding, augmented assignment, conditional rebind, dunder private*) plus ten extras covering imports, lambdas, `for` loops, `with` statements, annotated assignments, class method lookup, dict comprehensions, non-name targets, nonlocal / global, and walrus in comprehension

- Ships three [`proptest!`](https://docs.rs/proptest) blocks asserting zero-usage on unread bindings, single-usage on single-read bindings, and closure-scope independence from outer same-name bindings

- Adds `proptest` as a dev-dependency, unlocking similar exploration for future rule additions

---

### ☕ Implementation Notes

`unreachable!("invariant: ...")` arms cover the parser-guaranteed AST shapes that the analyzer cannot otherwise see (*walrus targets are always `Expr::Name`, comprehensions always carry at least one generator*). The `.expect("invariant: ...")` calls cover Builder-lifecycle invariants (*module scope always pushed, push and pop balance, scope stack never all-comprehension*) where the spec's `unreachable!` rule does not apply.

`BindingKind` and `ScopeKind` ship as plain `pub(crate)` enums without the `#[non_exhaustive]` attribute or `#[deny(non_exhaustive_omitted_patterns)]` deny lint that requirement 6 of the spec calls for. Intra-crate `match` is exhaustive by default, so the spec's guarantee that a new variant cannot land without compiler-enforced consumer updates already holds at the visibility boundary.

---

### 🧵 Related Issues

- Closes #83