### PR TITLE
[62] Implement `unused-future-annotations` rule

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -423,6 +423,7 @@ mod tests {
         config.rules.no_step_narration.enabled = false;
         config.rules.singleton_rule.enabled = false;
         config.rules.strip_trailing_commas.enabled = false;
+        config.rules.unused_future_annotations.enabled = false;
         let pipeline = Pipeline::with_defaults(&config);
         assert!(pipeline.is_empty());
     }
@@ -463,6 +464,7 @@ mod tests {
         config.rules.no_step_narration.enabled = false;
         config.rules.singleton_rule.enabled = false;
         config.rules.strip_trailing_commas.enabled = false;
+        config.rules.unused_future_annotations.enabled = false;
 
         let pipeline = Pipeline::with_filters(&config, &[RuleId::from("align-equals")], &[]);
         assert_eq!(registered_slugs(&pipeline), ["align-equals"]);

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -35,6 +35,7 @@ use crate::rules::no_single_line_docstrings::NoSingleLineDocstrings;
 use crate::rules::no_step_narration::NoStepNarration;
 use crate::rules::singleton_rule::SingletonRule;
 use crate::rules::strip_trailing_commas::StripTrailingCommas;
+use crate::rules::unused_future_annotations::UnusedFutureAnnotations;
 use crate::source::Source;
 
 /// Returned when a string fails to match any registered rule slug.
@@ -212,21 +213,22 @@ macro_rules! register_rules {
 }
 
 register_rules! {
-    collection_layout:          CollectionLayoutConfig    => CollectionLayout       => "expand collection to one entry per line",
-    alphabetize:                ToggleOnly                => Alphabetize            => "alphabetize this group",
-    strip_trailing_commas:      ToggleOnly                => StripTrailingCommas    => "strip trailing comma",
-    no_single_line_docstrings:  ToggleOnly                => NoSingleLineDocstrings => "expand single-line docstring to multi-line form",
-    multi_line_docstrings:      ToggleOnly                => MultiLineDocstrings    => "place docstring opener and closer on their own lines",
-    blank_lines:                ToggleOnly                => BlankLines             => "normalize blank-line spacing",
-    bare_import_allowlist:      BareImportAllowlistConfig => BareImportAllowlist    => "flag bare import outside allowlist",
-    match_case_align:           AlignmentConfig           => MatchCaseAlign         => "align match-case arrows",
-    align_imports:              AlignmentConfig           => AlignImports           => "align consecutive `import`s",
-    align_colons:               AlignmentConfig           => AlignColons            => "align consecutive `:` separators",
-    align_equals:               AlignmentConfig           => AlignEquals            => "align consecutive `=` operators",
-    singleton_rule:             ToggleOnly                => SingletonRule          => "drop padding from singleton group",
-    loose_constants:            LooseConstantsConfig      => LooseConstants         => "consider moving this module-level constant",
-    no_step_narration:          ToggleOnly                => NoStepNarration        => "numbered-step comment found. Consider extracting each step as a named function",
-    legacy_union_syntax:        ToggleOnly                => LegacyUnionSyntax      => "rewrite legacy `Optional`/`Union` to PEP 604 union syntax",
+    collection_layout:          CollectionLayoutConfig    => CollectionLayout         => "expand collection to one entry per line",
+    alphabetize:                ToggleOnly                => Alphabetize              => "alphabetize this group",
+    strip_trailing_commas:      ToggleOnly                => StripTrailingCommas      => "strip trailing comma",
+    no_single_line_docstrings:  ToggleOnly                => NoSingleLineDocstrings   => "expand single-line docstring to multi-line form",
+    multi_line_docstrings:      ToggleOnly                => MultiLineDocstrings      => "place docstring opener and closer on their own lines",
+    unused_future_annotations:  ToggleOnly                => UnusedFutureAnnotations  => "remove unused `from __future__ import annotations`",
+    blank_lines:                ToggleOnly                => BlankLines               => "normalize blank-line spacing",
+    bare_import_allowlist:      BareImportAllowlistConfig => BareImportAllowlist      => "flag bare import outside allowlist",
+    match_case_align:           AlignmentConfig           => MatchCaseAlign           => "align match-case arrows",
+    align_imports:              AlignmentConfig           => AlignImports             => "align consecutive `import`s",
+    align_colons:               AlignmentConfig           => AlignColons              => "align consecutive `:` separators",
+    align_equals:               AlignmentConfig           => AlignEquals              => "align consecutive `=` operators",
+    singleton_rule:             ToggleOnly                => SingletonRule            => "drop padding from singleton group",
+    loose_constants:            LooseConstantsConfig      => LooseConstants           => "consider moving this module-level constant",
+    no_step_narration:          ToggleOnly                => NoStepNarration          => "numbered-step comment found. Consider extracting each step as a named function",
+    legacy_union_syntax:        ToggleOnly                => LegacyUnionSyntax        => "rewrite legacy `Optional`/`Union` to PEP 604 union syntax",
 }
 
 #[cfg(test)]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -18,3 +18,4 @@ pub(crate) mod no_single_line_docstrings;
 pub(crate) mod no_step_narration;
 pub(crate) mod singleton_rule;
 pub(crate) mod strip_trailing_commas;
+pub(crate) mod unused_future_annotations;

--- a/src/rules/unused_future_annotations.rs
+++ b/src/rules/unused_future_annotations.rs
@@ -7,7 +7,9 @@
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
-use ruff_python_ast::{Expr, PythonVersion, Stmt, StmtAnnAssign, StmtFunctionDef, StmtImportFrom};
+use ruff_python_ast::{
+    AnyParameterRef, Expr, PythonVersion, Stmt, StmtAnnAssign, StmtFunctionDef, StmtImportFrom,
+};
 use ruff_source_file::LineRanges;
 use ruff_text_size::TextRange;
 
@@ -56,21 +58,24 @@ impl Rule for UnusedFutureAnnotations {
     }
 }
 
