### PR TITLE
[97] Add line-budget gate to `match_case_align` collapse path

### DIFF
--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -62,9 +62,10 @@ impl From<&AlignmentConfig> for Settings {
 }
 
 /// Aligns the members of a group, dispatching through `settings.policy`
-/// when the widest padding exceeds `settings.max_shift`. A `Split`
-/// sub-group of size one collapses its gap to one space, or to zero
-/// when `settings.strip_singleton_subgroup` is set.
+/// when the widest padding exceeds `settings.max_shift`. A singleton
+/// group collapses its gap to one space, or to zero when
+/// `settings.strip_singleton_subgroup` is set, matching the
+/// singleton-from-split treatment in `emit_split`.
 pub(crate) fn emit_group(
     source: &Source,
     members: &[Member],
@@ -80,7 +81,12 @@ pub(crate) fn emit_group(
             (mn.min(m.width), mx.max(m.width))
         });
     if max_w - min_w <= settings.max_shift {
-        emit_with_paddings(source, members, max_w, 1, edits);
+        let suffix = if members.len() == 1 && settings.strip_singleton_subgroup {
+            0
+        } else {
+            1
+        };
+        emit_with_paddings(source, members, max_w, suffix, edits);
         return;
     }
     match settings.policy {

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -16,3 +16,6 @@ pub(crate) mod colon_targets;
 pub(crate) mod docstring;
 pub(crate) mod edit;
 pub(crate) mod orderer;
+
+/// PEP 8 indent step in spaces, the depth one nested level adds.
+pub(crate) const INDENT_STEP: usize = 4;

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -15,11 +15,9 @@ use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
-use crate::primitives::edit::narrowed_replacement;
+use crate::primitives::{edit::narrowed_replacement, INDENT_STEP};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
-
-const INDENT_STEP: usize = 4;
 
 pub(crate) struct CollectionLayout {
     code_line_length: usize,

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -1,31 +1,37 @@
-//! Collapses each arm of a `match` statement to one source line of
-//! the form `case PATTERN : EXPR` and aligns the `:` column across
-//! arms whose body is a single collapsible statement on a single
-//! source line. A disqualifying arm (multi-statement body,
-//! compound-statement body, multi-line body, or a comment between
-//! the `:` and the body) breaks alignment into sub-groups on either
-//! side. Each sub-group runs the configured `Split` / `Drop` / `Skip`
-//! policy independently. Singleton sub-groups collapse without
-//! pre-colon padding. Nested matches recurse.
+//! Collapses each `match` arm to a one-line `case PATTERN : EXPR`
+//! and aligns the `:` column across arms whose body is a single
+//! collapsible statement on one source line. A disqualifying arm
+//! (multi-statement body, compound-statement body, multi-line body,
+//! or a comment between the `:` and the body) breaks alignment into
+//! sub-groups on either side. An arm whose collapsed form would
+//! exceed `Config::code_line_length` also disqualifies, and any
+//! such arm that sits on one source line splits so the body lands
+//! on the next line. Nested matches recurse.
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_compound_statement;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::{MatchCase, Stmt, StmtMatch};
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
-use crate::primitives::{aligner, colon_targets};
+use crate::primitives::{aligner, colon_targets, INDENT_STEP};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 pub(crate) struct MatchCaseAlign {
+    code_line_length: usize,
     settings: aligner::Settings,
 }
 
 impl MatchCaseAlign {
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
+            code_line_length: config
+                .code_line_length
+                .expect("Config::default synthesizes Some(88)")
+                .get(),
             settings: aligner::Settings::from(&config.rules.match_case_align)
                 .with_singleton_subgroup_strip(),
         }
@@ -35,6 +41,7 @@ impl MatchCaseAlign {
 impl Rule for MatchCaseAlign {
     fn apply(&self, source: &Source) -> Vec<Edit> {
         let mut visitor = Visitor {
+            code_line_length: self.code_line_length,
             edits: Vec::new(),
             settings: self.settings,
             source,
@@ -48,7 +55,18 @@ impl Rule for MatchCaseAlign {
     }
 }
 
+/// Outcome of qualifying one `case` arm. `Align` enrolls the arm in
+/// the active alignment sub-group. `Disqualify` breaks the sub-group
+/// without emitting an edit. `Split` breaks the sub-group and emits
+/// an edit pushing the body onto the next source line.
+enum CaseOutcome {
+    Align(aligner::Member, TextRange),
+    Disqualify,
+    Split(Edit),
+}
+
 struct Visitor<'a> {
+    code_line_length: usize,
     edits: Vec<Edit>,
     settings: aligner::Settings,
     source: &'a Source,
@@ -58,9 +76,7 @@ impl Visitor<'_> {
     /// Emits alignment and collapse edits for a sub-group and drains it.
     fn flush_subgroup(&mut self, group: &mut Vec<(aligner::Member, TextRange)>) {
         let (members, ranges): (Vec<aligner::Member>, Vec<TextRange>) = group.drain(..).unzip();
-        if aligner::is_alignment_candidate(&members) {
-            aligner::emit_group(self.source, &members, self.settings, &mut self.edits);
-        }
+        aligner::emit_group(self.source, &members, self.settings, &mut self.edits);
         self.edits.extend(
             ranges
                 .into_iter()
@@ -68,37 +84,75 @@ impl Visitor<'_> {
         );
     }
 
-    /// Emits collapse-and-align edits for one match. Sub-groups
-    /// form at disqualifying-arm boundaries. Each multi-member
-    /// sub-group runs through `aligner::emit_group`, and every
-    /// qualifying arm gets a collapse edit. Singleton sub-groups
-    /// skip alignment.
+    /// Returns `Disqualify` when the `:`-to-body gap already carries
+    /// a line break, otherwise `Split` carrying an edit that pushes
+    /// the body onto the next source line.
+    fn over_budget_outcome(&self, case: &MatchCase, collapse_range: TextRange) -> CaseOutcome {
+        if self.source.contains_line_break(collapse_range) {
+            return CaseOutcome::Disqualify;
+        }
+        let body_indent = self.source.line_indent_width(case.start()) + INDENT_STEP;
+        let replacement = format!("{}{}", self.source.newline_str(), " ".repeat(body_indent));
+        CaseOutcome::Split(Edit::range_replacement(replacement, collapse_range))
+    }
+
+    /// Returns `true` when the canonical
+    /// `[indent]case PATTERN[ if GUARD] : BODY` form for `case` would
+    /// exceed `code_line_length`.
+    fn overflows_budget(&self, case: &MatchCase, body_first: &Stmt) -> bool {
+        let pre_colon_end = case
+            .guard
+            .as_deref()
+            .map_or(case.pattern.end(), Ranged::end);
+        let lhs_width = self
+            .source
+            .slice(TextRange::new(case.start(), pre_colon_end))
+            .width();
+        let body_width = self.source.slice(body_first.range()).width();
+        self.source.column_of(case.start()) + lhs_width + 3 + body_width > self.code_line_length
+    }
+
+    /// Emits collapse-and-align edits for one match by walking each
+    /// case through `qualify_case` and dispatching on its outcome.
     fn process_match(&mut self, m: &StmtMatch) {
         let mut current: Vec<(aligner::Member, TextRange)> = Vec::new();
         for case in &m.cases {
             match self.qualify_case(case) {
-                Some(target) => current.push(target),
-                None => self.flush_subgroup(&mut current),
+                CaseOutcome::Align(member, range) => current.push((member, range)),
+                CaseOutcome::Disqualify => self.flush_subgroup(&mut current),
+                CaseOutcome::Split(edit) => {
+                    self.flush_subgroup(&mut current);
+                    self.edits.push(edit);
+                }
             }
         }
         self.flush_subgroup(&mut current);
     }
 
-    /// Returns the alignment member and the post-colon collapse
-    /// range for a qualifying arm, or `None` when the arm
-    /// disqualifies. The collapse range covers the whitespace span
-    /// between the `:` and the body's first statement.
-    fn qualify_case(&self, case: &MatchCase) -> Option<(aligner::Member, TextRange)> {
+    /// Classifies one arm into the matching `CaseOutcome` variant.
+    /// Disqualifies on multi-statement, compound, or multi-line
+    /// bodies and on a comment in the `:`-to-body gap; defers to
+    /// `over_budget_outcome` when the arm would overflow the
+    /// line-length budget collapsed.
+    fn qualify_case(&self, case: &MatchCase) -> CaseOutcome {
         let [body_first] = case.body.as_slice() else {
-            return None;
+            return CaseOutcome::Disqualify;
         };
         if is_compound_statement(body_first) || self.source.contains_line_break(body_first) {
-            return None;
+            return CaseOutcome::Disqualify;
         }
-        let member = colon_targets::match_case(self.source, case)?;
+        let Some(member) = colon_targets::match_case(self.source, case) else {
+            return CaseOutcome::Disqualify;
+        };
         let collapse_range =
             TextRange::new(member.gap.end() + TextSize::from(1u32), body_first.start());
-        (!self.source.intersects_comment(collapse_range)).then_some((member, collapse_range))
+        if self.source.intersects_comment(collapse_range) {
+            return CaseOutcome::Disqualify;
+        }
+        if self.overflows_budget(case, body_first) {
+            return self.over_budget_outcome(case, collapse_range);
+        }
+        CaseOutcome::Align(member, collapse_range)
     }
 }
 

--- a/tests/fixtures/match_case_align/budget_gate.input.py
+++ b/tests/fixtures/match_case_align/budget_gate.input.py
@@ -1,0 +1,24 @@
+"""
+Five arms multi-line in source:
+
+- arm 1 fits comfortably under the 88-char budget and collapses
+- arm 2 sits at exactly 88 columns collapsed and also collapses
+- arm 3 lands at 89 columns (one over) and stays multi-line
+- arm 4 lands well past the budget and stays multi-line
+- arm 5's `if` guard pushes the collapsed form past the budget,
+  pinning that the gate measures the guard width alongside the
+  pattern width
+"""
+
+def dispatch(event):
+    match event.kind:
+        case "under_88_columns":
+            counter = 1
+        case "exactly_88_columns":
+            counter = build(event.timestamp, event.src, event.k)
+        case "longer_pattern_name":
+            counter = build(event.timestamp, event.src, event.k)
+        case "kind_with_descriptive_long_label":
+            counter = build_for_long_kind(event.timestamp, event.source, event.kind)
+        case "key" if some_long_predicate_check(event.kind):
+            counter = compute(event.src)

--- a/tests/fixtures/thematic/match_dispatch.input.py
+++ b/tests/fixtures/thematic/match_dispatch.input.py
@@ -1,9 +1,10 @@
 """
 Cross-rule composition over a match statement: match_case_align
-collapses single-statement arms onto their pattern lines, alphabetize
-sorts the kwargs inside the dispatched calls, strip_trailing_commas
-removes the dangling commas the source carries, and the singleton
-rule strips the lone-key dict's pre-`:` padding. The full pipeline
+splits the three arms whose collapsed form would exceed 88 columns
+and collapses the under-budget fallback arm, alphabetize sorts the
+kwargs inside the dispatched calls, strip_trailing_commas removes
+the dangling commas the source carries, and the singleton rule
+strips the lone-key dict's pre-`:` padding. The full pipeline
 running twice produces no further change.
 """
 

--- a/tests/snapshots/match_case_align/budget_gate.diagnostics.snap
+++ b/tests/snapshots/match_case_align/budget_gate.diagnostics.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostics.rs
+assertion_line: 39
+expression: render(&diagnostics)
+input_file: tests/fixtures/match_case_align/budget_gate.input.py
+---
+match-case-align@503..503
+match-case-align@504..517
+match-case-align@562..562
+match-case-align@563..576

--- a/tests/snapshots/match_case_align/budget_gate.input.py.snap
+++ b/tests/snapshots/match_case_align/budget_gate.input.py.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration.rs
+assertion_line: 28
+expression: output
+input_file: tests/fixtures/match_case_align/budget_gate.input.py
+---
+"""
+Five arms multi-line in source:
+
+- arm 1 fits comfortably under the 88-char budget and collapses
+- arm 2 sits at exactly 88 columns collapsed and also collapses
+- arm 3 lands at 89 columns (one over) and stays multi-line
+- arm 4 lands well past the budget and stays multi-line
+- arm 5's `if` guard pushes the collapsed form past the budget,
+  pinning that the gate measures the guard width alongside the
+  pattern width
+"""
+
+def dispatch(event):
+    match event.kind:
+        case "under_88_columns"   : counter = 1
+        case "exactly_88_columns" : counter = build(event.timestamp, event.src, event.k)
+        case "longer_pattern_name":
+            counter = build(event.timestamp, event.src, event.k)
+        case "kind_with_descriptive_long_label":
+            counter = build_for_long_kind(event.timestamp, event.source, event.kind)
+        case "key" if some_long_predicate_check(event.kind):
+            counter = compute(event.src)

--- a/tests/snapshots/thematic/match_dispatch.diagnostics.snap
+++ b/tests/snapshots/thematic/match_dispatch.diagnostics.snap
@@ -1,16 +1,17 @@
 ---
 source: tests/diagnostics.rs
+assertion_line: 39
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/match_dispatch.input.py
 ---
-alphabetize@467..706
-blank-lines@384..386
-docstring-wrap@67..339
-loose-constants@750..793
-match-case-align@451..451
-match-case-align@544..544
-match-case-align@637..637
-match-case-align@723..729
-singleton-rule@783..784
-strip-trailing-commas@786..787
-strip-trailing-commas@833..834
+alphabetize@521..760
+blank-lines@438..440
+docstring-wrap@67..393
+loose-constants@829..872
+match-case-align@506..507
+match-case-align@599..600
+match-case-align@692..693
+match-case-align@777..783
+singleton-rule@862..863
+strip-trailing-commas@840..841
+strip-trailing-commas@887..888

--- a/tests/snapshots/thematic/match_dispatch.input.py.snap
+++ b/tests/snapshots/thematic/match_dispatch.input.py.snap
@@ -1,23 +1,28 @@
 ---
 source: tests/integration.rs
+assertion_line: 28
 expression: output
 input_file: tests/fixtures/thematic/match_dispatch.input.py
 ---
 """
-Cross-rule composition over a match statement: match_case_align collapses
-single-statement arms onto their pattern lines, alphabetize sorts the kwargs
-inside the dispatched calls, strip_trailing_commas removes the dangling
-commas the source carries, and the singleton rule strips the lone-key dict's
-pre-`:` padding. The full pipeline running twice produces no further change.
+Cross-rule composition over a match statement: match_case_align splits
+the three arms whose collapsed form would exceed 88 columns and collapses
+the under-budget fallback arm, alphabetize sorts the kwargs inside the
+dispatched calls, strip_trailing_commas removes the dangling commas the
+source carries, and the singleton rule strips the lone-key dict's pre-`:`
+padding. The full pipeline running twice produces no further change.
 """
 
 
 def dispatch(event):
     match event.kind:
-        case "create" : return Counter(action="create", source=event.src, timestamp=event.ts)
-        case "update" : return Counter(action="update", source=event.src, timestamp=event.ts)
-        case "delete" : return Counter(action="delete", source=event.src, timestamp=event.ts)
-        case _        : return None
+        case "create":
+            return Counter(action="create", source=event.src, timestamp=event.ts)
+        case "update":
+            return Counter(action="update", source=event.src, timestamp=event.ts)
+        case "delete":
+            return Counter(action="delete", source=event.src, timestamp=event.ts)
+        case _: return None
 
 
 SETTINGS = {


### PR DESCRIPTION
### 🪻 Quick Summary

Adds a per-arm code-line-length budget check to `match_case_align`'s collapse path. `qualify_case` refuses the collapse for any arm whose canonical `[indent]case PATTERN[ if GUARD] : BODY` form would exceed `Config::code_line_length` (*default 88*), and the new `CaseOutcome::{Align, Disqualify, Split}` enum routes multi-line over-budget arms to stay multi-line while pushing single-line over-budget arms onto a fresh body line. Under-budget arms continue through the existing alignment and collapse paths unchanged.

---

### 🗞️ Key Changes

- Adds `overflows_budget` and `over_budget_outcome` to `match_case_align`, gating `qualify_case` on the per-arm canonical width that includes `case`, pattern, optional ` if GUARD`, and ` : BODY`

- Introduces the three-state `CaseOutcome` enum so `process_match` can dispatch over-budget single-line arms into a `Split` edit that rewrites the `:`-to-body gap into a newline plus the body's natural indent

- Extends `aligner::emit_group` to mirror `emit_split`'s strip-on-singleton suffix when `strip_singleton_subgroup` is set, so `case _` in `thematic/match_dispatch` no longer carries leftover pre-`:` padding from its original alignment with siblings that have since split

- Hoists `INDENT_STEP = 4` to `crate::primitives`, replacing the duplicate const in `collection_layout` so both rules now share one definition

- Adds `tests/fixtures/match_case_align/budget_gate.input.py` covering the under-budget, exactly-88, one-over, comfortably-over, and guard-pushes-over cases in five arms of one match

- Regenerates the `tests/snapshots/thematic/match_dispatch.input.py.snap` and matching `.diagnostics.snap` so the three over-budget arms each split with their `return` on a separate line

---

### 🧵 Related Issues

- Closes #97
