### PR TITLE
[99] Break alignment groups on multi-line RHS in `align_equals` and `align_colons`

### DIFF
--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -21,9 +21,7 @@ use crate::source::Source;
 /// region, from the start of the member to the start of the gap. `gap`
 /// is the whitespace range ending immediately before the aligned
 /// token that the rule will rewrite. `line_start` is the offset of
-/// the start of the source line containing the gap, captured at
-/// construction time so [`is_alignment_candidate`] can compare line
-/// identity without re-scanning the source.
+/// the start of the source line containing the gap.
 #[derive(Clone, Copy)]
 pub(crate) struct Member {
     pub gap: TextRange,
@@ -34,8 +32,7 @@ pub(crate) struct Member {
 /// Emission knobs shared by every alignment rule.
 ///
 /// `strip_singleton_subgroup` overrides the suffix to `0` for
-/// size-one sub-groups in `emit_split`, used by the `:`-anchored
-/// rules.
+/// size-one sub-groups in `emit_split`.
 #[derive(Clone, Copy)]
 pub(crate) struct Settings {
     max_shift: usize,
@@ -91,10 +88,7 @@ pub(crate) fn emit_group(
 }
 
 /// Returns `true` when `members` form a multi-row group whose
-/// aligned tokens sit on distinct source lines. The two
-/// alignment-vs-collapse rules pivot on this predicate: the
-/// alignment side acts when it is `true`, the collapse side acts
-/// when it is `false`.
+/// aligned tokens sit on distinct source lines.
 pub(crate) fn is_alignment_candidate(members: &[Member]) -> bool {
     members.len() >= 2
         && members
@@ -105,13 +99,12 @@ pub(crate) fn is_alignment_candidate(members: &[Member]) -> bool {
 /// Generalization of [`line_adjacent_groups`] for rules that admit
 /// more than one member shape. The qualifier returns `Option<(K, M)>`
 /// where `K` tags the shape, and a run extends only while the next
-/// member shares both the active key and line-adjacency. A key change
-/// at an otherwise-adjacent boundary closes the active run and starts
-/// a fresh one without losing the boundary statement, which keeps
-/// `align_imports` from mixing `from`-import members with
-/// `import M as A` members in a single group. Walks `body` exactly
-/// once and calls `Source::is_line_adjacent` at most once per
-/// qualifying statement.
+/// member shares the active key, sits line-adjacent to the prior
+/// statement, and the prior statement itself fits on one source line.
+/// A key change at an otherwise-adjacent boundary closes the active
+/// run and starts a fresh one without losing the boundary statement.
+/// Walks `body` exactly once, calling the qualifier and each boundary
+/// predicate at most once per statement.
 pub(crate) fn keyed_line_adjacent_groups<'a, K, M, F>(
     source: &'a Source,
     body: &'a [Stmt],
@@ -122,14 +115,16 @@ where
     F: FnMut(&'a Stmt) -> Option<(K, M)>,
 {
     let mut groups: Vec<Vec<M>> = Vec::new();
-    let mut active: Option<(K, TextSize)> = None;
+    let mut active: Option<(K, TextRange)> = None;
     for stmt in body {
         let Some((key, member)) = qualify(stmt) else {
             active = None;
             continue;
         };
-        let extends = active.as_ref().is_some_and(|(active_key, last_end)| {
-            active_key == &key && source.is_line_adjacent(TextRange::new(*last_end, stmt.start()))
+        let extends = active.as_ref().is_some_and(|(active_key, prev)| {
+            active_key == &key
+                && !source.contains_line_break(prev)
+                && source.is_line_adjacent(TextRange::new(prev.end(), stmt.start()))
         });
         if extends {
             groups
@@ -139,19 +134,20 @@ where
         } else {
             groups.push(vec![member]);
         }
-        active = Some((key, stmt.end()));
+        active = Some((key, stmt.range()));
     }
     groups
 }
 
 /// Walks `body`, qualifying each statement through `qualify` and
 /// grouping the qualified members into runs where every consecutive
-/// pair sits on adjacent source lines. A non-qualifying statement, a
-/// comment in the inter-statement gap, or a blank line breaks the
-/// current run. Empty groups (statements that fail qualification with
-/// no qualified neighbors) are skipped. Thin wrapper over
-/// [`keyed_line_adjacent_groups`] for rules whose qualifier produces
-/// only one form, so every member shares an implicit `()` key.
+/// pair sits on adjacent source lines. A multi-line prior statement,
+/// a non-qualifying statement, a comment in the inter-statement gap,
+/// or a blank line breaks the current run. Empty groups (statements
+/// that fail qualification with no qualified neighbors) are skipped.
+/// Thin wrapper over [`keyed_line_adjacent_groups`] for rules whose
+/// qualifier produces only one form, so every member shares an
+/// implicit `()` key.
 pub(crate) fn line_adjacent_groups<'a, M, F>(
     source: &'a Source,
     body: &'a [Stmt],
@@ -167,7 +163,6 @@ where
 /// Width is the display width of the line's content from the first
 /// non-whitespace character to the last non-whitespace character
 /// before the gap, leaving the gap free for the rule to rewrite.
-/// Shared by every rule that aligns at a token's line position.
 pub(crate) fn line_anchored_member(source: &Source, anchor: TextSize) -> Member {
     let line_start = source.text().line_start(anchor);
     let prefix = source.slice(TextRange::new(line_start, anchor));
@@ -181,10 +176,7 @@ pub(crate) fn line_anchored_member(source: &Source, anchor: TextSize) -> Member 
 }
 
 /// Builds a `Member` whose anchor is the first token of `kind` within
-/// `search`. Convenience for the dominant rule-side composition,
-/// which finds a keyword or operator token in a tight range and then
-/// builds a line-anchored member from its start. Returns `None` when
-/// the search turns up nothing.
+/// `search`. Returns `None` when the search turns up nothing.
 pub(crate) fn line_anchored_member_at_kind(
     source: &Source,
     search: TextRange,
@@ -211,10 +203,7 @@ where
     F: FnMut(&Token) -> bool,
 {
     let anchor = source.first_token_offset_in_range(search, predicate)?;
-    if source
-        .text()
-        .contains_line_break(TextRange::new(target.start(), anchor))
-    {
+    if source.contains_line_break(TextRange::new(target.start(), anchor)) {
         return None;
     }
     Some(range_anchored_member(source, target, anchor, extra_width))
@@ -222,8 +211,7 @@ where
 
 /// Returns the edit needed to make `range` carry exactly `n` ASCII
 /// spaces, or `None` if it already does. Emits `Edit::range_deletion`
-/// when `n` is zero, because `Edit::range_replacement` rejects empty
-/// content.
+/// when `n` is zero.
 pub(crate) fn space_padding_edit(source: &Source, range: TextRange, n: usize) -> Option<Edit> {
     let text = source.slice(range);
     if text.len() == n && text.bytes().all(|b| b == b' ') {
@@ -354,9 +342,8 @@ mod tests {
 
     /// Builds a multi-line Python source where each row is
     /// `x...x{spaces}= 0\n`, returns the source plus one `Member` per
-    /// row pointing at that row's pre-`=` whitespace. The `gap_chars`
-    /// value seeds the existing pre-`=` whitespace so tests can probe
-    /// the "already correct" branch in `emit_with_paddings`.
+    /// row pointing at that row's pre-`=` whitespace. `gap_chars` seeds
+    /// the existing pre-`=` whitespace.
     fn rows(specs: &[(usize, usize)]) -> (Source, Vec<Member>) {
         let mut text = String::new();
         let mut members = Vec::new();
@@ -668,6 +655,16 @@ mod tests {
             groups.iter().map(Vec::len).collect::<Vec<_>>(),
             vec![1, 1, 1],
         );
+    }
+
+    #[test]
+    fn keyed_line_adjacent_groups_splits_on_multiline_prior_stmt() {
+        let source = parse("x = {\n    'a': 1,\n}\ny = 2\n");
+        let groups = keyed_line_adjacent_groups(&source, &source.ast().body, |s| {
+            s.as_assign_stmt().map(|_| ((), ()))
+        });
+
+        assert_eq!(groups.iter().map(Vec::len).collect::<Vec<_>>(), vec![1, 1]);
     }
 
     #[test]

--- a/tests/fixtures/align_colons/multiline_field_value_breaks_group.input.py
+++ b/tests/fixtures/align_colons/multiline_field_value_breaks_group.input.py
@@ -1,0 +1,13 @@
+"""
+A class field whose value spans multiple source lines breaks the
+colon-alignment group, so the following single-line field lands in
+its own group rather than aligning across the multi-line entry.
+"""
+
+
+class C:
+    primary: dict = {
+        "alpha": 1,
+        "beta": 2,
+    }
+    secondary: str

--- a/tests/fixtures/align_equals/multiline_value_breaks_group.input.py
+++ b/tests/fixtures/align_equals/multiline_value_breaks_group.input.py
@@ -1,0 +1,11 @@
+"""
+A right-hand side that spans multiple source lines breaks the
+alignment group, so the following single-line assignment lands in
+its own group rather than aligning across the multi-line entry.
+"""
+
+PRIMARY = {
+    "alpha": 1,
+    "beta": 2,
+}
+SECONDARY = 3

--- a/tests/snapshots/align_colons/multiline_field_value_breaks_group.diagnostics.snap
+++ b/tests/snapshots/align_colons/multiline_field_value_breaks_group.diagnostics.snap
@@ -1,0 +1,8 @@
+---
+source: tests/diagnostics.rs
+assertion_line: 39
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_colons/multiline_field_value_breaks_group.input.py
+---
+align-colons@252..252
+align-colons@271..271

--- a/tests/snapshots/align_colons/multiline_field_value_breaks_group.input.py.snap
+++ b/tests/snapshots/align_colons/multiline_field_value_breaks_group.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+assertion_line: 28
+expression: output
+input_file: tests/fixtures/align_colons/multiline_field_value_breaks_group.input.py
+---
+"""
+A class field whose value spans multiple source lines breaks the
+colon-alignment group, so the following single-line field lands in
+its own group rather than aligning across the multi-line entry.
+"""
+
+
+class C:
+    primary: dict = {
+        "alpha" : 1,
+        "beta"  : 2,
+    }
+    secondary: str

--- a/tests/snapshots/align_equals/multiline_value_breaks_group.diagnostics.snap
+++ b/tests/snapshots/align_equals/multiline_value_breaks_group.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+assertion_line: 39
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/multiline_value_breaks_group.input.py
+---
+

--- a/tests/snapshots/align_equals/multiline_value_breaks_group.input.py.snap
+++ b/tests/snapshots/align_equals/multiline_value_breaks_group.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+assertion_line: 28
+expression: output
+input_file: tests/fixtures/align_equals/multiline_value_breaks_group.input.py
+---
+"""
+A right-hand side that spans multiple source lines breaks the
+alignment group, so the following single-line assignment lands in
+its own group rather than aligning across the multi-line entry.
+"""
+
+PRIMARY = {
+    "alpha": 1,
+    "beta": 2,
+}
+SECONDARY = 3

--- a/tests/snapshots/composition/union_in_constant.diagnostics.snap
+++ b/tests/snapshots/composition/union_in_constant.diagnostics.snap
@@ -8,10 +8,9 @@ align-colons@265..265
 align-colons@292..292
 align-colons@327..327
 align-colons@359..359
-align-equals@249..250
 alphabetize@316..373
 collection-layout@253..357
-legacy-union-syntax@275..288
-legacy-union-syntax@309..324
-legacy-union-syntax@345..362
-legacy-union-syntax@383..396
+legacy-union-syntax@273..286
+legacy-union-syntax@307..322
+legacy-union-syntax@343..360
+legacy-union-syntax@381..394

--- a/tests/snapshots/composition/union_in_constant.input.py.snap
+++ b/tests/snapshots/composition/union_in_constant.input.py.snap
@@ -18,7 +18,7 @@ Rules:
 
 from typing import Optional, Union
 
-PRIMARY   = {
+PRIMARY = {
     "alpha"      : Optional[str],
     "beta"       : Union[int, str],
     "delta_long" : Union[bool, None],


### PR DESCRIPTION
### 🪻 Quick Summary

Breaks the alignment run in `keyed_line_adjacent_groups` whenever the prior statement itself spans more than one source line, so a multi-line dict literal, list comprehension, or triple-quoted string no longer pulls the following single-line assignment into its alignment group merely because the closing token sits on the immediately-preceding line. The `composition/union_in_constant` failure mode (*`PRIMARY = { ... }` aligning its `=` with `SECONDARY = "fallback"` across six lines of dict body*) disappears, and both `align_equals` and `align_colons` consumers inherit the new behavior through the shared grouping primitive.

---

### 🗞️ Key Changes

- Adds a multi-line check to `keyed_line_adjacent_groups`'s run-extension predicate, breaking the run when the prior statement spans more than one source line

- Widens the active-run state from `TextSize` to `TextRange` so the predicate can read the prior's full span through `Source::contains_line_break`

- Adds an inline test in `src/primitives/aligner.rs::tests` pinning a multi-line statement followed by a single-line statement as two groups

- Adds rule-level fixtures `tests/fixtures/align_equals/multiline_value_breaks_group.input.py` and `tests/fixtures/align_colons/multiline_field_value_breaks_group.input.py` pinning the new break at each consumer, with the `align_colons` fixture exercising the class-body annotated-field path through `class_field_groups` in `src/primitives/colon_targets.rs`

- Regenerates `tests/snapshots/composition/union_in_constant.input.py.snap` and the matching diagnostics snapshot so `PRIMARY`'s `=` and `SECONDARY`'s `=` sit in independent groups and no `align-equals` edit fires between them

- Switches `range_anchored_member_single_line` to call `source.contains_line_break` directly rather than reaching through `source.text()`, matching the new caller's idiom on the shared `Source` facade

- Trims motivation clauses from eight pre-existing doc comments across `Member`, `Settings`, `is_alignment_candidate`, `keyed_line_adjacent_groups`, `line_anchored_member`, `line_anchored_member_at_kind`, `space_padding_edit`, and the `rows` test helper, leaving each doc comment stating logic rather than rationale

---

### 🧵 Related Issues

- Closes #99