### PR TITLE
[101] Compose `align_equals` against `align_colons` columns in typed signatures

### DIFF
--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -6,7 +6,7 @@
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::token::{Token, TokenKind};
-use ruff_python_ast::Stmt;
+use ruff_python_ast::{AnyParameterRef, Parameters, Stmt};
 use ruff_python_trivia::PythonWhitespace;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -192,6 +192,22 @@ pub(crate) fn line_anchored_member_at_kind(
 ) -> Option<Member> {
     let anchor = source.first_token_offset_in_range(search, |t| t.kind() == kind)?;
     Some(line_anchored_member(source, anchor))
+}
+
+/// Walks `params` in source order, qualifying each parameter through
+/// `qualify` and returning one group per run of contiguous qualified
+/// parameters. A parameter that fails to qualify breaks the current
+/// run without joining either neighbor. Empty runs are filtered out.
+pub(crate) fn parameter_split_groups<F>(params: &Parameters, qualify: F) -> Vec<Vec<Member>>
+where
+    F: FnMut(AnyParameterRef<'_>) -> Option<Member>,
+{
+    let qualified: Vec<_> = params.iter_source_order().map(qualify).collect();
+    qualified
+        .split(Option::is_none)
+        .filter(|chunk| !chunk.is_empty())
+        .map(|chunk| chunk.iter().copied().flatten().collect())
+        .collect()
 }
 
 /// Builds a `Member` whose anchor is the first token in `search`

--- a/src/primitives/colon_targets.rs
+++ b/src/primitives/colon_targets.rs
@@ -257,15 +257,7 @@ fn parameter(source: &Source, param: AnyParameterRef<'_>) -> Option<aligner::Mem
 /// contiguous annotated parameters, splitting at every unannotated
 /// parameter.
 fn parameter_groups(source: &Source, params: &Parameters) -> Vec<Vec<aligner::Member>> {
-    let members: Vec<_> = params
-        .iter_source_order()
-        .map(|p| parameter(source, p))
-        .collect();
-    members
-        .split(Option::is_none)
-        .filter(|chunk| !chunk.is_empty())
-        .map(|chunk| chunk.iter().copied().flatten().collect())
-        .collect()
+    aligner::parameter_split_groups(params, |p| parameter(source, p))
 }
 
 #[cfg(test)]

--- a/src/rules/align_equals.rs
+++ b/src/rules/align_equals.rs
@@ -1,16 +1,19 @@
 //! Aligns the `=` character vertically across runs of same-indent,
 //! line-adjacent `Stmt::Assign` (single-target), `Stmt::AugAssign`,
-//! and `Stmt::AnnAssign` (with initializer) statements. Chained
-//! assignments and annotated assignments without an initializer are
+//! and `Stmt::AnnAssign` (with initializer) statements, and across
+//! runs of annotated function parameters carrying default values.
+//! Chained assignments, annotated assignments without an initializer,
+//! unannotated parameter defaults, and single-line signatures are
 //! skipped. Lone rows and singleton sub-groups still collapse their
 //! pre-`=` whitespace to one space. `+=` rows place `+` one column
 //! before the shared `=` column rather than pushing the `=` right.
+//! Parameter widths reflect the post-`align_colons` source.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{walk_body, StatementVisitor};
+use ruff_python_ast::statement_visitor::{walk_body, walk_stmt, StatementVisitor};
 use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::Stmt;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_python_ast::{AnyParameterRef, Parameters, Stmt};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::config::Config;
 use crate::primitives::aligner;
@@ -52,9 +55,32 @@ struct Visitor<'a> {
 }
 
 impl Visitor<'_> {
+    /// Builds an `=`-anchored member with `target` as the LHS span and
+    /// the search range running from `target.end()` to `value_start`.
+    fn equal_member(&self, target: TextRange, value_start: TextSize) -> Option<aligner::Member> {
+        aligner::range_anchored_member_single_line(
+            self.source,
+            target,
+            TextRange::new(target.end(), value_start),
+            |t| t.kind() == TokenKind::Equal,
+            0,
+        )
+    }
+
     fn process_body(&mut self, body: &[Stmt]) {
         for members in aligner::line_adjacent_groups(self.source, body, |s| self.qualify(s)) {
             aligner::emit_group(self.source, &members, self.settings, &mut self.edits);
+        }
+    }
+
+    /// Walks `params` through [`aligner::parameter_split_groups`] with
+    /// [`Self::qualify_parameter`], emitting an alignment pass for
+    /// each sub-group that clears [`aligner::is_alignment_candidate`].
+    fn process_parameters(&mut self, params: &Parameters) {
+        for members in aligner::parameter_split_groups(params, |p| self.qualify_parameter(p)) {
+            if aligner::is_alignment_candidate(&members) {
+                aligner::emit_group(self.source, &members, self.settings, &mut self.edits);
+            }
         }
     }
 
@@ -67,40 +93,25 @@ impl Visitor<'_> {
     /// the display-column distance from `target.start()` to the `=`
     /// character, and the `gap` is the whitespace the rule may rewrite.
     /// Returns `None` when the region between `target.start()` and the
-    /// `=` contains a line break, since rewriting across a continuation
-    /// would flatten the author's multi-line layout.
+    /// `=` contains a line break.
     fn qualify(&self, stmt: &Stmt) -> Option<aligner::Member> {
         match stmt {
             Stmt::AnnAssign(a) => {
                 let value = a.value.as_deref()?;
-                let annotation_range = a.annotation.range();
-                aligner::range_anchored_member_single_line(
-                    self.source,
-                    a.target.range().cover(annotation_range),
-                    TextRange::new(annotation_range.end(), value.range().start()),
-                    |t| t.kind() == TokenKind::Equal,
-                    0,
-                )
+                self.equal_member(a.target.range().cover(a.annotation.range()), value.start())
             }
             Stmt::Assign(a) => {
                 let [target] = a.targets.as_slice() else {
                     return None;
                 };
-                let target_range = target.range();
-                aligner::range_anchored_member_single_line(
-                    self.source,
-                    target_range,
-                    TextRange::new(target_range.end(), a.value.range().start()),
-                    |t| t.kind() == TokenKind::Equal,
-                    0,
-                )
+                self.equal_member(target.range(), a.value.start())
             }
             Stmt::AugAssign(a) => {
                 let target_range = a.target.range();
                 aligner::range_anchored_member_single_line(
                     self.source,
                     target_range,
-                    TextRange::new(target_range.end(), a.value.range().start()),
+                    TextRange::new(target_range.end(), a.value.start()),
                     |t| t.kind().as_augmented_assign_operator().is_some(),
                     a.op.as_str().len(),
                 )
@@ -108,11 +119,31 @@ impl Visitor<'_> {
             _ => None,
         }
     }
+
+    /// Returns the alignment member for an annotated function parameter
+    /// carrying a default value, or `None` for any other shape. Width
+    /// spans the parameter name through the annotation end, and the
+    /// gap is the whitespace between annotation end and the `=` token.
+    fn qualify_parameter(&self, param: AnyParameterRef<'_>) -> Option<aligner::Member> {
+        let annotation = param.annotation()?;
+        let default = param.default()?;
+        self.equal_member(
+            TextRange::new(param.name().start(), annotation.end()),
+            default.start(),
+        )
+    }
 }
 
 impl<'a> StatementVisitor<'a> for Visitor<'a> {
     fn visit_body(&mut self, body: &'a [Stmt]) {
         self.process_body(body);
         walk_body(self, body);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if let Stmt::FunctionDef(fd) = stmt {
+            self.process_parameters(&fd.parameters);
+        }
+        walk_stmt(self, stmt);
     }
 }

