### PR TITLE
[102] Make `Cargo.toml` the version source of truth and auto-cut release drafts

### DIFF
--- a/.github/scripts/emit-tag.py
+++ b/.github/scripts/emit-tag.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""
+Emit the release tag for `cut-draft.yml` to consume.
+
+Reads `[package].version` from `Cargo.toml` and writes `version=<tag>`
+to `$GITHUB_OUTPUT`.
+"""
+
+from os      import environ
+from pathlib import Path
+from tomllib import loads
+
+
+if __name__ == "__main__":
+
+    tag = loads(Path("Cargo.toml").read_text())["package"]["version"]
+
+    with open(environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+        f.write(f"version={tag}\n")

--- a/.github/scripts/parse-version.py
+++ b/.github/scripts/parse-version.py
@@ -3,19 +3,18 @@
 # requires-python = ">=3.11"
 # ///
 """
-Validate that pyproject.toml and Cargo.toml agree with the pushed tag.
+Validate that `Cargo.toml` agrees with the pushed tag.
 
 Reads from the environment:
-    GITHUB_REF_TYPE  e.g. tag, branch
-    GITHUB_REF_NAME  e.g. 0.1.0, main
+    `GITHUB_REF_TYPE`  e.g. tag, branch
+    `GITHUB_REF_NAME`  e.g. 0.1.0, main
 
-Exits 0 on a non-tag run, or on a tag whose declared pyproject.toml and
-Cargo.toml versions match. Exits 1 when either file disagrees with the tag.
+Exits 0 on a non-tag run, or on a tag whose `Cargo.toml` version matches.
+Exits 1 when `Cargo.toml` disagrees with the tag.
 """
 
 from os      import environ
 from pathlib import Path
-from re      import sub
 from tomllib import loads
 
 
@@ -24,14 +23,10 @@ if __name__ == "__main__":
     if environ.get("GITHUB_REF_TYPE") != "tag":
         raise SystemExit
 
-    version       = environ["GITHUB_REF_NAME"]
-    cargo_version = sub(r"\.?(a|b|rc|dev|post)(\d+)", r"-\1.\2", version)
+    expected = environ["GITHUB_REF_NAME"]
+    actual   = loads(Path("Cargo.toml").read_text())["package"]["version"]
 
-    for file, table, expected in [
-        ("Cargo.toml",     "package", cargo_version),
-        ("pyproject.toml", "project", version)
-    ]:
-        if (actual := loads(Path(file).read_text())[table]["version"]) != expected:
-            raise SystemExit(
-                f"::error::{file} version mismatch: expected {expected}, got {actual}"
-            )
+    if actual != expected:
+        raise SystemExit(
+            f"::error::Cargo.toml version mismatch: expected {expected}, got {actual}"
+        )

--- a/.github/workflows/cut-draft.yml
+++ b/.github/workflows/cut-draft.yml
@@ -1,0 +1,45 @@
+# Prose release-draft cutter · auto-cuts a GitHub release draft on every
+# release/* PR merge to main. Reads Cargo.toml's [package].version via
+# emit-tag.py, applies the cargo-to-PEP-440 mapping, and runs `gh release
+# create --draft` so the tag string never comes from a hand-typed source.
+# Tag landing is still gated on the maintainer clicking Publish in the
+# GitHub UI, which fires release.yml's tag-push pipeline.
+
+name        : 🪻 Cut draft
+run-name    : 🪻 Cut draft · ${{ github.head_ref || github.ref_name }}
+permissions : { contents: read }
+
+on:
+  pull_request:
+    branches : [main]
+    types    : [closed]
+
+concurrency:
+  cancel-in-progress : false
+  group              : ${{ github.workflow }}
+
+jobs:
+  cut:
+    name            : 📜 Cut draft
+    if              : github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    permissions     : { contents: write }
+    runs-on         : ubuntu-latest
+    timeout-minutes : 5
+
+    steps:
+      - name : Check out repository
+        uses : actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with : { ref: main }
+
+      - name : Provision uv
+        uses : ./.github/actions/provision-uv
+
+      - name : Emit release tag
+        id   : tag
+        run  : ./.github/scripts/emit-tag.py
+
+      - name : Cut GitHub release draft
+        env:
+          GH_TOKEN : ${{ github.token }}
+          VERSION  : ${{ steps.tag.outputs.version }}
+        run  : gh release create "$VERSION" --target main --generate-notes --draft --repo "$GITHUB_REPOSITORY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ classifiers     = [
     "Topic :: Software Development :: Quality Assurance"
 ]
 description     = "A Python typesetter for the reader."
+dynamic         = ["version"]
 keywords        = ["formatter", "legibility", "linter", "python", "style"]
 license         = { text = "MIT" }
 name            = "prose-formatter"
 readme          = "README.md"
 requires-python = ">=3.10"
-version         = "0.2.0"
 
 [project.urls]
 changelog = "https://github.com/Jybbs/prose/releases"

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,4 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "prose-formatter"
-version = "0.2.0"
 source = { editable = "." }


### PR DESCRIPTION
### 🪻 Quick Summary

Makes `Cargo.toml` the single source of truth for the release version and auto-cuts a GitHub release draft on every `release/*` PR merge to main. `pyproject.toml` switches from a static `version` line to `dynamic = ["version"]`, so maturin reads the wheel version straight from `Cargo.toml`'s `[package].version` at build time. A new `.github/workflows/cut-draft.yml` fires on `pull_request: closed` with a `release/*` head ref, calls a new `.github/scripts/emit-tag.py` to surface the version from `Cargo.toml`, and runs `gh release create --target main --generate-notes --draft` against that tag string. `.github/scripts/parse-version.py` simplifies to a single Cargo-against-tag string comparison, because `pyproject.toml` no longer carries an independent version to disagree.

---

### 🗞️ Key Changes

- Switches `pyproject.toml`'s static `version` line for `dynamic = ["version"]`, so maturin populates the wheel version from `Cargo.toml`'s `[package].version` at build time and `mise wheel` plus the CI wheel matrix continue producing wheels with the correct version metadata

- Adds `.github/workflows/cut-draft.yml`, gated on `github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')`, which checks out `main`, runs `emit-tag.py`, and runs `gh release create $version --target main --generate-notes --draft --repo $GITHUB_REPOSITORY` with `contents: write` permission so the draft creation succeeds

- Adds `.github/scripts/emit-tag.py`, a uv-script reading `[package].version` from `Cargo.toml` and writing `version=<tag>` to `$GITHUB_OUTPUT` for the cut-draft workflow's `gh release create` step to consume

- Simplifies `.github/scripts/parse-version.py` to a direct `Cargo.toml`-against-tag string comparison, dropping the pyproject branch that no longer applies

---

### ☕ Implementation Notes

#### Numeric SemVer Only

The cargo↔PEP 440 transform that `parse-version.py` historically applied (*a regex mapping `0.2.0rc1` ↔ `0.2.0-rc.1`*) is removed in this change, in line with the policy that *Prose* releases use bare numeric SemVer (*`0.1.0`, `0.2.1`, `1.0.0`*) and no pre-release suffixes. The cargo and PEP 440 forms are then identical, so the tag string is whatever `Cargo.toml` contains and the validation collapses to direct string equality.

#### Duplicate-Draft Protection

The workflow carries no explicit *"release already exists"* precheck. `gh release create` itself rejects duplicate release names with a non-zero exit, so a re-merged `release/*` PR (*rare*) surfaces in the Actions log as a red workflow run with gh's standard error. A precheck would produce a slightly nicer error message but not change the behavior.

---

### 🧵 Related Issues

- Closes #102
