### PR TITLE
[103] Finalize `0.2.1` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.82"
-version      = "0.2.0"
+version      = "0.2.1"
 
 [dependencies]
 annotate-snippets  = "=0.12.13"


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes *Prose* `0.2.1` as the first patch release on the `0.2` line. Bumps `Cargo.toml` from `0.2.0` to `0.2.1` and regenerates `Cargo.lock` against the new version. Patch content covers five rule fixes (*#97 `match_case_align` line-budget gate, #98 import-kind blank line, #99 multi-line-RHS group break, #100 widest-singleton anchor, #101 typed-signature `=`-composition*) and two release-plumbing items (*#96 release-notes categories, #102 Cargo-sourced tag*). The PyPI development-status classifier stays at `3 - Alpha` for the `0.2.x` line, moving to `4 - Beta` once `0.3.0` ships.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` from `0.2.0` to `0.2.1` and regenerates `Cargo.lock` against the new version

- Leaves `pyproject.toml` alone, whose `version` field has been `dynamic` since #102 and inherits from `Cargo.toml`

---

### ☕ Implementation Notes

#### Auto-Cut Release Draft

This is the first release where #102's `cut-draft.yml` workflow fires. On squash-merge to `main`, the workflow checks out the post-merge `main` SHA, runs `emit-tag.py` against `Cargo.toml`'s `[package].version` (*now `0.2.1`*), and calls `gh release create 0.2.1 --target main --generate-notes --draft`. The maintainer's only contact with the version string is the `Cargo.toml` bump above. The `0.2.1` tag attaches when the draft is published.

---

### 🧵 Related Issues

- Closes #103