--- a/tests/fixtures/align_equals/multi_line_annotation.input.py
+++ b/tests/fixtures/align_equals/multi_line_annotation.input.py
@@ -1,0 +1,16 @@
+"""
+A parameter whose annotation spans multiple lines breaks the
+parameter run. The surrounding parameters have widths that would
+align if grouped, but they stay unpadded as singletons.
+"""
+
+
+def configure(
+    host: str = "localhost",
+    fn: Callable[
+        [int, str],
+        bool,
+    ] = default,
+    timeout: float = 30.0,
+):
+    pass

--- a/tests/fixtures/align_equals/parameter_defaults.input.py
+++ b/tests/fixtures/align_equals/parameter_defaults.input.py
@@ -1,0 +1,13 @@
+"""
+Annotated parameter defaults align across a multi-line function
+signature. The `=` columns sit one space past the widest annotation
+end, with shorter rows padded between the annotation and `=`.
+"""
+
+
+def configure(
+    host: str = "localhost",
+    port: int = 8080,
+    delay: float = 0.5,
+):
+    pass

--- a/tests/fixtures/align_equals/parameter_run_split_by_no_default.input.py
+++ b/tests/fixtures/align_equals/parameter_run_split_by_no_default.input.py
@@ -1,0 +1,15 @@
+"""
+An annotated parameter without a default value splits the
+surrounding parameter run. The remaining parameters have widths
+that would align if grouped, but they stay unpadded as
+singletons.
+"""
+
+
+def f(
+    *,
+    x: int = 1,
+    flag: bool,
+    verbose: bool = True,
+):
+    pass