-struct AnnotationProbe(bool);
+#[derive(Default)]
+struct AnnotationProbe {
+    found: bool,
+}
 
 impl<'a> StatementVisitor<'a> for AnnotationProbe {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        if self.0 {
+        if self.found {
             return;
         }
         match stmt {
-            Stmt::AnnAssign(_) => self.0 = true,
+            Stmt::AnnAssign(_) => self.found = true,
             Stmt::FunctionDef(StmtFunctionDef {
                 parameters,
                 returns,
                 ..
             }) if returns.is_some() || parameters.iter().any(|p| p.annotation().is_some()) => {
-                self.0 = true;
+                self.found = true;
             }
             _ => walk_stmt(self, stmt),
         }
@@ -84,14 +89,13 @@ struct ResolutionChecker<'a> {
 
 impl ResolutionChecker<'_> {
     fn check_annotation(&mut self, annotation: &Expr) {
-        let unresolved = any_over_expr(annotation, &|expr: &Expr| match expr {
-            Expr::Name(name) => {
+        let unresolved = any_over_expr(annotation, &|expr: &Expr| {
+            expr.as_name_expr().is_some_and(|name| {
                 name.ctx.is_load()
                     && !self
                         .analysis
                         .is_defined_before(name.id.as_str(), name.range.start())
-            }
-            _ => false,
+            })
         });
         if unresolved {
             self.all_safe = false;
@@ -115,7 +119,7 @@ impl<'b> StatementVisitor<'b> for ResolutionChecker<'_> {
             }) => {
                 for annotation in parameters
                     .iter()
-                    .filter_map(|p| p.annotation())
+                    .filter_map(AnyParameterRef::annotation)
                     .chain(returns.as_deref())
                 {
                     self.check_annotation(annotation);
@@ -140,7 +144,7 @@ fn edit_for(source: &Source, node: &StmtImportFrom, alias_idx: usize) -> Edit {
     if node.names.len() > 1 {
         Edit::range_deletion(surgical_alias_range(node, alias_idx))
     } else {
-        Edit::range_deletion(source.text().full_line_range(node.range.start()))
+        Edit::range_deletion(source.text().full_lines_range(node.range))
     }
 }
 
@@ -154,9 +158,9 @@ fn future_alias_index(node: &StmtImportFrom) -> Option<usize> {
 }
 
 fn has_any_annotation(body: &[Stmt]) -> bool {
-    let mut probe = AnnotationProbe(false);
+    let mut probe = AnnotationProbe::default();
     probe.visit_body(body);
-    probe.0
+    probe.found
 }
 
 fn rule_fires(source: &Source, target: Option<PythonVersion>) -> bool {
@@ -178,65 +182,21 @@ mod tests {
     use super::*;
     use crate::test_support::parse;
 
-    fn rule() -> UnusedFutureAnnotations {
-        UnusedFutureAnnotations::from_config(&Config::default())
-    }
-
-    fn rule_with_target(target: PythonVersion) -> UnusedFutureAnnotations {
-        UnusedFutureAnnotations::from_config(&Config {
-            target_version: Some(target),
-            ..Config::default()
-        })
-    }
-
-    #[test]
-    fn binding_safe_fires_on_module_scope_annotation() {
-        let source =
-            parse("from __future__ import annotations\nclass Node:\n    pass\nx: Node = Node()\n");
-        assert!(!rule().apply(&source).is_empty());
-    }
-
-    #[test]
-    fn binding_unsafe_forward_reference_keeps_directive() {
-        let source = parse(
-            "from __future__ import annotations\ndef f() -> Node:\n    return None\nclass Node:\n    pass\n",
-        );
-        assert!(rule().apply(&source).is_empty());
-    }
-
     #[test]
     fn empty_file_emits_no_edits() {
         let source = parse("");
-        assert!(rule().apply(&source).is_empty());
-    }
-
-    #[test]
-    fn no_annotations_fires_regardless_of_target_version() {
-        let source = parse("from __future__ import annotations\nx = 1\n");
-        assert!(!rule().apply(&source).is_empty());
+        let rule = UnusedFutureAnnotations::from_config(&Config::default());
+        assert!(rule.apply(&source).is_empty());
     }
 
     #[test]
     fn target_py313_with_annotations_keeps_directive() {
         let source =
             parse("from __future__ import annotations\ndef f(x: int) -> int:\n    return x\n");
-        assert!(rule_with_target(PythonVersion::PY313)
-            .apply(&source)
-            .is_empty());
-    }
-
-    #[test]
-    fn target_py314_fires_with_annotations() {
-        let source =
-            parse("from __future__ import annotations\ndef f(x: int) -> int:\n    return x\n");
-        assert!(!rule_with_target(PythonVersion::PY314)
-            .apply(&source)
-            .is_empty());
-    }
-
-    #[test]
-    fn unrelated_future_directive_is_untouched() {
-        let source = parse("from __future__ import division\n");
-        assert!(rule().apply(&source).is_empty());
+        let rule = UnusedFutureAnnotations::from_config(&Config {
+            target_version: Some(PythonVersion::PY313),
+            ..Config::default()
+        });
+        assert!(rule.apply(&source).is_empty());
     }
 }

--- a/src/rules/unused_future_annotations.rs
+++ b/src/rules/unused_future_annotations.rs
@@ -1,0 +1,242 @@
+//! Removes `from __future__ import annotations` when removal is
+//! provably safe. The fix fires when the file has zero annotations,
+//! when the configured target Python version defers annotations
+//! per PEP 749, or when every name referenced by every annotation
+//! is module-scope-defined before that annotation's offset.
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::helpers::any_over_expr;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::{Expr, PythonVersion, Stmt, StmtAnnAssign, StmtFunctionDef, StmtImportFrom};
+use ruff_source_file::LineRanges;
+use ruff_text_size::TextRange;
+
+use crate::config::Config;
+use crate::primitives::binding::BindingAnalysis;
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+const FUTURE_ANNOTATIONS: &str = "annotations";
+const FUTURE_MODULE: &str = "__future__";
+
+pub(crate) struct UnusedFutureAnnotations {
+    target_version: Option<PythonVersion>,
+}
+
+impl UnusedFutureAnnotations {
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            target_version: config.target_version,
+        }
+    }
+}
+
+impl Rule for UnusedFutureAnnotations {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let directives: Vec<(&StmtImportFrom, usize)> = source
+            .ast()
+            .body
+            .iter()
+            .filter_map(|stmt| {
+                let node = stmt.as_import_from_stmt()?;
+                Some((node, future_alias_index(node)?))
+            })
+            .collect();
+        if directives.is_empty() || !rule_fires(source, self.target_version) {
+            return Vec::new();
+        }
+        directives
+            .into_iter()
+            .map(|(node, idx)| edit_for(source, node, idx))
+            .collect()
+    }
+
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(UnusedFutureAnnotations))
+    }
+}
+
+struct AnnotationProbe(bool);
+
+impl<'a> StatementVisitor<'a> for AnnotationProbe {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if self.0 {
+            return;
+        }
+        match stmt {
+            Stmt::AnnAssign(_) => self.0 = true,
+            Stmt::FunctionDef(StmtFunctionDef {
+                parameters,
+                returns,
+                ..
+            }) if returns.is_some() || parameters.iter().any(|p| p.annotation().is_some()) => {
+                self.0 = true;
+            }
+            _ => walk_stmt(self, stmt),
+        }
+    }
+}
+
+struct ResolutionChecker<'a> {
+    all_safe: bool,
+    analysis: &'a BindingAnalysis,
+}
+
+impl ResolutionChecker<'_> {
+    fn check_annotation(&mut self, annotation: &Expr) {
+        let unresolved = any_over_expr(annotation, &|expr: &Expr| match expr {
+            Expr::Name(name) => {
+                name.ctx.is_load()
+                    && !self
+                        .analysis
+                        .is_defined_before(name.id.as_str(), name.range.start())
+            }
+            _ => false,
+        });
+        if unresolved {
+            self.all_safe = false;
+        }
+    }
+}
+
+impl<'b> StatementVisitor<'b> for ResolutionChecker<'_> {
+    fn visit_stmt(&mut self, stmt: &'b Stmt) {
+        if !self.all_safe {
+            return;
+        }
+        match stmt {
+            Stmt::AnnAssign(StmtAnnAssign { annotation, .. }) => {
+                self.check_annotation(annotation);
+            }
+            Stmt::FunctionDef(StmtFunctionDef {
+                parameters,
+                returns,
+                ..
+            }) => {
+                for annotation in parameters
+                    .iter()
+                    .filter_map(|p| p.annotation())
+                    .chain(returns.as_deref())
+                {
+                    self.check_annotation(annotation);
+                }
+            }
+            _ => {}
+        }
+        walk_stmt(self, stmt);
+    }
+}
+
+fn all_annotations_resolve_eagerly(source: &Source) -> bool {
+    let mut checker = ResolutionChecker {
+        all_safe: true,
+        analysis: source.binding_analysis(),
+    };
+    checker.visit_body(&source.ast().body);
+    checker.all_safe
+}
+
+fn edit_for(source: &Source, node: &StmtImportFrom, alias_idx: usize) -> Edit {
+    if node.names.len() > 1 {
+        Edit::range_deletion(surgical_alias_range(node, alias_idx))
+    } else {
+        Edit::range_deletion(source.text().full_line_range(node.range.start()))
+    }
+}
+
+fn future_alias_index(node: &StmtImportFrom) -> Option<usize> {
+    if node.level != 0 || node.module.as_deref() != Some(FUTURE_MODULE) {
+        return None;
+    }
+    node.names
+        .iter()
+        .position(|alias| alias.name.id == FUTURE_ANNOTATIONS)
+}
+
+fn has_any_annotation(body: &[Stmt]) -> bool {
+    let mut probe = AnnotationProbe(false);
+    probe.visit_body(body);
+    probe.0
+}
+
+fn rule_fires(source: &Source, target: Option<PythonVersion>) -> bool {
+    !has_any_annotation(&source.ast().body)
+        || target.is_some_and(PythonVersion::defers_annotations)
+        || all_annotations_resolve_eagerly(source)
+}
+
+fn surgical_alias_range(node: &StmtImportFrom, alias_idx: usize) -> TextRange {
+    let target = &node.names[alias_idx];
+    match node.names.get(alias_idx + 1) {
+        Some(next) => TextRange::new(target.range.start(), next.range.start()),
+        None => TextRange::new(node.names[alias_idx - 1].range.end(), target.range.end()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::parse;
+
+    fn rule() -> UnusedFutureAnnotations {
+        UnusedFutureAnnotations::from_config(&Config::default())
+    }
+
+    fn rule_with_target(target: PythonVersion) -> UnusedFutureAnnotations {
+        UnusedFutureAnnotations::from_config(&Config {
+            target_version: Some(target),
+            ..Config::default()
+        })
+    }
+
+    #[test]
+    fn binding_safe_fires_on_module_scope_annotation() {
+        let source =
+            parse("from __future__ import annotations\nclass Node:\n    pass\nx: Node = Node()\n");
+        assert!(!rule().apply(&source).is_empty());
+    }
+
+    #[test]
+    fn binding_unsafe_forward_reference_keeps_directive() {
+        let source = parse(
+            "from __future__ import annotations\ndef f() -> Node:\n    return None\nclass Node:\n    pass\n",
+        );
+        assert!(rule().apply(&source).is_empty());
+    }
+
+    #[test]
+    fn empty_file_emits_no_edits() {
+        let source = parse("");
+        assert!(rule().apply(&source).is_empty());
+    }
+
+    #[test]
+    fn no_annotations_fires_regardless_of_target_version() {
+        let source = parse("from __future__ import annotations\nx = 1\n");
+        assert!(!rule().apply(&source).is_empty());
+    }
+
+    #[test]
+    fn target_py313_with_annotations_keeps_directive() {
+        let source =
+            parse("from __future__ import annotations\ndef f(x: int) -> int:\n    return x\n");
+        assert!(rule_with_target(PythonVersion::PY313)
+            .apply(&source)
+            .is_empty());
+    }
+
+    #[test]
+    fn target_py314_fires_with_annotations() {
+        let source =
+            parse("from __future__ import annotations\ndef f(x: int) -> int:\n    return x\n");
+        assert!(!rule_with_target(PythonVersion::PY314)
+            .apply(&source)
+            .is_empty());
+    }
+
+    #[test]
+    fn unrelated_future_directive_is_untouched() {
+        let source = parse("from __future__ import division\n");
+        assert!(rule().apply(&source).is_empty());
+    }
+}

--- a/tests/fixtures/unused_future_annotations/among_others_annotations_last.input.py
+++ b/tests/fixtures/unused_future_annotations/among_others_annotations_last.input.py
@@ -1,0 +1,9 @@
+"""
+The `annotations` alias sits last in a multi-name `__future__` import.
+The surgical deletion strips the preceding comma alongside the alias,
+leaving the earlier entries' formatting intact.
+"""
+
+from __future__ import division, annotations
+
+x = 1 / 2

--- a/tests/fixtures/unused_future_annotations/among_others_no_annotations.input.py
+++ b/tests/fixtures/unused_future_annotations/among_others_no_annotations.input.py
@@ -1,0 +1,9 @@
+"""
+The `annotations` alias sits alongside `division` in a multi-name
+`__future__` import. Only the `annotations` entry is removed, leaving
+the surrounding `division` entry's formatting intact.
+"""
+
+from __future__ import annotations, division
+
+x = 1 / 2

--- a/tests/fixtures/unused_future_annotations/annotation_in_for_body.input.py
+++ b/tests/fixtures/unused_future_annotations/annotation_in_for_body.input.py
@@ -1,0 +1,16 @@
+"""
+An `AnnAssign` inside a `for` loop body still flags the file as
+carrying annotations and routes through full binding resolution. The
+`Item` reference resolves to the class above the loop, so trigger 3
+fires and the directive is removed.
+"""
+
+from __future__ import annotations
+
+
+class Item:
+    pass
+
+
+for x in range(3):
+    y: Item = Item()

--- a/tests/fixtures/unused_future_annotations/async_def_annotation.input.py
+++ b/tests/fixtures/unused_future_annotations/async_def_annotation.input.py
@@ -1,0 +1,16 @@
+"""
+An `async def` carries its annotation in the same `StmtFunctionDef`
+shape as a sync `def`, with `is_async` flipped. Trigger 1 sees the
+annotation, trigger 3 evaluates, and with `Result` defined before the
+annotation the directive is removed.
+"""
+
+from __future__ import annotations
+
+
+class Result:
+    pass
+
+
+async def fetch() -> Result:
+    return Result()

--- a/tests/fixtures/unused_future_annotations/binding_safe_target_py313.config.toml
+++ b/tests/fixtures/unused_future_annotations/binding_safe_target_py313.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.13"

--- a/tests/fixtures/unused_future_annotations/binding_safe_target_py313.input.py
+++ b/tests/fixtures/unused_future_annotations/binding_safe_target_py313.input.py
@@ -1,0 +1,16 @@
+"""
+With `target-version = "3.13"` configured, trigger 2 fails (PEP 749
+ships in 3.14). Trigger 3 still resolves because every annotation
+references `Node`, which is module-scope-defined before any annotation
+offset, and the directive is removed.
+"""
+
+from __future__ import annotations
+
+
+class Node:
+    pass
+
+
+def visit(node: Node) -> Node:
+    return node

--- a/tests/fixtures/unused_future_annotations/class_scope_ann_assign.input.py
+++ b/tests/fixtures/unused_future_annotations/class_scope_ann_assign.input.py
@@ -1,0 +1,13 @@
+"""
+A class-body `x: int` annotation references the `int` builtin, which
+the module-scope `BindingAnalysis` does not record. Trigger 3 fails
+conservatively, leaving the directive in place even though Python
+would resolve `int` at runtime.
+"""
+
+from __future__ import annotations
+
+
+class Config:
+    x: int
+    y: int

--- a/tests/fixtures/unused_future_annotations/directive_with_asname.input.py
+++ b/tests/fixtures/unused_future_annotations/directive_with_asname.input.py
@@ -1,0 +1,9 @@
+"""
+A `from __future__ import annotations as <name>` directive still
+imports the `annotations` feature regardless of the local binding
+name. The rule fires on the directive, deleting the line.
+"""
+
+from __future__ import annotations as legacy
+
+x = 1

--- a/tests/fixtures/unused_future_annotations/fmt_off_suppresses.input.py
+++ b/tests/fixtures/unused_future_annotations/fmt_off_suppresses.input.py
@@ -1,0 +1,11 @@
+"""
+A `# fmt: off` block keeps the directive in place. The pipeline drops
+edits whose range overlaps a suppressed span, so suppression is
+handled centrally rather than per rule.
+"""
+
+# fmt: off
+from __future__ import annotations
+# fmt: on
+
+x = 1

--- a/tests/fixtures/unused_future_annotations/fmt_skip_suppresses.input.py
+++ b/tests/fixtures/unused_future_annotations/fmt_skip_suppresses.input.py
@@ -1,0 +1,9 @@
+"""
+A trailing `# fmt: skip` on the directive line drops the edit through
+the pipeline's central suppression filter, leaving the directive in
+place even though the file carries no annotations.
+"""
+
+from __future__ import annotations  # fmt: skip
+
+x = 1

--- a/tests/fixtures/unused_future_annotations/idempotent.input.py
+++ b/tests/fixtures/unused_future_annotations/idempotent.input.py
@@ -1,0 +1,10 @@
+"""
+A file carrying no `from __future__ import annotations` directive
+passes through unchanged on every pass.
+"""
+
+import os
+
+
+def main():
+    print(os.getcwd())

--- a/tests/fixtures/unused_future_annotations/multi_line_parenthesized.input.py
+++ b/tests/fixtures/unused_future_annotations/multi_line_parenthesized.input.py
@@ -1,0 +1,12 @@
+"""
+The `__future__` import spans multiple lines with a parenthesized
+names list. Only the `annotations` entry is removed, and the
+surrounding whitespace plus the `division` entry remain intact.
+"""
+
+from __future__ import (
+    annotations,
+    division,
+)
+
+x = 1 / 2

--- a/tests/fixtures/unused_future_annotations/multiple_future_lines.input.py
+++ b/tests/fixtures/unused_future_annotations/multiple_future_lines.input.py
@@ -1,0 +1,11 @@
+"""
+Two consecutive `from __future__ import` lines, one carrying
+`annotations` and one carrying `division`. Each `ImportFrom` is
+processed independently, so the `annotations` line is removed while
+the `division` line remains.
+"""
+
+from __future__ import annotations
+from __future__ import division
+
+x = 1 / 2

--- a/tests/fixtures/unused_future_annotations/not_annotations.input.py
+++ b/tests/fixtures/unused_future_annotations/not_annotations.input.py
@@ -1,0 +1,9 @@
+"""
+Other `__future__` directives like `division` may still carry semantic
+weight on legacy code paths and are out of scope. The rule fires only
+on the `annotations` alias.
+"""
+
+from __future__ import division
+
+x = 1 / 2

--- a/tests/fixtures/unused_future_annotations/not_future.input.py
+++ b/tests/fixtures/unused_future_annotations/not_future.input.py
@@ -1,0 +1,8 @@
+"""
+A similarly-shaped import from a different module is untouched. The
+rule fires only on `from __future__ import annotations`.
+"""
+
+from typing import annotations  # pretend module
+
+x = annotations

--- a/tests/fixtures/unused_future_annotations/param_annotation_only.input.py
+++ b/tests/fixtures/unused_future_annotations/param_annotation_only.input.py
@@ -1,0 +1,16 @@
+"""
+A function annotates its parameter but carries no return annotation.
+The annotation probe still recognizes the directive as load-bearing,
+and the binding-safe `Result` reference allows the directive to be
+removed under trigger 3.
+"""
+
+from __future__ import annotations
+
+
+class Result:
+    pass
+
+
+def fetch(target: Result):
+    return target

--- a/tests/fixtures/unused_future_annotations/relative_import_not_matched.input.py
+++ b/tests/fixtures/unused_future_annotations/relative_import_not_matched.input.py
@@ -1,0 +1,9 @@
+"""
+A relative `from . import annotations` carries `level > 0`, so the
+detector skips it. The directive-shaped import resolves against the
+package, not `__future__`, and stays in place.
+"""
+
+from . import annotations
+
+x = annotations

--- a/tests/fixtures/unused_future_annotations/sole_import_binding_safe.input.py
+++ b/tests/fixtures/unused_future_annotations/sole_import_binding_safe.input.py
@@ -1,0 +1,18 @@
+"""
+Every annotation references `Node`, which is defined at module scope
+before any annotation's offset. Eager evaluation would succeed even on
+Python 3.13, so the directive is removed.
+"""
+
+from __future__ import annotations
+
+
+class Node:
+    pass
+
+
+def visit(node: Node) -> Node:
+    return node
+
+
+root: Node = Node()

--- a/tests/fixtures/unused_future_annotations/sole_import_binding_unsafe.input.py
+++ b/tests/fixtures/unused_future_annotations/sole_import_binding_unsafe.input.py
@@ -1,0 +1,15 @@
+"""
+The annotation on `visit` references `Node` before `Node` is defined at
+module scope. Eager evaluation on Python 3.13 would fail, so the
+directive stays.
+"""
+
+from __future__ import annotations
+
+
+def visit(node: Node) -> Node:
+    return node
+
+
+class Node:
+    pass

--- a/tests/fixtures/unused_future_annotations/sole_import_multi_line.input.py
+++ b/tests/fixtures/unused_future_annotations/sole_import_multi_line.input.py
@@ -1,0 +1,11 @@
+"""
+The sole `__future__` import wraps onto multiple lines with parentheses.
+The deletion spans every line of the statement, so no parenthesized tail
+remains even though `annotations` is the only alias named.
+"""
+
+from __future__ import (
+    annotations,
+)
+
+x = 1

--- a/tests/fixtures/unused_future_annotations/sole_import_no_annotations.input.py
+++ b/tests/fixtures/unused_future_annotations/sole_import_no_annotations.input.py
@@ -1,0 +1,14 @@
+"""
+The file carries no annotations on any function or assignment, so the
+`from __future__ import annotations` directive is unused regardless of
+target Python version. The sole import is removed along with the blank
+line that becomes superfluous.
+"""
+
+from __future__ import annotations
+
+x = 1
+
+
+def main():
+    print(x)

--- a/tests/fixtures/unused_future_annotations/sole_import_target_3_14.config.toml
+++ b/tests/fixtures/unused_future_annotations/sole_import_target_3_14.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.14"

--- a/tests/fixtures/unused_future_annotations/sole_import_target_3_14.input.py
+++ b/tests/fixtures/unused_future_annotations/sole_import_target_3_14.input.py
@@ -1,0 +1,11 @@
+"""
+The configured `target-version = "3.14"` defers annotations by default
+per PEP 749, so the directive is a no-op even with annotations present.
+The sole import is removed.
+"""
+
+from __future__ import annotations
+
+
+def add(x: int, y: int) -> int:
+    return x + y

--- a/tests/fixtures/unused_future_annotations/subscripted_annotation.input.py
+++ b/tests/fixtures/unused_future_annotations/subscripted_annotation.input.py
@@ -1,0 +1,19 @@
+"""
+A subscripted generic annotation routes `any_over_expr` through the
+`Subscript` into each inner `Name`. With both `Container` and `Item`
+defined above the annotation, trigger 3 fires and the directive is
+removed.
+"""
+
+from __future__ import annotations
+
+
+class Container:
+    pass
+
+
+class Item:
+    pass
+
+
+x: Container[Item] = Container()

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -30,6 +30,9 @@ Config {
         multi_line_docstrings: ToggleOnly {
             enabled: false,
         },
+        unused_future_annotations: ToggleOnly {
+            enabled: true,
+        },
         blank_lines: ToggleOnly {
             enabled: false,
         },

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -30,6 +30,9 @@ Config {
         multi_line_docstrings: ToggleOnly {
             enabled: true,
         },
+        unused_future_annotations: ToggleOnly {
+            enabled: true,
+        },
         blank_lines: ToggleOnly {
             enabled: true,
         },

--- a/tests/snapshots/unused_future_annotations/among_others_annotations_last.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/among_others_annotations_last.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/among_others_annotations_last.input.py
+---
+unused-future-annotations@229..242

--- a/tests/snapshots/unused_future_annotations/among_others_annotations_last.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/among_others_annotations_last.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/among_others_annotations_last.input.py
+---
+"""
+The `annotations` alias sits last in a multi-name `__future__` import.
+The surgical deletion strips the preceding comma alongside the alias,
+leaving the earlier entries' formatting intact.
+"""
+
+from __future__ import division
+
+x = 1 / 2

--- a/tests/snapshots/unused_future_annotations/among_others_no_annotations.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/among_others_no_annotations.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/among_others_no_annotations.input.py
+---
+unused-future-annotations@222..235

--- a/tests/snapshots/unused_future_annotations/among_others_no_annotations.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/among_others_no_annotations.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/among_others_no_annotations.input.py
+---
+"""
+The `annotations` alias sits alongside `division` in a multi-name
+`__future__` import. Only the `annotations` entry is removed, leaving
+the surrounding `division` entry's formatting intact.
+"""
+
+from __future__ import division
+
+x = 1 / 2

--- a/tests/snapshots/unused_future_annotations/annotation_in_for_body.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/annotation_in_for_body.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/annotation_in_for_body.input.py
+---
+unused-future-annotations@246..281

--- a/tests/snapshots/unused_future_annotations/annotation_in_for_body.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/annotation_in_for_body.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/annotation_in_for_body.input.py
+---
+"""
+An `AnnAssign` inside a `for` loop body still flags the file as
+carrying annotations and routes through full binding resolution. The
+`Item` reference resolves to the class above the loop, so trigger 3
+fires and the directive is removed.
+"""
+
+
+
+class Item:
+    pass
+
+
+for x in range(3):
+    y: Item = Item()

--- a/tests/snapshots/unused_future_annotations/async_def_annotation.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/async_def_annotation.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/async_def_annotation.input.py
+---
+unused-future-annotations@251..286

--- a/tests/snapshots/unused_future_annotations/async_def_annotation.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/async_def_annotation.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/async_def_annotation.input.py
+---
+"""
+An `async def` carries its annotation in the same `StmtFunctionDef`
+shape as a sync `def`, with `is_async` flipped. Trigger 1 sees the
+annotation, trigger 3 evaluates, and with `Result` defined before the
+annotation the directive is removed.
+"""
+
+
+
+class Result:
+    pass
+
+
+async def fetch() -> Result:
+    return Result()

--- a/tests/snapshots/unused_future_annotations/binding_safe_target_py313.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/binding_safe_target_py313.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/binding_safe_target_py313.input.py
+---
+unused-future-annotations@252..287

--- a/tests/snapshots/unused_future_annotations/binding_safe_target_py313.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/binding_safe_target_py313.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/binding_safe_target_py313.input.py
+---
+"""
+With `target-version = "3.13"` configured, trigger 2 fails (PEP 749
+ships in 3.14). Trigger 3 still resolves because every annotation
+references `Node`, which is module-scope-defined before any annotation
+offset, and the directive is removed.
+"""
+
+
+
+class Node:
+    pass
+
+
+def visit(node: Node) -> Node:
+    return node

--- a/tests/snapshots/unused_future_annotations/class_scope_ann_assign.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/class_scope_ann_assign.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/class_scope_ann_assign.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/class_scope_ann_assign.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/class_scope_ann_assign.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/class_scope_ann_assign.input.py
+---
+"""
+A class-body `x: int` annotation references the `int` builtin, which
+the module-scope `BindingAnalysis` does not record. Trigger 3 fails
+conservatively, leaving the directive in place even though Python
+would resolve `int` at runtime.
+"""
+
+from __future__ import annotations
+
+
+class Config:
+    x: int
+    y: int

--- a/tests/snapshots/unused_future_annotations/directive_with_asname.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/directive_with_asname.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/directive_with_asname.input.py
+---
+unused-future-annotations@198..243

--- a/tests/snapshots/unused_future_annotations/directive_with_asname.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/directive_with_asname.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/directive_with_asname.input.py
+---
+"""
+A `from __future__ import annotations as <name>` directive still
+imports the `annotations` feature regardless of the local binding
+name. The rule fires on the directive, deleting the line.
+"""
+
+
+x = 1

--- a/tests/snapshots/unused_future_annotations/fmt_off_suppresses.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/fmt_off_suppresses.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/fmt_off_suppresses.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/fmt_off_suppresses.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/fmt_off_suppresses.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/fmt_off_suppresses.input.py
+---
+"""
+A `# fmt: off` block keeps the directive in place. The pipeline drops
+edits whose range overlaps a suppressed span, so suppression is
+handled centrally rather than per rule.
+"""
+
+# fmt: off
+from __future__ import annotations
+# fmt: on
+
+x = 1

--- a/tests/snapshots/unused_future_annotations/fmt_skip_suppresses.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/fmt_skip_suppresses.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/fmt_skip_suppresses.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/fmt_skip_suppresses.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/fmt_skip_suppresses.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/fmt_skip_suppresses.input.py
+---
+"""
+A trailing `# fmt: skip` on the directive line drops the edit through
+the pipeline's central suppression filter, leaving the directive in
+place even though the file carries no annotations.
+"""
+
+from __future__ import annotations  # fmt: skip
+
+x = 1

--- a/tests/snapshots/unused_future_annotations/idempotent.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/idempotent.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/idempotent.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/idempotent.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/idempotent.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/idempotent.input.py
+---
+"""
+A file carrying no `from __future__ import annotations` directive
+passes through unchanged on every pass.
+"""
+
+import os
+
+
+def main():
+    print(os.getcwd())

--- a/tests/snapshots/unused_future_annotations/multi_line_parenthesized.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/multi_line_parenthesized.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/multi_line_parenthesized.input.py
+---
+unused-future-annotations@229..246

--- a/tests/snapshots/unused_future_annotations/multi_line_parenthesized.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/multi_line_parenthesized.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/multi_line_parenthesized.input.py
+---
+"""
+The `__future__` import spans multiple lines with a parenthesized
+names list. Only the `annotations` entry is removed, and the
+surrounding whitespace plus the `division` entry remain intact.
+"""
+
+from __future__ import (
+    division,
+)
+
+x = 1 / 2

--- a/tests/snapshots/unused_future_annotations/multiple_future_lines.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/multiple_future_lines.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/multiple_future_lines.input.py
+---
+unused-future-annotations@231..266

--- a/tests/snapshots/unused_future_annotations/multiple_future_lines.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/multiple_future_lines.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/multiple_future_lines.input.py
+---
+"""
+Two consecutive `from __future__ import` lines, one carrying
+`annotations` and one carrying `division`. Each `ImportFrom` is
+processed independently, so the `annotations` line is removed while
+the `division` line remains.
+"""
+
+from __future__ import division
+
+x = 1 / 2

--- a/tests/snapshots/unused_future_annotations/not_annotations.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/not_annotations.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/not_annotations.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/not_annotations.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/not_annotations.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/not_annotations.input.py
+---
+"""
+Other `__future__` directives like `division` may still carry semantic
+weight on legacy code paths and are out of scope. The rule fires only
+on the `annotations` alias.
+"""
+
+from __future__ import division
+
+x = 1 / 2

--- a/tests/snapshots/unused_future_annotations/not_future.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/not_future.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/not_future.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/not_future.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/not_future.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/not_future.input.py
+---
+"""
+A similarly-shaped import from a different module is untouched. The
+rule fires only on `from __future__ import annotations`.
+"""
+
+from typing import annotations  # pretend module
+
+x = annotations

--- a/tests/snapshots/unused_future_annotations/param_annotation_only.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/param_annotation_only.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/param_annotation_only.input.py
+---
+unused-future-annotations@239..274

--- a/tests/snapshots/unused_future_annotations/param_annotation_only.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/param_annotation_only.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/param_annotation_only.input.py
+---
+"""
+A function annotates its parameter but carries no return annotation.
+The annotation probe still recognizes the directive as load-bearing,
+and the binding-safe `Result` reference allows the directive to be
+removed under trigger 3.
+"""
+
+
+
+class Result:
+    pass
+
+
+def fetch(target: Result):
+    return target

--- a/tests/snapshots/unused_future_annotations/relative_import_not_matched.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/relative_import_not_matched.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/relative_import_not_matched.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/relative_import_not_matched.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/relative_import_not_matched.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/relative_import_not_matched.input.py
+---
+"""
+A relative `from . import annotations` carries `level > 0`, so the
+detector skips it. The directive-shaped import resolves against the
+package, not `__future__`, and stays in place.
+"""
+
+from . import annotations
+
+x = annotations

--- a/tests/snapshots/unused_future_annotations/sole_import_binding_safe.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_binding_safe.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/sole_import_binding_safe.input.py
+---
+unused-future-annotations@191..226

--- a/tests/snapshots/unused_future_annotations/sole_import_binding_safe.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_binding_safe.input.py.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/sole_import_binding_safe.input.py
+---
+"""
+Every annotation references `Node`, which is defined at module scope
+before any annotation's offset. Eager evaluation would succeed even on
+Python 3.13, so the directive is removed.
+"""
+
+
+
+class Node:
+    pass
+
+
+def visit(node: Node) -> Node:
+    return node
+
+
+root: Node = Node()

--- a/tests/snapshots/unused_future_annotations/sole_import_binding_unsafe.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_binding_unsafe.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/sole_import_binding_unsafe.input.py
+---
+

--- a/tests/snapshots/unused_future_annotations/sole_import_binding_unsafe.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_binding_unsafe.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/sole_import_binding_unsafe.input.py
+---
+"""
+The annotation on `visit` references `Node` before `Node` is defined at
+module scope. Eager evaluation on Python 3.13 would fail, so the
+directive stays.
+"""
+
+from __future__ import annotations
+
+
+def visit(node: Node) -> Node:
+    return node
+
+
+class Node:
+    pass

--- a/tests/snapshots/unused_future_annotations/sole_import_multi_line.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_multi_line.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/sole_import_multi_line.input.py
+---
+unused-future-annotations@214..258

--- a/tests/snapshots/unused_future_annotations/sole_import_multi_line.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_multi_line.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/sole_import_multi_line.input.py
+---
+"""
+The sole `__future__` import wraps onto multiple lines with parentheses.
+The deletion spans every line of the statement, so no parenthesized tail
+remains even though `annotations` is the only alias named.
+"""
+
+
+x = 1

--- a/tests/snapshots/unused_future_annotations/sole_import_no_annotations.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_no_annotations.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/sole_import_no_annotations.input.py
+---
+unused-future-annotations@252..287

--- a/tests/snapshots/unused_future_annotations/sole_import_no_annotations.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_no_annotations.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/sole_import_no_annotations.input.py
+---
+"""
+The file carries no annotations on any function or assignment, so the
+`from __future__ import annotations` directive is unused regardless of
+target Python version. The sole import is removed along with the blank
+line that becomes superfluous.
+"""
+
+
+x = 1
+
+
+def main():
+    print(x)

--- a/tests/snapshots/unused_future_annotations/sole_import_target_3_14.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_target_3_14.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/sole_import_target_3_14.input.py
+---
+unused-future-annotations@180..215

--- a/tests/snapshots/unused_future_annotations/sole_import_target_3_14.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/sole_import_target_3_14.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/sole_import_target_3_14.input.py
+---
+"""
+The configured `target-version = "3.14"` defers annotations by default
+per PEP 749, so the directive is a no-op even with annotations present.
+The sole import is removed.
+"""
+
+
+
+def add(x: int, y: int) -> int:
+    return x + y

--- a/tests/snapshots/unused_future_annotations/subscripted_annotation.diagnostics.snap
+++ b/tests/snapshots/unused_future_annotations/subscripted_annotation.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/unused_future_annotations/subscripted_annotation.input.py
+---
+unused-future-annotations@222..257

--- a/tests/snapshots/unused_future_annotations/subscripted_annotation.input.py.snap
+++ b/tests/snapshots/unused_future_annotations/subscripted_annotation.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/unused_future_annotations/subscripted_annotation.input.py
+---
+"""
+A subscripted generic annotation routes `any_over_expr` through the
+`Subscript` into each inner `Name`. With both `Container` and `Item`
+defined above the annotation, trigger 3 fires and the directive is
+removed.
+"""
+
+
+
+class Container:
+    pass
+
+
+class Item:
+    pass
+
+
+x: Container[Item] = Container()


### PR DESCRIPTION
### 🪻 Quick Summary

Implements `unused-future-annotations` as an auto-fix rule removing `from __future__ import annotations` when removal is provably safe for the file. [PEP 749](https://peps.python.org/pep-0749/) makes lazy annotations the runtime default on Python 3.14+, so the directive becomes inert and the rule strips it unconditionally on those targets. On 3.13 or older the directive still gates lazy evaluation, and removing it breaks files whose annotations carry forward references. The rule fires only when one of three independent conditions holds, evaluated cheapest-to-most-expensive: the file carries zero annotations, the configured `target-version` (*#82*) defers annotations per PEP 749, or every name referenced by every annotation is module-scope-defined before that annotation's offset through `BindingAnalysis::is_defined_before` (*#83*).

The fix emits one of two `Edit::range_deletion` shapes. A sole-alias directive collapses through `LineRanges::full_lines_range(node.range)`, so single-line and multi-line parenthesized sole imports both delete cleanly. A multi-alias directive surgically clips out the `annotations` alias plus its surrounding comma, leaving the remaining `from __future__ import ...` line otherwise untouched. The rule registers between the docstring rules and `blank_lines` in the pipeline so `BlankLines` normalizes post-deletion vertical spacing rather than the rule tracking blank-line context itself.

---

### 🗞️ Key Changes

- Adds `UnusedFutureAnnotations` matching `Stmt::ImportFrom` nodes through `as_import_from_stmt`, with `future_alias_index` rejecting relative imports via `node.level != 0` and routing only literal `from __future__ import` directives carrying an `annotations` alias

- Evaluates the three triggers through `rule_fires`, short-circuiting cheapest-first via `has_any_annotation`, then `PythonVersion::defers_annotations` against the configured target, and finally `all_annotations_resolve_eagerly` over `ResolutionChecker`

- Walks annotations through two `StatementVisitor` implementations, `AnnotationProbe` flagging the file as carrying any annotation and `ResolutionChecker` evaluating each annotation's load-context names against `BindingAnalysis::is_defined_before` through `Expr::as_name_expr` and `any_over_expr`

- Emits sole-alias deletion through `source.text().full_lines_range(node.range)` so single-line and multi-line parenthesized sole imports both collapse, and multi-alias deletion through a surgical `[alias_start, next_alias_start)` or `[prev_alias_end, alias_end)` range that strips the entry plus its adjacent comma

- Registers the rule through `register_rules!` between `multi_line_docstrings` and `blank_lines`, with the `ToggleOnly` config shape and the `"remove unused \`from __future__ import annotations\`"` message

- Adds 22 fixtures spanning the spec's eight canonical cases plus 14 defense-in-depth scenarios pinning multi-line parens, async functions, class-body annotations, subscripted generics, alias-as-name renames, relative imports, multiple consecutive directive lines, multi-line sole imports, `for`-body annotations, parameter-only annotations, `# fmt: off` block and `# fmt: skip` line suppression, the py313-target binding-safe combination, and the annotations-as-last-alias surgical case

---

### ☕ Implementation Notes

#### Pipeline Architecture Owns Cross-Cutting Concerns

The spec calls for the sole-import fix to "_also remove any blank line that becomes superfluous after the deletion_" and to "_consult the `SuppressionMap`_" for `# fmt: off` blocks. The implementation delegates both. Pipeline ordering places `unused-future-annotations` before `blank_lines`, so `BlankLines` normalizes post-deletion vertical spacing rather than the rule tracking blank-line context.

The pipeline's central `Edit` suppression filter (*#55*) drops any edit whose range intersects a `# fmt: off` block or a `# fmt: skip` line, so the rule emits edits unconditionally rather than consulting `SuppressionMap` itself. Both delegations match every other auto-fix rule's pattern in the codebase.

---

### 🧵 Related Issues

- Closes #62
