### PR TITLE
[98] Insert blank line between bare-import and `from`-import groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Auto-fix rules:
 | `align-imports` | The `import` keyword in `from ... import ...` groups and `as` in `import ... as ...` groups |
 | `alphabetize` | Classes, methods (*grouped dunders → properties → privates → publics*), enum members, Pydantic fields (*required then optional*), function parameters, keyword arguments, and `from` imports |
 | `bare-import-allowlist` | Bare `import X` outside a configurable allowlist (*default `numpy`, `pandas`*) |
-| `blank-lines` | Module-level `def` and `class` carry 2 blank lines before them, methods inside a class body carry 1, and a module-level statement after `if __name__ == "__main__":` carries 1 |
+| `blank-lines` | Module-level `def` and `class` carry 2 blank lines before them, methods inside a class body carry 1, a module-level statement after `if __name__ == "__main__":` carries 1, and adjacent module-level bare `import` and `from` imports carry 1 between them |
 | `collection-layout` | Expands `dict`, `list`, and `set` literals to one entry per line, even when they fit inline |
 | `docstring-wrap` | Wraps docstring description prose to `docstring-line-length` and structured `Args:` / `Returns:` / `Raises:` sections to the budget chosen by `docstring-structured-policy` |
 | `match-case-align` | Single-expression case bodies |

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -653,10 +653,9 @@ where
 }
 
 /// Builds a `Vec<Range<usize>>` of body slots whose statements all
-/// match `predicate`. Adjacent matching statements stay in the same
-/// run regardless of any blank lines between them, so all imports
-/// of the same form collapse into one block at the top of the body.
-/// Non-matching statements break the run. Singleton runs drop.
+/// match `predicate`. Consecutive matching slots collapse into one
+/// run, and a non-matching statement between two matching ones breaks
+/// the run. Singleton runs drop.
 fn statement_run_ranges(
     body: &[Stmt],
     mut predicate: impl FnMut(&Stmt) -> bool,

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -3,9 +3,10 @@
 //! class body carry 1 blank line. A class-scope predecessor that is a
 //! string-literal docstring carries 1 blank line before the next member.
 //! A module-level statement following an `if __name__ == "__main__":`
-//! block carries 1 blank line of separation. Own-line comments between
-//! adjacent statements carry 1 blank line of separation from the
-//! following statement.
+//! block carries 1 blank line of separation. Adjacent module-level bare
+//! `import` and `from` import statements carry 1 blank line between them.
+//! Own-line comments between adjacent statements carry 1 blank line of
+//! separation from the following statement.
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_docstring_stmt;
@@ -135,13 +136,14 @@ fn canonical_blanks(prev: &Stmt, curr: &Stmt, scope: BodyScope) -> Option<u32> {
             || matches!((prev, curr), (Stmt::FunctionDef(_), Stmt::FunctionDef(_))))
         .then_some(1),
         BodyScope::Function => None,
-        BodyScope::Module => {
-            if is_main_guard(prev) {
+        BodyScope::Module => match (prev, curr) {
+            _ if is_main_guard(prev) => Some(1),
+            (Stmt::Import(_), Stmt::ImportFrom(_)) | (Stmt::ImportFrom(_), Stmt::Import(_)) => {
                 Some(1)
-            } else {
-                matches!(curr, Stmt::FunctionDef(_) | Stmt::ClassDef(_)).then_some(2)
             }
-        }
+            (_, Stmt::FunctionDef(_) | Stmt::ClassDef(_)) => Some(2),
+            _ => None,
+        },
     }
 }
 
@@ -249,6 +251,38 @@ mod tests {
             canonical_blanks(&body[0], &body[1], BodyScope::Module),
             Some(2)
         );