--- a/tests/fixtures/align_equals/post_colon_aligned_subgroups.input.py
+++ b/tests/fixtures/align_equals/post_colon_aligned_subgroups.input.py
@@ -1,0 +1,14 @@
+"""
+A typed signature already carrying `align_colons`-style padding,
+partitioned by widths exceeding `max_shift` into two sub-groups.
+`align_equals` aligns `=` within each sub-group.
+"""
+
+
+def configure(
+    host : str = "localhost",
+    port : int = 8080,
+    timeout_seconds : float = 30.0,
+    retries         : int = 3,
+):
+    pass

--- a/tests/fixtures/align_equals/single_line_typed_signature.input.py
+++ b/tests/fixtures/align_equals/single_line_typed_signature.input.py
@@ -1,0 +1,7 @@
+"""
+A single-line typed signature passes through `align_equals`
+unchanged.
+"""
+
+
+def f(a: int = 1, bee: int = 2): pass

--- a/tests/fixtures/align_equals/unannotated_parameter_defaults.input.py
+++ b/tests/fixtures/align_equals/unannotated_parameter_defaults.input.py
@@ -1,0 +1,13 @@
+"""
+An unannotated parameter splits the parameter run. The
+surrounding annotated parameters have widths that would align if
+grouped, but they stay unpadded as singletons.
+"""
+
+
+def f(
+    x: int = 1,
+    unannotated=2,
+    verbose: bool = True,
+):
+    pass

--- a/tests/snapshots/align_equals/multi_line_annotation.diagnostics.snap
+++ b/tests/snapshots/align_equals/multi_line_annotation.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/multi_line_annotation.input.py
+---
+

--- a/tests/snapshots/align_equals/multi_line_annotation.input.py.snap
+++ b/tests/snapshots/align_equals/multi_line_annotation.input.py.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_equals/multi_line_annotation.input.py
+---
+"""
+A parameter whose annotation spans multiple lines breaks the
+parameter run. The surrounding parameters have widths that would
+align if grouped, but they stay unpadded as singletons.
+"""
+
+
+def configure(
+    host: str = "localhost",
+    fn: Callable[
+        [int, str],
+        bool,
+    ] = default,
+    timeout: float = 30.0,
+):
+    pass

--- a/tests/snapshots/align_equals/parameter_defaults.diagnostics.snap
+++ b/tests/snapshots/align_equals/parameter_defaults.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/parameter_defaults.input.py
+---
+align-equals@232..233
+align-equals@261..262

--- a/tests/snapshots/align_equals/parameter_defaults.input.py.snap
+++ b/tests/snapshots/align_equals/parameter_defaults.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_equals/parameter_defaults.input.py
+---
+"""
+Annotated parameter defaults align across a multi-line function
+signature. The `=` columns sit one space past the widest annotation
+end, with shorter rows padded between the annotation and `=`.
+"""
+
+
+def configure(
+    host: str    = "localhost",
+    port: int    = 8080,
+    delay: float = 0.5,
+):
+    pass

--- a/tests/snapshots/align_equals/parameter_run_split_by_no_default.diagnostics.snap
+++ b/tests/snapshots/align_equals/parameter_run_split_by_no_default.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/parameter_run_split_by_no_default.input.py
+---
+

--- a/tests/snapshots/align_equals/parameter_run_split_by_no_default.input.py.snap
+++ b/tests/snapshots/align_equals/parameter_run_split_by_no_default.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_equals/parameter_run_split_by_no_default.input.py
+---
+"""
+An annotated parameter without a default value splits the
+surrounding parameter run. The remaining parameters have widths
+that would align if grouped, but they stay unpadded as
+singletons.
+"""
+
+
+def f(
+    *,
+    x: int = 1,
+    flag: bool,
+    verbose: bool = True,
+):
+    pass

--- a/tests/snapshots/align_equals/post_colon_aligned_subgroups.diagnostics.snap
+++ b/tests/snapshots/align_equals/post_colon_aligned_subgroups.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/post_colon_aligned_subgroups.input.py
+---
+align-equals@318..319

--- a/tests/snapshots/align_equals/post_colon_aligned_subgroups.input.py.snap
+++ b/tests/snapshots/align_equals/post_colon_aligned_subgroups.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_equals/post_colon_aligned_subgroups.input.py
+---
+"""
+A typed signature already carrying `align_colons`-style padding,
+partitioned by widths exceeding `max_shift` into two sub-groups.
+`align_equals` aligns `=` within each sub-group.
+"""
+
+
+def configure(
+    host : str = "localhost",
+    port : int = 8080,
+    timeout_seconds : float = 30.0,
+    retries         : int   = 3,
+):
+    pass

