### PR TITLE
[100] Fix `align_colons` off-by-one when widest field forces a singleton sub-group

### DIFF
--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -33,9 +33,10 @@ pub(crate) struct Member {
 
 /// Emission knobs shared by every alignment rule.
 ///
-/// `strip_singleton_subgroup` overrides the suffix to `0` for
-/// size-one sub-groups in `emit_split`, used by the `:`-anchored
-/// rules.
+/// `strip_singleton_subgroup` collapses size-one sub-groups in
+/// `emit_split` to a zero-width gap, except when the singleton is
+/// strictly the widest member of the group, in which case it anchors
+/// every sub-group's padding at `singleton.width + 1`.
 #[derive(Clone, Copy)]
 pub(crate) struct Settings {
     max_shift: usize,
@@ -255,36 +256,26 @@ fn emit_drop(source: &Source, members: &[Member], settings: Settings, edits: &mu
     emit_with_paddings(source, kept, max_w, 1, edits);
 }
 
-/// Partitions greedily, extending the current sub-group while its
-/// widest padding stays under the cap and then starting a new
-/// sub-group. Each contiguous sub-group aligns independently. A
-/// singleton sub-group collapses its gap to one space by default, or
-/// to zero when `settings.strip_singleton_subgroup` is set.
+/// Partitions greedily into sub-groups capped at `settings.max_shift`
+/// spread, each aligning at its own widest member by default. A
+/// singleton collapses its gap to one space, or to zero when
+/// `settings.strip_singleton_subgroup` is set. The strip shortcut
+/// inverts when the singleton is strictly the widest member, wherein
+/// it anchors every sub-group at `singleton.width + 1`.
 fn emit_split(source: &Source, members: &[Member], settings: Settings, edits: &mut Vec<Edit>) {
-    let mut cursor = 0;
-    while cursor < members.len() {
-        let mut min_w = members[cursor].width;
-        let mut max_w = min_w;
-        let mut end = cursor + 1;
-        while end < members.len() {
-            let w = members[end].width;
-            let new_min = min_w.min(w);
-            let new_max = max_w.max(w);
-            if new_max - new_min > settings.max_shift {
-                break;
-            }
-            min_w = new_min;
-            max_w = new_max;
-            end += 1;
-        }
-        let sub = &members[cursor..end];
-        let suffix = if sub.len() == 1 && settings.strip_singleton_subgroup {
-            0
-        } else {
-            1
+    let subs = partition_by_spread(members, settings.max_shift);
+    let anchor = settings
+        .strip_singleton_subgroup
+        .then(|| widest_singleton_anchor_width(members, &subs))
+        .flatten();
+    for &(start, end, sub_max_w) in &subs {
+        let sub = &members[start..end];
+        let (max_w, suffix) = match (anchor, sub.len()) {
+            (Some(a), _) => (a, 1),
+            (None, 1) if settings.strip_singleton_subgroup => (sub[0].width, 0),
+            (None, _) => (sub_max_w, 1),
         };
         emit_with_paddings(source, sub, max_w, suffix, edits);
-        cursor = end;
     }
 }
 
@@ -305,6 +296,33 @@ fn emit_with_paddings(
     );
 }
 
+/// Returns the half-open `(start, end, max_width)` sub-group ranges
+/// into `members` produced by greedily extending each sub-group while
+/// the running `max_width - min_width` stays at or below `max_shift`.
+fn partition_by_spread(members: &[Member], max_shift: usize) -> Vec<(usize, usize, usize)> {
+    let mut subs = Vec::new();
+    let mut cursor = 0;
+    while cursor < members.len() {
+        let mut min_w = members[cursor].width;
+        let mut max_w = min_w;
+        let mut end = cursor + 1;
+        while end < members.len() {
+            let w = members[end].width;
+            let new_min = min_w.min(w);
+            let new_max = max_w.max(w);
+            if new_max - new_min > max_shift {
+                break;
+            }
+            min_w = new_min;
+            max_w = new_max;
+            end += 1;
+        }
+        subs.push((cursor, end, max_w));
+        cursor = end;
+    }
+    subs
+}
+
 /// Builds a `Member` for a row whose aligned token sits at `anchor`,
 /// with width measured by the display width of `target` plus
 /// `extra_width`. Pass `extra_width = 0` when the LHS is exactly
@@ -323,6 +341,21 @@ fn range_anchored_member(
         line_start: source.text().line_start(anchor),
         width: source.slice(target).width() + extra_width,
     }
+}
+
+/// Returns the width of the strictly-widest member in `members` when
+/// the greedy partition isolates that member as its own sub-group.
+fn widest_singleton_anchor_width(
+    members: &[Member],
+    subs: &[(usize, usize, usize)],
+) -> Option<usize> {
+    let (widest_idx, widest) = members.iter().enumerate().max_by_key(|(_, m)| m.width)?;
+    let w = widest.width;
+    let unique = members.iter().filter(|m| m.width == w).nth(1).is_none();
+    let isolated = subs
+        .iter()
+        .any(|&(s, e, _)| s == widest_idx && e == widest_idx + 1);
+    (unique && isolated).then_some(w)
 }
 
 #[cfg(test)]
@@ -512,6 +545,30 @@ mod tests {
     }
 
     #[test]
+    fn emit_group_split_anchors_at_widest_singleton_when_strip_is_set() {
+        // Widths span 13 → 4, a 9-wide spread that exceeds max_shift=8.
+        // The greedy partition isolates the leading width-13 member as
+        // a singleton. With strip on, the singleton anchors the whole
+        // group at width 13 + 1, so every member's `:` lands at the
+        // same column: 13+1, 4+10, 11+3, 7+7 = 14.
+        let (source, members) = rows(&[(13, 1), (4, 1), (11, 1), (7, 1)]);
+        let mut edits = Vec::new();
+
+        let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
+        emit_group(&source, &members, settings, &mut edits);
+
+        // member[0] already carries gap=1 (the target), so no edit emits.
+        assert_eq!(
+            sorted_summaries(&edits),
+            vec![
+                fill(&members[1], 10),
+                fill(&members[2], 3),
+                fill(&members[3], 7),
+            ],
+        );
+    }
+
+    #[test]
     fn emit_group_split_partitions_into_contiguous_subgroups() {
         let (source, members) = rows(&[(1, 1), (2, 1), (15, 1), (3, 1), (4, 1)]);
         let mut edits = Vec::new();
@@ -533,20 +590,43 @@ mod tests {
     }
 
     #[test]
-    fn emit_group_split_strips_singleton_subgroup_when_flag_is_set() {
-        let (source, members) = rows(&[(1, 1), (2, 1), (15, 1), (3, 1), (4, 1)]);
+    fn emit_group_split_skips_anchor_when_widest_width_ties() {
+        // widths 13, 4, 13 yield spread = 9, exceeding max_shift=8.
+        // Partition isolates each as a singleton. Both 13s share max
+        // width, so no strictly-widest singleton anchor fires, and
+        // strip collapses each gap to zero.
+        let (source, members) = rows(&[(13, 1), (4, 1), (13, 1)]);
         let mut edits = Vec::new();
 
         let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
         emit_group(&source, &members, settings, &mut edits);
 
-        // [15] singleton sub-group collapses to 0 with strip on.
+        assert_eq!(
+            sorted_summaries(&edits),
+            vec![
+                delete(&members[0]),
+                delete(&members[1]),
+                delete(&members[2]),
+            ],
+        );
+    }
+
+    #[test]
+    fn emit_group_split_strips_singleton_subgroup_when_flag_is_set() {
+        let (source, members) = rows(&[(10, 1), (11, 1), (1, 1), (12, 1), (13, 1)]);
+        let mut edits = Vec::new();
+
+        let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
+        emit_group(&source, &members, settings, &mut edits);
+
+        // [1] is a narrow singleton, so strip collapses its gap to 0
+        // while [10, 11] and [12, 13] align within their own max_w.
         assert_eq!(
             sorted_summaries(&edits),
             vec![
                 fill(&members[0], 2),
                 delete(&members[2]),
-                fill(&members[3], 2)
+                fill(&members[3], 2),
             ],
         );
     }

--- a/tests/fixtures/align_colons/multi_subgroup_alignment.input.py
+++ b/tests/fixtures/align_colons/multi_subgroup_alignment.input.py
@@ -1,0 +1,12 @@
+"""
+Class fields whose widths split into two sub-groups under the
+rule's `max-shift` cap. The widest field sits in a multi-member
+sub-group rather than its own singleton, so no anchor override
+fires and each sub-group aligns at its own widest member's column.
+"""
+
+class Packet:
+    host: str
+    index: int
+    payload_buffer: bytes
+    response_buffer: list

--- a/tests/fixtures/align_colons/narrow_singleton_strip.input.py
+++ b/tests/fixtures/align_colons/narrow_singleton_strip.input.py
@@ -1,0 +1,14 @@
+"""
+Class fields whose widths split into sub-groups under the rule's
+`max-shift` cap. A single narrow field falls into its own singleton
+sub-group whose width sits below the surrounding sub-groups' max,
+triggering the strip-to-zero collapse rather than the wide-singleton
+anchor.
+"""
+
+class Packet:
+    connection: int
+    descriptors: list
+    n: int
+    payload_size: int
+    request_buffer: bytes

--- a/tests/fixtures/align_colons/shift_limit_split.input.py
+++ b/tests/fixtures/align_colons/shift_limit_split.input.py
@@ -1,9 +1,9 @@
 """
 Class fields whose widths span more than the rule's `max-shift`
 apart trigger the default `split` policy. The greedy partitioner
-produces three contiguous sub-groups, each aligning at its own
-widest member's column. The outlier falls into a singleton
-sub-group whose gap collapses to zero.
+isolates `really_really_long_field` as a singleton sub-group. As
+the strictly widest member, it anchors every other sub-group at
+its column, overriding the cap so all `:`s share one column.
 """
 
 class Packet:

--- a/tests/fixtures/match_case_align/or_pattern.input.py
+++ b/tests/fixtures/match_case_align/or_pattern.input.py
@@ -1,8 +1,8 @@
 """
 Arms with `case A | B` pattern alternations. The third arm's
 pattern is wide enough to break the greedy split-policy run,
-falling into its own singleton sub-group whose colon hugs.
-The first two align against each other at the narrower column.
+falling into its own singleton sub-group. As the strictly widest
+arm, it anchors the other two so all `:`s share one column.
 """
 
 match status:

--- a/tests/snapshots/align_colons/multi_subgroup_alignment.diagnostics.snap
+++ b/tests/snapshots/align_colons/multi_subgroup_alignment.diagnostics.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostics.rs
+assertion_line: 39
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_colons/multi_subgroup_alignment.input.py
+---
+align-colons@287..287
+align-colons@302..302
+align-colons@326..326
+align-colons@353..353

--- a/tests/snapshots/align_colons/multi_subgroup_alignment.input.py.snap
+++ b/tests/snapshots/align_colons/multi_subgroup_alignment.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+assertion_line: 28
+expression: output
+input_file: tests/fixtures/align_colons/multi_subgroup_alignment.input.py
+---
+"""
+Class fields whose widths split into two sub-groups under the
+rule's `max-shift` cap. The widest field sits in a multi-member
+sub-group rather than its own singleton, so no anchor override
+fires and each sub-group aligns at its own widest member's column.
+"""
+
+class Packet:
+    host  : str
+    index : int
+    payload_buffer  : bytes
+    response_buffer : list

--- a/tests/snapshots/align_colons/narrow_singleton_strip.diagnostics.snap
+++ b/tests/snapshots/align_colons/narrow_singleton_strip.diagnostics.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostics.rs
+assertion_line: 39
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_colons/narrow_singleton_strip.input.py
+---
+align-colons@313..313
+align-colons@334..334
+align-colons@368..368
+align-colons@392..392

--- a/tests/snapshots/align_colons/narrow_singleton_strip.input.py.snap
+++ b/tests/snapshots/align_colons/narrow_singleton_strip.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+assertion_line: 28
+expression: output
+input_file: tests/fixtures/align_colons/narrow_singleton_strip.input.py
+---
+"""
+Class fields whose widths split into sub-groups under the rule's
+`max-shift` cap. A single narrow field falls into its own singleton
+sub-group whose width sits below the surrounding sub-groups' max,
+triggering the strip-to-zero collapse rather than the wide-singleton
+anchor.
+"""
+
+class Packet:
+    connection  : int
+    descriptors : list
+    n: int
+    payload_size   : int
+    request_buffer : bytes

--- a/tests/snapshots/align_colons/shift_limit_split.diagnostics.snap
+++ b/tests/snapshots/align_colons/shift_limit_split.diagnostics.snap
@@ -1,9 +1,11 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 39
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_colons/shift_limit_split.input.py
 ---
-align-colons@322..322
-align-colons@343..343
-align-colons@395..395
-align-colons@409..409
+align-colons@351..351
+align-colons@372..372
+align-colons@406..406
+align-colons@424..424
+align-colons@438..438

--- a/tests/snapshots/align_colons/shift_limit_split.input.py.snap
+++ b/tests/snapshots/align_colons/shift_limit_split.input.py.snap
@@ -1,19 +1,20 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+assertion_line: 28
+expression: output
 input_file: tests/fixtures/align_colons/shift_limit_split.input.py
 ---
 """
 Class fields whose widths span more than the rule's `max-shift`
 apart trigger the default `split` policy. The greedy partitioner
-produces three contiguous sub-groups, each aligning at its own
-widest member's column. The outlier falls into a singleton
-sub-group whose gap collapses to zero.
+isolates `really_really_long_field` as a singleton sub-group. As
+the strictly widest member, it anchors every other sub-group at
+its column, overriding the cap so all `:`s share one column.
 """
 
 class Packet:
-    short       : int
-    medium_size : str
-    really_really_long_field: bytes
-    longer : int
-    tiny   : str
+    short                    : int
+    medium_size              : str
+    really_really_long_field : bytes
+    longer                   : int
+    tiny                     : str

--- a/tests/snapshots/composition/class_field_block.diagnostics.snap
+++ b/tests/snapshots/composition/class_field_block.diagnostics.snap
@@ -1,12 +1,14 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 39
 expression: render(&diagnostics)
 input_file: tests/fixtures/composition/class_field_block.input.py
 ---
+align-colons@228..228
 align-colons@254..254
 align-colons@289..289
 align-colons@310..310
-align-equals@233..234
-align-equals@267..268
-align-equals@303..304
+align-equals@234..235
+align-equals@270..271
+align-equals@308..309
 alphabetize@215..324

--- a/tests/snapshots/composition/class_field_block.input.py.snap
+++ b/tests/snapshots/composition/class_field_block.input.py.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration.rs
+assertion_line: 28
 expression: output
 input_file: tests/fixtures/composition/class_field_block.input.py
 ---
@@ -15,7 +16,7 @@ Rules:
 
 
 class Endpoint:
-    backend_label: str  = "primary"
-    host        : str   = "localhost"
-    retry_count : int   = 3
-    timeout     : float = 30.0
+    backend_label : str   = "primary"
+    host          : str   = "localhost"
+    retry_count   : int   = 3
+    timeout       : float = 30.0

--- a/tests/snapshots/match_case_align/or_pattern.diagnostics.snap
+++ b/tests/snapshots/match_case_align/or_pattern.diagnostics.snap
@@ -1,10 +1,12 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 39
 expression: render(&diagnostics)
 input_file: tests/fixtures/match_case_align/or_pattern.input.py
 ---
-match-case-align@289..289
-match-case-align@290..299
-match-case-align@328..328
-match-case-align@329..338
-match-case-align@388..397
+match-case-align@292..292
+match-case-align@293..302
+match-case-align@331..331
+match-case-align@332..341
+match-case-align@390..390
+match-case-align@391..400

--- a/tests/snapshots/match_case_align/or_pattern.input.py.snap
+++ b/tests/snapshots/match_case_align/or_pattern.input.py.snap
@@ -1,16 +1,17 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+assertion_line: 28
+expression: output
 input_file: tests/fixtures/match_case_align/or_pattern.input.py
 ---
 """
 Arms with `case A | B` pattern alternations. The third arm's
 pattern is wide enough to break the greedy split-policy run,
-falling into its own singleton sub-group whose colon hugs.
-The first two align against each other at the narrower column.
+falling into its own singleton sub-group. As the strictly widest
+arm, it anchors the other two so all `:`s share one column.
 """
 
 match status:
-    case "ok" | "pass" : result = True
-    case "warn"        : result = True
-    case "fail" | "error" | "panic": result = False
+    case "ok" | "pass"              : result = True
+    case "warn"                     : result = True
+    case "fail" | "error" | "panic" : result = False


### PR DESCRIPTION
### 🪻 Quick Summary

Fixes an off-by-one in `align_colons` where the widest member of a class-field block landed one column to the right of its narrower siblings. In `emit_split`, the greedy partition isolated the widest member as its own singleton sub-group, and with strip-to-zero set, the singleton's gap collapsed while the remaining sub-group padded up to its own smaller `max_w`, leaving the singleton's `:` one column to the right of everyone else's. The fix detects when a singleton's width is strictly the widest member overall and anchors every sub-group at `singleton.width + 1`, so all four `:`s share one column.

---

### 🗞️ Key Changes

- Rewrites `emit_split` to anchor every sub-group at the widest singleton, extracting `partition_by_spread` and `widest_singleton_anchor_width` helpers

- Adds inline tests pinning the wide-singleton anchor case and the tied-max-width skip

- Reshapes the existing strip test to narrow-singleton widths so it still pins strip-to-zero

- Regenerates the `class_field_block`, `shift_limit_split`, and `or_pattern` snapshots so each fixture's `:`s share one column

- Updates the `shift_limit_split` and `or_pattern` fixture docstrings to describe the new anchor behavior

- Adds `multi_subgroup_alignment` fixture pinning split-policy without the wide-singleton anchor override

- Adds `narrow_singleton_strip` fixture pinning strip-to-zero on a narrow singleton between wider sub-groups

---

### 🧵 Related Issues

- Closes #100