### PR TITLE
[68] Implement `legacy-union-syntax` rule

### DIFF
--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -415,6 +415,7 @@ mod tests {
         config.rules.bare_import_allowlist.enabled = false;
         config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
+        config.rules.legacy_union_syntax.enabled = false;
         config.rules.loose_constants.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.multi_line_docstrings.enabled = false;
@@ -456,6 +457,7 @@ mod tests {
         config.rules.bare_import_allowlist.enabled = false;
         config.rules.blank_lines.enabled = false;
         config.rules.collection_layout.enabled = false;
+        config.rules.legacy_union_syntax.enabled = false;
         config.rules.loose_constants.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.no_step_narration.enabled = false;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -27,6 +27,7 @@ use crate::rules::alphabetize::Alphabetize;
 use crate::rules::bare_import_allowlist::BareImportAllowlist;
 use crate::rules::blank_lines::BlankLines;
 use crate::rules::collection_layout::CollectionLayout;
+use crate::rules::legacy_union_syntax::LegacyUnionSyntax;
 use crate::rules::loose_constants::LooseConstants;
 use crate::rules::match_case_align::MatchCaseAlign;
 use crate::rules::multi_line_docstrings::MultiLineDocstrings;
@@ -225,6 +226,7 @@ register_rules! {
     singleton_rule:             ToggleOnly                => SingletonRule          => "drop padding from singleton group",
     loose_constants:            LooseConstantsConfig      => LooseConstants         => "consider moving this module-level constant",
     no_step_narration:          ToggleOnly                => NoStepNarration        => "numbered-step comment found. Consider extracting each step as a named function",
+    legacy_union_syntax:        ToggleOnly                => LegacyUnionSyntax      => "rewrite legacy `Optional`/`Union` to PEP 604 union syntax",
 }
 
 #[cfg(test)]

--- a/src/rules/legacy_union_syntax.rs
+++ b/src/rules/legacy_union_syntax.rs
@@ -56,27 +56,11 @@ impl Rule for LegacyUnionSyntax {
     }
 }
 
-#[derive(Copy, Clone)]
-enum TypingForm {
-    Optional,
-    Union,
-}
-
-impl TypingForm {
-    fn from_segments(segments: &[&str]) -> Option<Self> {
-        match segments {
-            ["typing" | "typing_extensions", "Optional"] => Some(Self::Optional),
-            ["typing" | "typing_extensions", "Union"] => Some(Self::Union),
-            _ => None,
-        }
-    }
-}
-
 /// Visits every `Subscript` and emits one diagnostic per match
 /// against `typing.Optional` or `typing.Union`.
 struct Walker<'a> {
     diagnostics: Vec<Diagnostic>,
-    imports: &'a HashMap<&'a str, Vec<&'a str>>,
+    imports: &'a HashMap<&'a str, QualifiedName<'a>>,
     parents: Vec<AnyNodeRef<'a>>,
     rule: RuleId,
     source: &'a Source,
@@ -87,8 +71,10 @@ impl<'a> Walker<'a> {
         let Some(qualified) = self.resolve(&subscript.value) else {
             return;
         };
-        let Some(form) = TypingForm::from_segments(qualified.segments()) else {
-            return;
+        let suffix = match qualified.segments() {
+            ["typing" | "typing_extensions", "Optional"] => " | None",
+            ["typing" | "typing_extensions", "Union"] => "",
+            _ => return,
         };
         let elements: &[Expr] = match subscript.slice.as_ref() {
             Expr::Tuple(tuple) => &tuple.elts,
@@ -99,12 +85,8 @@ impl<'a> Walker<'a> {
             .map(|e| self.source.slice(e))
             .collect::<Vec<_>>()
             .join(" | ");
-        let modern = match form {
-            TypingForm::Optional => format!("{joined} | None"),
-            TypingForm::Union => joined,
-        };
         let legacy = self.source.slice(subscript);
-        let message = format!("`{legacy}` is the legacy form. Use `{modern}`");
+        let message = format!("`{legacy}` is the legacy form. Use `{joined}{suffix}`");
         let parent = *self
             .parents
             .last()
@@ -124,7 +106,7 @@ impl<'a> Walker<'a> {
         let unqualified = UnqualifiedName::from_expr(value)?;
         let (head, tail) = unqualified.segments().split_first()?;
         let base = self.imports.get(head)?;
-        Some(base.iter().copied().chain(tail.iter().copied()).collect())
+        Some(base.clone().extend_members(tail.iter().copied()))
     }
 }
 
@@ -149,8 +131,8 @@ impl<'a> Visitor<'a> for Walker<'a> {
 /// recording the bound name and qualified path for each alias whose
 /// source is `typing` or `typing_extensions`. Imports nested below
 /// module scope are skipped.
-fn collect_typing_aliases(body: &[Stmt]) -> HashMap<&str, Vec<&str>> {
-    let mut imports: HashMap<&str, Vec<&str>> = HashMap::new();
+fn collect_typing_aliases(body: &[Stmt]) -> HashMap<&str, QualifiedName<'_>> {
+    let mut imports = HashMap::new();
     for stmt in body {
         match stmt {
             Stmt::Import(import) => {
@@ -160,7 +142,7 @@ fn collect_typing_aliases(body: &[Stmt]) -> HashMap<&str, Vec<&str>> {
                         continue;
                     }
                     let bound = alias.asname.as_ref().map_or(name, Identifier::as_str);
-                    imports.insert(bound, name.split('.').collect());
+                    imports.insert(bound, QualifiedName::user_defined(name));
                 }
             }
             Stmt::ImportFrom(import) => {
@@ -173,7 +155,11 @@ fn collect_typing_aliases(body: &[Stmt]) -> HashMap<&str, Vec<&str>> {
                 };
                 for alias in &import.names {
                     let bound = alias.asname.as_ref().unwrap_or(&alias.name).as_str();
-                    imports.insert(bound, vec![module.as_str(), alias.name.as_str()]);
+                    imports.insert(
+                        bound,
+                        QualifiedName::user_defined(module.as_str())
+                            .append_member(alias.name.as_str()),
+                    );
                 }
             }
             _ => {}
@@ -202,14 +188,20 @@ mod tests {
     fn collects_aliased_from_import() {
         let source = parse("from typing import Optional as Opt\n");
         let imports = collect_typing_aliases(&source.ast().body);
-        assert_eq!(imports.get("Opt"), Some(&vec!["typing", "Optional"]));
+        assert_eq!(
+            imports.get("Opt").map(QualifiedName::segments),
+            Some(["typing", "Optional"].as_slice()),
+        );
     }
 
     #[test]
     fn collects_aliased_module_import() {
         let source = parse("import typing as t\n");
         let imports = collect_typing_aliases(&source.ast().body);
-        assert_eq!(imports.get("t"), Some(&vec!["typing"]));
+        assert_eq!(
+            imports.get("t").map(QualifiedName::segments),
+            Some(["typing"].as_slice()),
+        );
     }
 
     #[test]
@@ -217,8 +209,8 @@ mod tests {
         let source = parse("from typing_extensions import Union\n");
         let imports = collect_typing_aliases(&source.ast().body);
         assert_eq!(
-            imports.get("Union"),
-            Some(&vec!["typing_extensions", "Union"]),
+            imports.get("Union").map(QualifiedName::segments),
+            Some(["typing_extensions", "Union"].as_slice()),
         );
     }
 
@@ -250,5 +242,11 @@ mod tests {
         assert!(only.fix.is_none());
         assert!(only.message.contains("`Optional[int]`"));
         assert!(only.message.contains("`int | None`"));
+    }
+
+    #[test]
+    fn rejects_non_typing_bare_import() {
+        let source = parse("import os\n");
+        assert!(collect_typing_aliases(&source.ast().body).is_empty());
     }
 }

--- a/src/rules/legacy_union_syntax.rs
+++ b/src/rules/legacy_union_syntax.rs
@@ -1,0 +1,254 @@
+//! Recommends `X | Y` and `X | None` over `Union[X, Y]` and
+//! `Optional[X]` when `target-version` is `3.10` or higher. Lint-only,
+//! emits no edits.
+
+use std::collections::HashMap;
+
+use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
+use ruff_python_ast::token::parenthesized_range;
+use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::{AnyNodeRef, Expr, ExprSubscript, Identifier, PythonVersion, Stmt};
+use ruff_text_size::Ranged;
+
+use crate::config::Config;
+use crate::diagnostics::Diagnostic;
+use crate::primitives::binding::top_level_module;
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+pub(crate) struct LegacyUnionSyntax {
+    target_version: Option<PythonVersion>,
+}
+
+impl LegacyUnionSyntax {
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            target_version: config.target_version,
+        }
+    }
+}
+
+impl Rule for LegacyUnionSyntax {
+    fn id(&self) -> RuleId {
+        RuleId::from(ruff_macros::kebab_case!(LegacyUnionSyntax))
+    }
+
+    fn lint(&self, source: &Source) -> Vec<Diagnostic> {
+        if self
+            .target_version
+            .is_none_or(|version| version < PythonVersion::PY310)
+        {
+            return Vec::new();
+        }
+        let imports = collect_typing_aliases(&source.ast().body);
+        if imports.is_empty() {
+            return Vec::new();
+        }
+        let mut walker = Walker {
+            diagnostics: Vec::new(),
+            imports: &imports,
+            parents: Vec::new(),
+            rule: self.id(),
+            source,
+        };
+        walker.visit_body(&source.ast().body);
+        walker.diagnostics
+    }
+}
+
+#[derive(Copy, Clone)]
+enum TypingForm {
+    Optional,
+    Union,
+}
+
+impl TypingForm {
+    fn from_segments(segments: &[&str]) -> Option<Self> {
+        match segments {
+            ["typing" | "typing_extensions", "Optional"] => Some(Self::Optional),
+            ["typing" | "typing_extensions", "Union"] => Some(Self::Union),
+            _ => None,
+        }
+    }
+}
+
+/// Visits every `Subscript` and emits one diagnostic per match
+/// against `typing.Optional` or `typing.Union`.
+struct Walker<'a> {
+    diagnostics: Vec<Diagnostic>,
+    imports: &'a HashMap<&'a str, Vec<&'a str>>,
+    parents: Vec<AnyNodeRef<'a>>,
+    rule: RuleId,
+    source: &'a Source,
+}
+
+impl<'a> Walker<'a> {
+    fn maybe_emit(&mut self, subscript: &'a ExprSubscript) {
+        let Some(qualified) = self.resolve(&subscript.value) else {
+            return;
+        };
+        let Some(form) = TypingForm::from_segments(qualified.segments()) else {
+            return;
+        };
+        let elements: &[Expr] = match subscript.slice.as_ref() {
+            Expr::Tuple(tuple) => &tuple.elts,
+            other => std::slice::from_ref(other),
+        };
+        let joined = elements
+            .iter()
+            .map(|e| self.source.slice(e))
+            .collect::<Vec<_>>()
+            .join(" | ");
+        let modern = match form {
+            TypingForm::Optional => format!("{joined} | None"),
+            TypingForm::Union => joined,
+        };
+        let legacy = self.source.slice(subscript);
+        let message = format!("`{legacy}` is the legacy form. Use `{modern}`");
+        let parent = *self
+            .parents
+            .last()
+            .expect("invariant: subscript visited inside a stmt or expr");
+        let range = parenthesized_range(subscript.into(), parent, self.source.tokens())
+            .unwrap_or(subscript.range());
+        self.diagnostics
+            .push(Diagnostic::lint(self.rule, range, message));
+    }
+
+    /// Resolves `value` (the head of a `Subscript`) to the qualified
+    /// path it would name, given the module's `typing` aliases. `Opt`
+    /// resolves to `typing.Optional`, `typing.Optional` resolves to
+    /// `typing.Optional`, and an unresolved or non-`typing` head
+    /// returns `None`.
+    fn resolve(&self, value: &'a Expr) -> Option<QualifiedName<'a>> {
+        let unqualified = UnqualifiedName::from_expr(value)?;
+        let (head, tail) = unqualified.segments().split_first()?;
+        let base = self.imports.get(head)?;
+        Some(base.iter().copied().chain(tail.iter().copied()).collect())
+    }
+}
+
+impl<'a> Visitor<'a> for Walker<'a> {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if let Expr::Subscript(subscript) = expr {
+            self.maybe_emit(subscript);
+        }
+        self.parents.push(expr.into());
+        walk_expr(self, expr);
+        self.parents.pop();
+    }
+
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        self.parents.push(stmt.into());
+        walk_stmt(self, stmt);
+        self.parents.pop();
+    }
+}
+
+/// Walks every top-level `Stmt::Import` and `Stmt::ImportFrom`,
+/// recording the bound name and qualified path for each alias whose
+/// source is `typing` or `typing_extensions`. Imports nested below
+/// module scope are skipped.
+fn collect_typing_aliases(body: &[Stmt]) -> HashMap<&str, Vec<&str>> {
+    let mut imports: HashMap<&str, Vec<&str>> = HashMap::new();
+    for stmt in body {
+        match stmt {
+            Stmt::Import(import) => {
+                for alias in &import.names {
+                    let name = alias.name.as_str();
+                    if !is_typing_root(top_level_module(name)) {
+                        continue;
+                    }
+                    let bound = alias.asname.as_ref().map_or(name, Identifier::as_str);
+                    imports.insert(bound, name.split('.').collect());
+                }
+            }
+            Stmt::ImportFrom(import) => {
+                let Some(module) = import
+                    .module
+                    .as_ref()
+                    .filter(|m| is_typing_root(m.as_str()))
+                else {
+                    continue;
+                };
+                for alias in &import.names {
+                    let bound = alias.asname.as_ref().unwrap_or(&alias.name).as_str();
+                    imports.insert(bound, vec![module.as_str(), alias.name.as_str()]);
+                }
+            }
+            _ => {}
+        }
+    }
+    imports
+}
+
+fn is_typing_root(module: &str) -> bool {
+    matches!(module, "typing" | "typing_extensions")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::Severity;
+    use crate::test_support::parse;
+
+    fn rule(version: Option<PythonVersion>) -> LegacyUnionSyntax {
+        LegacyUnionSyntax {
+            target_version: version,
+        }
+    }
+
+    #[test]
+    fn collects_aliased_from_import() {
+        let source = parse("from typing import Optional as Opt\n");
+        let imports = collect_typing_aliases(&source.ast().body);
+        assert_eq!(imports.get("Opt"), Some(&vec!["typing", "Optional"]));
+    }
+
+    #[test]
+    fn collects_aliased_module_import() {
+        let source = parse("import typing as t\n");
+        let imports = collect_typing_aliases(&source.ast().body);
+        assert_eq!(imports.get("t"), Some(&vec!["typing"]));
+    }
+
+    #[test]
+    fn collects_typing_extensions_alias() {
+        let source = parse("from typing_extensions import Union\n");
+        let imports = collect_typing_aliases(&source.ast().body);
+        assert_eq!(
+            imports.get("Union"),
+            Some(&vec!["typing_extensions", "Union"]),
+        );
+    }
+
+    #[test]
+    fn empty_when_target_version_is_none() {
+        let source = parse("from typing import Optional\nx: Optional[int]\n");
+        assert!(rule(None).lint(&source).is_empty());
+    }
+
+    #[test]
+    fn empty_when_target_version_below_310() {
+        let source = parse("from typing import Optional\nx: Optional[int]\n");
+        assert!(rule(Some(PythonVersion::PY39)).lint(&source).is_empty());
+    }
+
+    #[test]
+    fn ignores_non_typing_imports() {
+        let source = parse("from collections import OrderedDict\n");
+        assert!(collect_typing_aliases(&source.ast().body).is_empty());
+    }
+
+    #[test]
+    fn pins_severity_no_fix_and_message_format() {
+        let source = parse("from typing import Optional\nx: Optional[int]\n");
+        let diagnostics = rule(Some(PythonVersion::PY310)).lint(&source);
+        let only = diagnostics.first().expect("one diagnostic");
+
+        assert_eq!(only.severity, Severity::Lint);
+        assert!(only.fix.is_none());
+        assert!(only.message.contains("`Optional[int]`"));
+        assert!(only.message.contains("`int | None`"));
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod alphabetize;
 pub(crate) mod bare_import_allowlist;
 pub(crate) mod blank_lines;
 pub(crate) mod collection_layout;
+pub(crate) mod legacy_union_syntax;
 pub(crate) mod loose_constants;
 pub(crate) mod match_case_align;
 pub(crate) mod multi_line_docstrings;

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -27,6 +27,9 @@ enabled = false
 enabled = false
 max-atomics-per-line = 3
 
+[tool.prose.rules.legacy-union-syntax]
+enabled = false
+
 [tool.prose.rules.loose-constants]
 allow = ["LOG_LEVEL"]
 enabled = false

--- a/tests/fixtures/legacy_union_syntax/aliased_import.config.toml
+++ b/tests/fixtures/legacy_union_syntax/aliased_import.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/aliased_import.input.py
+++ b/tests/fixtures/legacy_union_syntax/aliased_import.input.py
@@ -1,0 +1,8 @@
+"""
+`from typing import Optional as Opt` binds `Opt` to `typing.Optional`,
+so `Opt[int]` resolves and flags through the alias.
+"""
+
+from typing import Optional as Opt
+
+x: Opt[int] = None

--- a/tests/fixtures/legacy_union_syntax/idempotent.config.toml
+++ b/tests/fixtures/legacy_union_syntax/idempotent.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/idempotent.input.py
+++ b/tests/fixtures/legacy_union_syntax/idempotent.input.py
@@ -1,0 +1,10 @@
+"""
+The rule emits no edits, so every pass leaves the source byte-for-byte
+identical. A mix of legacy and modern forms stays as written.
+"""
+
+from typing import Optional, Union
+
+legacy_optional: Optional[int] = None
+legacy_union: Union[int, str]  = 0
+modern: int | None = None

--- a/tests/fixtures/legacy_union_syntax/modern_pipe_preserved.config.toml
+++ b/tests/fixtures/legacy_union_syntax/modern_pipe_preserved.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/modern_pipe_preserved.input.py
+++ b/tests/fixtures/legacy_union_syntax/modern_pipe_preserved.input.py
@@ -1,0 +1,8 @@
+"""
+Already-modern PEP 604 annotations using `|` are not flagged. The
+walker only inspects `Subscript` shapes, so the binary `BitOr`
+expression that backs `int | None` slips past entirely.
+"""
+
+x: int | None = None
+y: int | str  = 0

--- a/tests/fixtures/legacy_union_syntax/nested_subscript.config.toml
+++ b/tests/fixtures/legacy_union_syntax/nested_subscript.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/nested_subscript.input.py
+++ b/tests/fixtures/legacy_union_syntax/nested_subscript.input.py
@@ -1,0 +1,9 @@
+"""
+A legacy `Optional[X]` nested inside another `Subscript` is flagged
+on the inner expression. The parent passed to `parenthesized_range`
+is the enclosing expression rather than the enclosing statement.
+"""
+
+from typing import Optional
+
+table: dict[str, Optional[int]] = {}

--- a/tests/fixtures/legacy_union_syntax/optional_basic.config.toml
+++ b/tests/fixtures/legacy_union_syntax/optional_basic.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/optional_basic.input.py
+++ b/tests/fixtures/legacy_union_syntax/optional_basic.input.py
@@ -1,0 +1,9 @@
+"""
+A bare `Optional[int]` flags as the legacy form. The diagnostic message
+spells out the recommended `int | None` shape, leaving the source
+untouched for the human to migrate.
+"""
+
+from typing import Optional
+
+x: Optional[int] = None

--- a/tests/fixtures/legacy_union_syntax/parens_extended_range.config.toml
+++ b/tests/fixtures/legacy_union_syntax/parens_extended_range.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/parens_extended_range.input.py
+++ b/tests/fixtures/legacy_union_syntax/parens_extended_range.input.py
@@ -1,0 +1,10 @@
+"""
+Surrounding parentheses around a `Subscript` are folded into the
+diagnostic range via `parenthesized_range`, so the surfaced span
+matches the user's mental model of "this annotation."
+"""
+
+from typing import Optional
+
+
+def annotate(x: (Optional[int])) -> None: ...

--- a/tests/fixtures/legacy_union_syntax/qualified_typing_optional.config.toml
+++ b/tests/fixtures/legacy_union_syntax/qualified_typing_optional.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/qualified_typing_optional.input.py
+++ b/tests/fixtures/legacy_union_syntax/qualified_typing_optional.input.py
@@ -1,0 +1,9 @@
+"""
+`typing.Optional[int]` after `import typing` resolves through the
+attribute chain back to `typing.Optional` and flags the same as the
+bare `Optional[int]` form.
+"""
+
+import typing
+
+x: typing.Optional[int] = None

--- a/tests/fixtures/legacy_union_syntax/typing_list_not_flagged.config.toml
+++ b/tests/fixtures/legacy_union_syntax/typing_list_not_flagged.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/typing_list_not_flagged.input.py
+++ b/tests/fixtures/legacy_union_syntax/typing_list_not_flagged.input.py
@@ -1,0 +1,9 @@
+"""
+A typing import that names something other than `Optional` or `Union`
+is not flagged. The walker resolves `List[int]` to `typing.List` and
+falls through the suffix match's catch-all.
+"""
+
+from typing import List
+
+values: List[int] = []

--- a/tests/fixtures/legacy_union_syntax/union_two_args.config.toml
+++ b/tests/fixtures/legacy_union_syntax/union_two_args.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/union_two_args.input.py
+++ b/tests/fixtures/legacy_union_syntax/union_two_args.input.py
@@ -1,0 +1,8 @@
+"""
+`Union[int, str]` flags as the legacy form, with the diagnostic
+recommending `int | str` joined by the PEP 604 pipe.
+"""
+
+from typing import Union
+
+x: Union[int, str] = 0

--- a/tests/fixtures/legacy_union_syntax/union_with_none.config.toml
+++ b/tests/fixtures/legacy_union_syntax/union_with_none.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+target-version = "3.10"

--- a/tests/fixtures/legacy_union_syntax/union_with_none.input.py
+++ b/tests/fixtures/legacy_union_syntax/union_with_none.input.py
@@ -1,0 +1,8 @@
+"""
+`Union[int, str, None]` flattens its explicit `None` arg into the
+recommendation `int | str | None`, leaving the source untouched.
+"""
+
+from typing import Union
+
+x: Union[int, str, None] = None

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -72,6 +72,9 @@ Config {
         no_step_narration: ToggleOnly {
             enabled: false,
         },
+        legacy_union_syntax: ToggleOnly {
+            enabled: false,
+        },
     },
     target_version: Some(
         PythonVersion {

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/config_parsing.rs
-assertion_line: 30
 expression: config
 input_file: tests/fixtures/config/target_version_only.toml
 ---
@@ -69,6 +68,9 @@ Config {
             enabled: true,
         },
         no_step_narration: ToggleOnly {
+            enabled: true,
+        },
+        legacy_union_syntax: ToggleOnly {
             enabled: true,
         },
     },

--- a/tests/snapshots/legacy_union_syntax/aliased_import.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/aliased_import.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/aliased_import.input.py
+---
+legacy-union-syntax@171..179

--- a/tests/snapshots/legacy_union_syntax/aliased_import.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/aliased_import.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/aliased_import.input.py
+---
+"""
+`from typing import Optional as Opt` binds `Opt` to `typing.Optional`,
+so `Opt[int]` resolves and flags through the alias.
+"""
+
+from typing import Optional as Opt
+
+x: Opt[int] = None

--- a/tests/snapshots/legacy_union_syntax/idempotent.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/idempotent.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/idempotent.input.py
+---
+legacy-union-syntax@195..208
+legacy-union-syntax@230..245

--- a/tests/snapshots/legacy_union_syntax/idempotent.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/idempotent.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/idempotent.input.py
+---
+"""
+The rule emits no edits, so every pass leaves the source byte-for-byte
+identical. A mix of legacy and modern forms stays as written.
+"""
+
+from typing import Optional, Union
+
+legacy_optional: Optional[int] = None
+legacy_union: Union[int, str]  = 0
+modern: int | None = None

--- a/tests/snapshots/legacy_union_syntax/modern_pipe_preserved.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/modern_pipe_preserved.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/modern_pipe_preserved.input.py
+---
+

--- a/tests/snapshots/legacy_union_syntax/modern_pipe_preserved.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/modern_pipe_preserved.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/modern_pipe_preserved.input.py
+---
+"""
+Already-modern PEP 604 annotations using `|` are not flagged. The
+walker only inspects `Subscript` shapes, so the binary `BitOr`
+expression that backs `int | None` slips past entirely.
+"""
+
+x: int | None = None
+y: int | str  = 0

--- a/tests/snapshots/legacy_union_syntax/nested_subscript.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/nested_subscript.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/nested_subscript.input.py
+---
+legacy-union-syntax@256..269

--- a/tests/snapshots/legacy_union_syntax/nested_subscript.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/nested_subscript.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/nested_subscript.input.py
+---
+"""
+A legacy `Optional[X]` nested inside another `Subscript` is flagged
+on the inner expression. The parent passed to `parenthesized_range`
+is the enclosing expression rather than the enclosing statement.
+"""
+
+from typing import Optional
+
+table: dict[str, Optional[int]] = {}

--- a/tests/snapshots/legacy_union_syntax/optional_basic.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/optional_basic.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/optional_basic.input.py
+---
+legacy-union-syntax@215..228

--- a/tests/snapshots/legacy_union_syntax/optional_basic.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/optional_basic.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/optional_basic.input.py
+---
+"""
+A bare `Optional[int]` flags as the legacy form. The diagnostic message
+spells out the recommended `int | None` shape, leaving the source
+untouched for the human to migrate.
+"""
+
+from typing import Optional
+
+x: Optional[int] = None

--- a/tests/snapshots/legacy_union_syntax/parens_extended_range.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/parens_extended_range.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/parens_extended_range.input.py
+---
+legacy-union-syntax@239..254

--- a/tests/snapshots/legacy_union_syntax/parens_extended_range.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/parens_extended_range.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/parens_extended_range.input.py
+---
+"""
+Surrounding parentheses around a `Subscript` are folded into the
+diagnostic range via `parenthesized_range`, so the surfaced span
+matches the user's mental model of "this annotation."
+"""
+
+from typing import Optional
+
+
+def annotate(x: (Optional[int])) -> None: ...

--- a/tests/snapshots/legacy_union_syntax/qualified_typing_optional.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/qualified_typing_optional.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/qualified_typing_optional.input.py
+---
+legacy-union-syntax@188..208

--- a/tests/snapshots/legacy_union_syntax/qualified_typing_optional.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/qualified_typing_optional.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/qualified_typing_optional.input.py
+---
+"""
+`typing.Optional[int]` after `import typing` resolves through the
+attribute chain back to `typing.Optional` and flags the same as the
+bare `Optional[int]` form.
+"""
+
+import typing
+
+x: typing.Optional[int] = None

--- a/tests/snapshots/legacy_union_syntax/typing_list_not_flagged.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/typing_list_not_flagged.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/typing_list_not_flagged.input.py
+---
+

--- a/tests/snapshots/legacy_union_syntax/typing_list_not_flagged.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/typing_list_not_flagged.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/typing_list_not_flagged.input.py
+---
+"""
+A typing import that names something other than `Optional` or `Union`
+is not flagged. The walker resolves `List[int]` to `typing.List` and
+falls through the suffix match's catch-all.
+"""
+
+from typing import List
+
+values: List[int] = []

--- a/tests/snapshots/legacy_union_syntax/union_two_args.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/union_two_args.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/union_two_args.input.py
+---
+legacy-union-syntax@155..170

--- a/tests/snapshots/legacy_union_syntax/union_two_args.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/union_two_args.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/union_two_args.input.py
+---
+"""
+`Union[int, str]` flags as the legacy form, with the diagnostic
+recommending `int | str` joined by the PEP 604 pipe.
+"""
+
+from typing import Union
+
+x: Union[int, str] = 0

--- a/tests/snapshots/legacy_union_syntax/union_with_none.diagnostics.snap
+++ b/tests/snapshots/legacy_union_syntax/union_with_none.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/legacy_union_syntax/union_with_none.input.py
+---
+legacy-union-syntax@169..190

--- a/tests/snapshots/legacy_union_syntax/union_with_none.input.py.snap
+++ b/tests/snapshots/legacy_union_syntax/union_with_none.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/legacy_union_syntax/union_with_none.input.py
+---
+"""
+`Union[int, str, None]` flattens its explicit `None` arg into the
+recommendation `int | str | None`, leaving the source untouched.
+"""
+
+from typing import Union
+
+x: Union[int, str, None] = None


### PR DESCRIPTION
### 🪻 Quick Summary

Implements `legacy-union-syntax`, a lint-only rule recommending [PEP 604](https://peps.python.org/pep-0604/) (*Python 3.10+*) `X | Y` and `X | None` over the legacy `Union[X, Y]` and `Optional[X]` forms from `typing` / `typing_extensions`. The rule fires only when `Config::target_version` (#82) resolves to `3.10` or higher, staying quiet on older targets where the modern syntax would not parse and on projects that have not declared a target version.

The walker collects every top-level `Stmt::Import` and `Stmt::ImportFrom` whose root resolves to `typing` or `typing_extensions`, storing each binding's qualified path as a `ruff_python_ast::name::QualifiedName`. Every `Expr::Subscript` then resolves its head through `UnqualifiedName::from_expr`, extends the looked-up path with any remaining attribute tail, and matches against the `Optional` / `Union` arms. The modern-form recommendation appends a `" | None"` suffix for `Optional` and an empty suffix for `Union`, so `Union[int, str, None]` flattens through the same join path as `Optional[int]` produces `int | None`. The diagnostic range covers the full subscript, extended over any surrounding parentheses via `ruff_python_ast::token::parenthesized_range` so `(Optional[int])` surfaces with its parens included.

Because the rule emits `Severity::Lint` diagnostics (#57) rather than edits, suppression flows through `SuppressionMap` from #55 for `# fmt: off` blocks and through the per-line lint path from #59 for `# prose: ignore[legacy-union-syntax]` directives, both handled in `Pipeline::run` without per-rule plumbing.

---

### 🗞️ Key Changes

- Adds `LegacyUnionSyntax` flagging `Expr::Subscript` heads that resolve to `typing.Optional` or `typing.Union` (*and the `typing_extensions` equivalents*) when `Config::target_version` resolves to `3.10` or higher, with the rule staying quiet on `None` or older targets

- Builds the typing-alias map at lint time from every top-level `Stmt::Import` and `Stmt::ImportFrom` whose root segment is `typing` or `typing_extensions`, storing each binding's qualified path as `ruff_python_ast::name::QualifiedName` via `QualifiedName::user_defined` and `append_member`

- Resolves each `Subscript` head through `UnqualifiedName::from_expr`, looking up the leading segment against the alias map and extending the qualified path with the remaining attribute tail via `QualifiedName::extend_members` before matching the `Optional` / `Union` arms

- Constructs the modern-form recommendation by joining the subscript's elements with `" | "` (*splatting `Expr::Tuple` slices and wrapping single elements via `std::slice::from_ref`*) and appending a `" | None"` suffix for `Optional` or an empty suffix for `Union`, so `Union[int, str, None]` flattens through the same path that produces `int | None` from `Optional[int]`

- Extends the diagnostic range over surrounding parens via `ruff_python_ast::token::parenthesized_range`, fed the immediate enclosing node from a `Vec<AnyNodeRef>` parent stack that the Visitor pushes on every `visit_stmt` and `visit_expr` and pops on the way out

- Registers `legacy-union-syntax` via `register_rules!` with the `ToggleOnly` config shape and the `"rewrite legacy \`Optional\`/\`Union\` to PEP 604 union syntax"` message, and adds the toggle to `tests/fixtures/config/full_override.toml` with the matching regenerated snapshot

- Adds 10 fixtures under `tests/fixtures/legacy_union_syntax/` covering the spec's eight canonical cases (*`optional_basic`, `union_two_args`, `union_with_none`, `qualified_typing_optional`, `aliased_import`, `modern_pipe_preserved`, `parens_extended_range`, `idempotent`*) plus two additional scenarios (*`nested_subscript` exercising the expression-parent arm of the parents stack, and `typing_list_not_flagged` pinning the suffix match's catch-all return when a typing import names something other than `Optional` or `Union`*)

- Adds inline tests covering the alias-collection variants (*bare `import typing`, `import typing as t`, `from typing import X`, `from typing import X as Y`, `from typing_extensions import Union`, and rejection of both bare-import and from-import non-typing forms*) plus pinning severity, fix absence, and the message-format invariants

---

### ☕ Implementation Notes

#### Parens Fixture Form

The `parens_extended_range` fixture uses a function-parameter annotation (*`def annotate(x: (Optional[int])) -> None: ...`*) rather than a top-level annotation assignment. Both forms surface the parens-wrapped `Subscript` through the same `parenthesized_range` path, so the snapshot pins the same diagnostic-range behavior.

---

### 🧵 Related Issues

- Closes #68