--- a/tests/snapshots/align_equals/single_line_typed_signature.diagnostics.snap
+++ b/tests/snapshots/align_equals/single_line_typed_signature.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/single_line_typed_signature.input.py
+---
+

--- a/tests/snapshots/align_equals/single_line_typed_signature.input.py.snap
+++ b/tests/snapshots/align_equals/single_line_typed_signature.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_equals/single_line_typed_signature.input.py
+---
+"""
+A single-line typed signature passes through `align_equals`
+unchanged.
+"""
+
+
+def f(a: int = 1, bee: int = 2): pass

--- a/tests/snapshots/align_equals/unannotated_parameter_defaults.diagnostics.snap
+++ b/tests/snapshots/align_equals/unannotated_parameter_defaults.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/unannotated_parameter_defaults.input.py
+---
+

--- a/tests/snapshots/align_equals/unannotated_parameter_defaults.input.py.snap
+++ b/tests/snapshots/align_equals/unannotated_parameter_defaults.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_equals/unannotated_parameter_defaults.input.py
+---
+"""
+An unannotated parameter splits the parameter run. The
+surrounding annotated parameters have widths that would align if
+grouped, but they stay unpadded as singletons.
+"""
+
+
+def f(
+    x: int = 1,
+    unannotated=2,
+    verbose: bool = True,
+):
+    pass

--- a/tests/snapshots/composition/typed_func_args.diagnostics.snap
+++ b/tests/snapshots/composition/typed_func_args.diagnostics.snap
@@ -7,3 +7,4 @@ align-colons@239..239
 align-colons@268..268
 align-colons@301..301
 align-colons@328..328
+align-equals@345..346

--- a/tests/snapshots/composition/typed_func_args.input.py.snap
+++ b/tests/snapshots/composition/typed_func_args.input.py.snap
@@ -18,6 +18,6 @@ def configure(
     host : str = "localhost",
     port : int = 8080,
     timeout_seconds : float = 30.0,
-    retries         : int = 3,
+    retries         : int   = 3,
 ):
     return (host, port, timeout_seconds, retries)


### PR DESCRIPTION
### 🪻 Quick Summary

Composes `align_equals` against `align_colons` so the `=` columns align across whichever sub-group `align_colons` settled on. The pipeline already runs `align_colons` before `align_equals` with a reparse between them, so widths in `align_equals` are measured against the post-colon-aligned source. The default `Split` policy then partitions parameter members into the same sub-groups `align_colons` produced, and `=` aligns within each sub-group with a one-space buffer past the widest annotation end. The `composition/typed_func_args` snapshot regenerates so `retries` gains two spaces between `int` and `=` to match `timeout_seconds`, while the `[host, port]` sub-group already aligned because both have width 10 post-colon-alignment.

---

### 🗞️ Key Changes

- Extends `align_equals` to walk function parameters through `process_parameters` and `qualify_parameter`, emitting `=` alignment per sub-group via `aligner::emit_group` under the default `Split` policy. Annotated parameters with defaults qualify, while unannotated, default-less, and multi-line-annotation parameters break the run

- Extracts `aligner::parameter_split_groups` as a shared source-order primitive consumed by both `colon_targets::parameter_groups` and the new `align_equals` walker, with each call site providing its own qualifier closure

- Extracts an `equal_member` helper inside `align_equals` collapsing the three `=`-anchored arms in `qualify` (for `Stmt::AnnAssign` and `Stmt::Assign`) and `qualify_parameter` to a single call site, leaving `Stmt::AugAssign` inline because its predicate and extra-width differ

- Regenerates the `composition/typed_func_args` snapshot, padding `retries` with two spaces between `int` and `=` to match the `: float =` column of `timeout_seconds`

- Adds `parameter_defaults` and `post_colon_aligned_subgroups` fixtures under `tests/fixtures/align_equals/` pinning `=` alignment across multi-line typed defaults, the former for a single sub-group and the latter for the `Split` partition into two sub-groups

- Adds four skip-pinning fixtures (`single_line_typed_signature`, `unannotated_parameter_defaults`, `parameter_run_split_by_no_default`, `multi_line_annotation`) covering each branch where `align_equals` deliberately emits nothing, mirroring the existing statement-level skip fixtures `chained`, `continuation_before_equals`, and `multi_line_target`

---

### ☕ Implementation Notes

`process_parameters` guards each sub-group through `aligner::is_alignment_candidate` before emitting, whereas `process_body` does not. Statement groups pass through `aligner::line_adjacent_groups`, which rejects same-line members at the grouping stage, so the candidate check is redundant there. Parameter groups go through `aligner::parameter_split_groups`, which splits only on qualifier failure, so the guard catches single-line typed signatures that would otherwise reach `emit_group` and distort the compact line.

---

### 🧵 Related Issues

- Closes #101