### PR TITLE
[96] Extend `.github/release.yml` categories for `🧶 lint` and `🐞 bug` labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,7 +6,11 @@ changelog:
         - 🪜 alignment
         - 🪉 ordering
         - 🪶 formatting
+        - 🧶 lint
         - 🪄 cli
+    - title: 🐞 Bugs
+      labels:
+        - 🐞 bug
     - title: 📰 Docs
       labels:
         - 📰 docs


### PR DESCRIPTION
### 🪻 Quick Summary

Extends `.github/release.yml` so `🧶 lint` joins the `✨ Features` bucket alongside the other user-facing-rule labels and a new `🐞 Bugs` category lands between `✨ Features` and `📰 Docs`. From `0.2.1` forward, lint-only rule PRs and bug-fix PRs route to their own buckets in *Prose*'s auto-generated release notes rather than falling through to `🧱 Internals` or `Other`.

---

### 🗞️ Key Changes

- Adds `🧶 lint` to the `✨ Features` bucket label list, slotted between `🪶 formatting` and `🪄 cli` so the rule-domain run stays contiguous

- Adds a new `🐞 Bugs` category between `✨ Features` and `📰 Docs` mapping the `🐞 bug` label, positioned by reader interest (*features first, then bug fixes, then docs and build housekeeping*)

---

### 🧵 Related Issues

- Closes #96