+    }
+
+    #[test]
+    fn canonical_blanks_module_import_kind_boundary_returns_one() {
+        for src in [
+            "import os\nfrom sys import argv\n",
+            "from sys import argv\nimport os\n",
+        ] {
+            let s = parse(src);
+            let body = &s.ast().body;
+            assert_eq!(
+                canonical_blanks(&body[0], &body[1], BodyScope::Module),
+                Some(1),
+                "src = {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_blanks_module_same_kind_import_run_returns_none() {
+        for src in [
+            "import os\nimport sys\n",
+            "from os import path\nfrom sys import argv\n",
+        ] {
+            let s = parse(src);
+            let body = &s.ast().body;
+            assert_eq!(
+                canonical_blanks(&body[0], &body[1], BodyScope::Module),
+                None,
+                "src = {src:?}",
+            );
+        }
     }
 
     #[test]

--- a/tests/fixtures/blank_lines/bare_then_from_collapse.input.py
+++ b/tests/fixtures/blank_lines/bare_then_from_collapse.input.py
@@ -1,0 +1,9 @@
+"""
+A bare `import` followed by a `from` import separated by two blank
+lines collapses to one.
+"""
+
+import os
+
+
+from sys import argv

--- a/tests/fixtures/blank_lines/bare_then_from_idempotent.input.py
+++ b/tests/fixtures/blank_lines/bare_then_from_idempotent.input.py
@@ -1,0 +1,8 @@
+"""
+A bare `import` followed by a `from` import already separated by one
+blank line stays at one.
+"""
+
+import os
+
+from sys import argv

--- a/tests/fixtures/blank_lines/bare_then_from_insert.input.py
+++ b/tests/fixtures/blank_lines/bare_then_from_insert.input.py
@@ -1,0 +1,7 @@
+"""
+A bare `import` immediately followed by a `from` import with zero
+blank lines between them expands to one blank line of separation.
+"""
+
+import os
+from sys import argv

--- a/tests/fixtures/blank_lines/bare_then_from_with_comment.input.py
+++ b/tests/fixtures/blank_lines/bare_then_from_with_comment.input.py
@@ -1,0 +1,9 @@
+"""
+An own-line comment between a bare `import` and a following `from`
+import surfaces 1 blank line above the comment and 1 blank line
+between the comment and the from-import.
+"""
+
+import os
+# boundary
+from sys import argv

--- a/tests/fixtures/blank_lines/from_then_bare_collapse.input.py
+++ b/tests/fixtures/blank_lines/from_then_bare_collapse.input.py
@@ -1,0 +1,9 @@
+"""
+A `from` import followed by a bare `import` separated by two blank
+lines collapses to one.
+"""
+
+from sys import argv
+
+
+import os

--- a/tests/fixtures/blank_lines/from_then_bare_idempotent.input.py
+++ b/tests/fixtures/blank_lines/from_then_bare_idempotent.input.py
@@ -1,0 +1,8 @@
+"""
+A `from` import followed by a bare `import` already separated by one
+blank line stays at one.
+"""
+
+from sys import argv
+
+import os

--- a/tests/fixtures/blank_lines/from_then_bare_insert.input.py
+++ b/tests/fixtures/blank_lines/from_then_bare_insert.input.py
@@ -1,0 +1,7 @@
+"""
+A `from` import immediately followed by a bare `import` with zero
+blank lines between them expands to one blank line of separation.
+"""
+
+from sys import argv
+import os

--- a/tests/fixtures/composition/imports_mixed_kinds.config.toml
+++ b/tests/fixtures/composition/imports_mixed_kinds.config.toml
@@ -1,2 +1,2 @@
 [harness]
-rules = ["alphabetize", "align-imports"]
+rules = ["alphabetize", "align-imports", "blank-lines"]

--- a/tests/fixtures/composition/imports_mixed_kinds.input.py
+++ b/tests/fixtures/composition/imports_mixed_kinds.input.py
@@ -1,11 +1,13 @@
 """
 Module top with a mixed run of bare imports and from-imports, each
-kind out of alphabetical order. alphabetize sorts each kind in place
-and align_imports aligns the `as` keyword across the aliased lines.
+kind out of alphabetical order. alphabetize sorts each kind in place,
+align_imports aligns the `as` keyword across the aliased lines, and
+blank_lines inserts one blank line at the bare-to-from boundary.
 
 Rules:
 - alphabetize
 - align_imports
+- blank_lines
 """
 
 import requests as req

--- a/tests/snapshots/blank_lines/bare_then_from_collapse.diagnostics.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_collapse.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/bare_then_from_collapse.input.py
+---
+blank-lines@109..112

--- a/tests/snapshots/blank_lines/bare_then_from_collapse.input.py.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_collapse.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/bare_then_from_collapse.input.py
+---
+"""
+A bare `import` followed by a `from` import separated by two blank
+lines collapses to one.
+"""
+
+import os
+
+from sys import argv

--- a/tests/snapshots/blank_lines/bare_then_from_idempotent.diagnostics.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_idempotent.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/bare_then_from_idempotent.input.py
+---
+

--- a/tests/snapshots/blank_lines/bare_then_from_idempotent.input.py.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_idempotent.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/bare_then_from_idempotent.input.py
+---
+"""
+A bare `import` followed by a `from` import already separated by one
+blank line stays at one.
+"""
+
+import os
+
+from sys import argv

--- a/tests/snapshots/blank_lines/bare_then_from_insert.diagnostics.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_insert.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/bare_then_from_insert.input.py
+---
+blank-lines@150..151

--- a/tests/snapshots/blank_lines/bare_then_from_insert.input.py.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_insert.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/bare_then_from_insert.input.py
+---
+"""
+A bare `import` immediately followed by a `from` import with zero
+blank lines between them expands to one blank line of separation.
+"""
+
+import os
+
+from sys import argv

--- a/tests/snapshots/blank_lines/bare_then_from_with_comment.diagnostics.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_with_comment.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/bare_then_from_with_comment.input.py
+---
+blank-lines@190..191
+blank-lines@201..202

--- a/tests/snapshots/blank_lines/bare_then_from_with_comment.input.py.snap
+++ b/tests/snapshots/blank_lines/bare_then_from_with_comment.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/bare_then_from_with_comment.input.py
+---
+"""
+An own-line comment between a bare `import` and a following `from`
+import surfaces 1 blank line above the comment and 1 blank line
+between the comment and the from-import.
+"""
+
+import os
+
+# boundary
+
+from sys import argv

--- a/tests/snapshots/blank_lines/from_then_bare_collapse.diagnostics.snap
+++ b/tests/snapshots/blank_lines/from_then_bare_collapse.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/from_then_bare_collapse.input.py
+---
+blank-lines@120..123

--- a/tests/snapshots/blank_lines/from_then_bare_collapse.input.py.snap
+++ b/tests/snapshots/blank_lines/from_then_bare_collapse.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/from_then_bare_collapse.input.py
+---
+"""
+A `from` import followed by a bare `import` separated by two blank
+lines collapses to one.
+"""
+
+from sys import argv
+
+import os

--- a/tests/snapshots/blank_lines/from_then_bare_idempotent.diagnostics.snap
+++ b/tests/snapshots/blank_lines/from_then_bare_idempotent.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/from_then_bare_idempotent.input.py
+---
+

--- a/tests/snapshots/blank_lines/from_then_bare_idempotent.input.py.snap
+++ b/tests/snapshots/blank_lines/from_then_bare_idempotent.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/from_then_bare_idempotent.input.py
+---
+"""
+A `from` import followed by a bare `import` already separated by one
+blank line stays at one.
+"""
+
+from sys import argv
+
+import os

--- a/tests/snapshots/blank_lines/from_then_bare_insert.diagnostics.snap
+++ b/tests/snapshots/blank_lines/from_then_bare_insert.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/from_then_bare_insert.input.py
+---
+blank-lines@161..162

--- a/tests/snapshots/blank_lines/from_then_bare_insert.input.py.snap
+++ b/tests/snapshots/blank_lines/from_then_bare_insert.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/from_then_bare_insert.input.py
+---
+"""
+A `from` import immediately followed by a bare `import` with zero
+blank lines between them expands to one blank line of separation.
+"""
+
+from sys import argv
+
+import os

--- a/tests/snapshots/composition/imports_mixed_kinds.diagnostics.snap
+++ b/tests/snapshots/composition/imports_mixed_kinds.diagnostics.snap
@@ -3,7 +3,8 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/composition/imports_mixed_kinds.input.py
 ---
-align-imports@289..290
-align-imports@311..312
-align-imports@358..359
-alphabetize@258..393
+align-imports@369..370
+align-imports@391..392
+align-imports@439..440
+alphabetize@338..473
+blank-lines@398..399

--- a/tests/snapshots/composition/imports_mixed_kinds.input.py.snap
+++ b/tests/snapshots/composition/imports_mixed_kinds.input.py.snap
@@ -5,17 +5,20 @@ input_file: tests/fixtures/composition/imports_mixed_kinds.input.py
 ---
 """
 Module top with a mixed run of bare imports and from-imports, each
-kind out of alphabetical order. alphabetize sorts each kind in place
-and align_imports aligns the `as` keyword across the aliased lines.
+kind out of alphabetical order. alphabetize sorts each kind in place,
+align_imports aligns the `as` keyword across the aliased lines, and
+blank_lines inserts one blank line at the bare-to-from boundary.
 
 Rules:
 - alphabetize
 - align_imports
+- blank_lines
 """
 
 import collections as col
 import numpy       as np
 import requests    as req
+
 from collections import Counter
 from os     import path
 from typing import Any


### PR DESCRIPTION
### 🪻 Quick Summary

Inserts one blank line between adjacent module-level bare `import` and `from` import statements, treating the kind boundary as a canonical separator the way *Prose* already separates two top-level `def`s by two blank lines. The `canonical_blanks` function in `src/rules/blank_lines.rs` gains a transition arm returning `Some(1)` for both directions of the boundary (*bare → from and from → bare*), and the `composition/imports_mixed_kinds` snapshot now carries the blank line between its bare-import block and its from-import block.

---

### 🗞️ Key Changes

- Adds the bare-to-from and from-to-bare arm to `canonical_blanks` in `src/rules/blank_lines.rs`, returning `Some(1)` for both directions at the import-kind boundary

- Converts the `BodyScope::Module` branch of `canonical_blanks` from an if-else ladder to a flat `match (prev, curr)`, so the four cases (*main-guard predecessor, import-kind boundary, top-level def/class, fallthrough*) each read as a pair-pattern mapping

- Rewrites the `statement_run_ranges` docstring in `src/rules/alphabetize.rs` to describe the `chunk_by` semantics actually in force, dropping the prior *"promote and merge across gaps"* framing that belonged to import-block unification work targeted for `0.3.0`

- Updates the `//!` module preamble of `src/rules/blank_lines.rs` and the auto-fix rules table in `README.md` to enumerate the new transition case alongside the existing canonical-count rules

- Adds 7 fixtures under `tests/fixtures/blank_lines/` covering the 2×3 direction matrix (*`bare_then_from_{insert,idempotent,collapse}` and `from_then_bare_{insert,idempotent,collapse}`*) plus `bare_then_from_with_comment` pinning the new arm's interaction with `leading_block_of` when an own-line comment sits at the boundary

- Adds inline tests `canonical_blanks_module_import_kind_boundary_returns_one` and `canonical_blanks_module_same_kind_import_run_returns_none` pinning both directions of the new arm and that same-kind import pairs fall through to `None`

- Wires `blank-lines` into the `[harness] rules` list of `tests/fixtures/composition/imports_mixed_kinds.config.toml` so the snapshot regenerates with the new canonical blank line between its bare-import and from-import blocks

---

### 🧵 Related Issues

- Closes #98
