### PR TITLE
[112] Extend `warm.yml` and slim `ci.yml` to PR runs

### DIFF
--- a/.github/actions/provision-cargo/action.yml
+++ b/.github/actions/provision-cargo/action.yml
@@ -1,10 +1,10 @@
 name        : Provision the cargo toolchain with a warm build cache
-description : Install mise tools, which provisions the Rust toolchain pinned in `mise.toml`, and restore the Swatinem cargo cache for the given `shared-key`. Cache write-back is gated by `save-cache` so PR runs read but do not pollute caches.
+description : Install mise tools, which provisions the Rust toolchain pinned in `mise.toml`, and restore the Swatinem cargo cache for the given `shared-key`. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
 
 inputs:
-  save-cache:
-    default     : 'false'
-    description : When `'true'` the mise and Cargo caches write back to GHA. Set to `'true'` only on main-branch runs.
+  cache:
+    default     : true
+    description : When `false` the Swatinem cargo cache step is skipped and the mise toolchain cache is not written back. Use for cells (*`Format`, `Unused`*) that populate neither `target/` nor `~/.cargo/registry/`.
     required    : false
 
   shared-key:
@@ -20,11 +20,11 @@ runs:
       uses : jdx/mise-action@1648a7812b9aeae629881980618f079932869151
       with:
         cache      : true
-        cache_save : ${{ inputs.save-cache }}
+        cache_save : ${{ inputs.cache != 'false' }}
 
     - name : Restore Cargo cache
+      if   : ${{ inputs.cache != 'false' }}
       uses : Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
       with:
         cache-on-failure : 'true'
-        save-if          : ${{ inputs.save-cache }}
         shared-key       : ${{ inputs.shared-key }}

--- a/.github/scripts/summary.py
+++ b/.github/scripts/summary.py
@@ -64,13 +64,12 @@ class Summary:
         """
         Render the CI gate summary and exit with the matrix verdict.
         """
-        check = environ["CHECK"]
+        failed = environ["CHECK"] != "success"
         self._emit(
             "ci-summary.md.j2",
-            check      = check,
-            check_mark = "✅" if check == "success" else "❌"
+            check_mark = "❌" if failed else "✅"
         )
-        raise SystemExit(check != "success")
+        raise SystemExit(failed)
 
     def release(self):
         """

--- a/.github/scripts/summary.py
+++ b/.github/scripts/summary.py
@@ -7,9 +7,8 @@
 Render a Prose step summary and gate the workflow's exit code.
 
 Subcommands:
-    ci       Render the CI gate summary. Reads `CHECK`, `COVERAGE`,
-             `COVERAGE_PERCENT`, plus the GitHub-runner defaults.
-             Exits 0 only when both required jobs succeeded.
+    ci       Render the CI gate summary. Reads `CHECK` plus the
+             GitHub-runner defaults. Exits 0 when `CHECK` is success.
     release  Render the Release gate summary. Reads `BUILD`, `SDIST`,
              `VALIDATE`, `PUBLISH`, plus the GitHub-runner defaults.
              Exits 0 when every required job succeeded. `PUBLISH` is
@@ -28,11 +27,6 @@ from tomllib import loads
 class Summary:
     """
     Render a Prose CI or Release step summary and gate the workflow.
-
-    `__init__` pre-composes every URL and link that's stable for the
-    whole script invocation into `env.globals`. Per-render kwargs in
-    `ci()` and `release()` carry only what genuinely varies: gate
-    inputs, the artifacts glob, and the pre-publish-failure boolean.
     """
 
     def __init__(self):
@@ -52,13 +46,10 @@ class Summary:
         self.env.globals.update(
             codecov_url = f"https://app.codecov.io/gh/{repo}/commit/{sha}",
             commit_link = f"[`{sha[:7]}`]({base}/commit/{sha})",
-            commit_url  = f"{base}/commit/{sha}",
             is_tag      = self.is_tag,
             pypi_url    = f"https://pypi.org/project/prose-formatter/{ref}/",
             ref         = ref,
-            run_url     = f"{base}/actions/runs/{environ['GITHUB_RUN_ID']}",
-            tag_link    = f"[`{ref}`]({base}/releases/tag/{ref})",
-            tree_link   = f"[`{ref}`]({base}/tree/{ref})"
+            tag_link    = f"[`{ref}`]({base}/releases/tag/{ref})"
         )
         self.platforms = loads((here / "platforms.toml").read_text())["platforms"]
 
@@ -73,13 +64,13 @@ class Summary:
         """
         Render the CI gate summary and exit with the matrix verdict.
         """
-        status = {k.lower(): environ[k] for k in ["CHECK", "COVERAGE"]}
-        marks  = {
-            f"{k}_mark": {"success": "✅"}.get(v, "❌")
-            for k, v in status.items()
-        }
-        self._emit("ci-summary.md.j2", **status, **marks)
-        raise SystemExit(any(v != "success" for v in status.values()))
+        check = environ["CHECK"]
+        self._emit(
+            "ci-summary.md.j2",
+            check      = check,
+            check_mark = "✅" if check == "success" else "❌"
+        )
+        raise SystemExit(check != "success")
 
     def release(self):
         """

--- a/.github/scripts/templates/ci-summary.md.j2
+++ b/.github/scripts/templates/ci-summary.md.j2
@@ -1,6 +1,3 @@
-## 🪻 Prose CI
+## 🪻 Prose CI {{ check_mark }}
 
-| Stage | Result |
-|---|---|
-| [🪶 Lint, build, test]({{ commit_url }}) | {{ check_mark }} `{{ check }}` |
-| [☂️ Coverage]({{ codecov_url }}) | {{ coverage_mark }} `{{ coverage }}` |
+Run {{ commit_link }} on `{{ ref }}` {% if check == "success" %}passed{% else %}failed{% endif %}. [Coverage]({{ codecov_url }}) on **Codecov**.

--- a/.github/scripts/templates/ci-summary.md.j2
+++ b/.github/scripts/templates/ci-summary.md.j2
@@ -1,3 +1,3 @@
-## 🪻 Prose CI {{ check_mark }}
+## 🪻 Prose CI
 
-Run {{ commit_link }} on `{{ ref }}` {% if check == "success" %}passed{% else %}failed{% endif %}. [Coverage]({{ codecov_url }}) on **Codecov**.
+{{ check_mark }} Run {{ commit_link }} on `{{ ref }}`. [Coverage]({{ codecov_url }}) on **Codecov**.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,10 @@ permissions : { contents: read }
 
 on:
   pull_request:
-    paths-ignore: &doc-paths
+    paths-ignore:
       - '**.md'
       - LICENSE
       - assets/**
-
-  push:
-    branches     : [main]
-    paths-ignore : *doc-paths
 
   workflow_dispatch:
 
@@ -33,21 +29,24 @@ jobs:
 
       matrix:
         include:
-          - command    : mise run check
+          - cache      : false
+            command    : mise run check
             name       : 🪶 Format
-            shared-key : prose-fmt
-          - command    : mise run audit
+          - cache      : false
+            command    : mise run audit
             name       : 🪓 Unused
-            shared-key : prose-audit
           - command    : mise run lint
             name       : 📎 Clippy
-            shared-key : prose-build
+            shared-key : prose-clippy
           - command    : mise run build
             name       : 🗜️ Build
             shared-key : prose-build
           - command    : mise run test
             name       : ⚖️ Test
-            shared-key : prose-build
+            shared-key : prose-test
+          - command    : mise run coverage
+            name       : ☂️ Coverage
+            shared-key : prose-coverage
 
     steps:
       - name : Check out repository
@@ -56,30 +55,14 @@ jobs:
       - name : Provision cargo
         uses : ./.github/actions/provision-cargo
         with:
-          save-cache : ${{ github.event_name == 'push' }}
+          cache      : ${{ matrix.cache }}
           shared-key : ${{ matrix.shared-key }}
 
       - name : ${{ matrix.command }}
         run  : ${{ matrix.command }}
 
-  coverage:
-    name    : ☂️ Coverage
-    runs-on : ubuntu-latest
-
-    steps:
-      - name : Check out repository
-        uses : actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name : Provision cargo
-        uses : ./.github/actions/provision-cargo
-        with:
-          save-cache : ${{ github.event_name == 'push' }}
-          shared-key : prose-coverage
-
-      - name : Generate LCOV report
-        run  : mise run coverage
-
-      - name : Upload to Codecov
+      - name : Upload coverage to Codecov
+        if   : matrix.shared-key == 'prose-coverage'
         uses : codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa
         with:
           fail_ci_if_error : true
@@ -89,7 +72,7 @@ jobs:
   gate:
     name    : 🗞️ Brief
     if      : always()
-    needs   : [check, coverage]
+    needs   : check
     runs-on : ubuntu-latest
 
     steps:
@@ -101,8 +84,7 @@ jobs:
 
       - name : Summarize and gate
         env:
-          CHECK    : ${{ needs.check.result }}
-          COVERAGE : ${{ needs.coverage.result }}
-          REF      : ${{ github.head_ref || github.ref_name }}
-          SHA      : ${{ github.event.pull_request.head.sha || github.sha }}
+          CHECK : ${{ needs.check.result }}
+          REF   : ${{ github.head_ref || github.ref_name }}
+          SHA   : ${{ github.event.pull_request.head.sha || github.sha }}
         run  : ./.github/scripts/summary.py ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     name    : ${{ matrix.name }}
     runs-on : ubuntu-latest
 
+    env : { CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}" }
+
     strategy:
       fail-fast: false
 
@@ -44,7 +46,7 @@ jobs:
           - command    : mise run test
             name       : ⚖️ Test
             shared-key : prose-test
-          - command    : mise run coverage
+          - command    : mise run upload
             name       : ☂️ Coverage
             shared-key : prose-coverage
 
@@ -60,14 +62,6 @@ jobs:
 
       - name : ${{ matrix.command }}
         run  : ${{ matrix.command }}
-
-      - name : Upload coverage to Codecov
-        if   : matrix.shared-key == 'prose-coverage'
-        uses : codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa
-        with:
-          fail_ci_if_error : true
-          files            : target/lcov.info
-          token            : ${{ secrets.CODECOV_TOKEN }}
 
   gate:
     name    : 🗞️ Brief

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,3 @@
-# Prose release pipeline · tag-driven publish to PyPI via OIDC.
-#
-# Triggers on bare-semver tag push (build + publish) and packaging-relevant PRs
-# (build dry-run only). Builds wheels for Linux x86_64/aarch64, macOS
-# x86_64/aarch64, Windows x86_64, plus an sdist. Trusted publishing means
-# no API tokens are stored in repo or org secrets.
-#
-# The PyPI trusted-publisher contract must exist before the first tag push.
-# Field values, set under Account → Publishing on pypi.org, must match:
-#
-#   PyPI Project Name    prose-formatter
-#   Owner                Jybbs
-#   Repository name      prose
-#   Workflow filename    release.yml
-#   Environment name     release
-#
-# Renaming this file, the `release` environment, the repo, or the owner
-# breaks the trust relationship. Update PyPI before the next tag.
-#
-# https://docs.pypi.org/trusted-publishers/adding-a-publisher/
-
 name        : 🪻 Release
 run-name    : 🪻 Release · ${{ github.head_ref || github.ref_name }}
 permissions : { contents: read }

--- a/.github/workflows/warm.yml
+++ b/.github/workflows/warm.yml
@@ -1,12 +1,3 @@
-# Prose cache warmer · populates main-branch cache scope for wheel builds.
-#
-# Fires on main-branch pushes that touch build-relevant files, mirrors the
-# `release.yml` matrix via `platforms.toml`, runs `cargo build --release`
-# per target, and lets `provision-cargo` save into the `prose-wheel-<name>`
-# shared-key scope. Subsequent PR and tag wheel builds restore from main's
-# scope via GHA's base-branch fallback rule, turning cold matrix builds
-# into warm ones.
-
 name        : 🪻 Warm
 run-name    : 🪻 Warm · ${{ github.head_ref || github.ref_name }}
 permissions : { contents: read }
@@ -47,7 +38,48 @@ jobs:
         id   : matrix
         run  : ./.github/scripts/emit-matrix.py
 
-  warm:
+  checks:
+    name    : ${{ matrix.name }}
+    runs-on : ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          - command    : mise run lint
+            name       : 📎 Clippy
+            shared-key : prose-clippy
+          - command    : mise run build
+            name       : 🗜️ Build
+            shared-key : prose-build
+          - command    : mise run test
+            name       : ⚖️ Test
+            shared-key : prose-test
+          - command    : mise run coverage
+            name       : ☂️ Coverage
+            shared-key : prose-coverage
+
+    steps:
+      - name : Check out repository
+        uses : actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name : Provision cargo
+        uses : ./.github/actions/provision-cargo
+        with : { shared-key: "${{ matrix.shared-key }}" }
+
+      - name : ${{ matrix.command }}
+        run  : ${{ matrix.command }}
+
+      - name : Upload coverage to Codecov
+        if   : matrix.shared-key == 'prose-coverage'
+        uses : codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa
+        with:
+          fail_ci_if_error : true
+          files            : target/lcov.info
+          token            : ${{ secrets.CODECOV_TOKEN }}
+
+  wheels:
     name            : 🔥 ${{ matrix.name }}
     needs           : plan
     runs-on         : ${{ matrix.runner }}
@@ -63,9 +95,7 @@ jobs:
 
       - name : Provision cargo
         uses : ./.github/actions/provision-cargo
-        with:
-          save-cache : true
-          shared-key : prose-wheel-${{ matrix.name }}
+        with : { shared-key: "prose-wheel-${{ matrix.name }}" }
 
       - name : Build release artifacts for ${{ matrix.target }}
         run  : mise exec -- cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/warm.yml
+++ b/.github/workflows/warm.yml
@@ -42,6 +42,8 @@ jobs:
     name    : ${{ matrix.name }}
     runs-on : ubuntu-latest
 
+    env : { CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}" }
+
     strategy:
       fail-fast: false
 
@@ -56,7 +58,7 @@ jobs:
           - command    : mise run test
             name       : ⚖️ Test
             shared-key : prose-test
-          - command    : mise run coverage
+          - command    : mise run upload
             name       : ☂️ Coverage
             shared-key : prose-coverage
 
@@ -70,14 +72,6 @@ jobs:
 
       - name : ${{ matrix.command }}
         run  : ${{ matrix.command }}
-
-      - name : Upload coverage to Codecov
-        if   : matrix.shared-key == 'prose-coverage'
-        uses : codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa
-        with:
-          fail_ci_if_error : true
-          files            : target/lcov.info
-          token            : ${{ secrets.CODECOV_TOKEN }}
 
   wheels:
     name            : 🔥 ${{ matrix.name }}

--- a/mise.toml
+++ b/mise.toml
@@ -58,6 +58,12 @@ run         = "cargo insta review"
 description = "Run all tests including `insta` snapshots"
 run         = "cargo test --locked"
 
+[tasks.upload]
+depends     = ["coverage"]
+description = "Generate `target/lcov.info` and upload it to Codecov"
+tools       = { "pipx:codecov-cli" = "latest" }
+run         = "codecovcli upload-process --file target/lcov.info"
+
 [tasks.wheel]
 description = "Build the `maturin` wheel into the active virtualenv"
 run         = "maturin develop"


### PR DESCRIPTION
### 🪻 Quick Summary

Extends `warm.yml` and slims `ci.yml` so per-cell cache scopes write coherently per-PR. The shared `prose-build` key splits into `prose-clippy`, `prose-build`, `prose-test`, and `prose-coverage`, with `provision-cargo`'s `cache` input gating both the Swatinem step and mise's toolchain write-back. `ci.yml` drops the `push: branches: [main]` trigger so cache writes from main come through `warm.yml`, which gains a four-cell `checks` matrix (*Clippy/Build/Test/Coverage*) alongside the renamed `wheels` matrix.

---

### 🗞️ Key Changes

- Splits the single `prose-build` cache scope into per-cell `prose-clippy`, `prose-build`, `prose-test`, and `prose-coverage` keys, so concurrent matrix cells can save coherently without racing under one shared key

- Folds `coverage` into `ci.yml`'s `check` matrix as a sixth cell with a conditional `if: matrix.shared-key == 'prose-coverage'` Codecov upload step

- Drops the `push: branches: [main]` trigger from `ci.yml` so cache writes from main come through `warm.yml`

- Extends `warm.yml` with a four-cell `checks` matrix (*Clippy/Build/Test/Coverage*) alongside the renamed `wheels` matrix

- Collapses `provision-cargo`'s `save-cache` and cache-gate into a single `cache` input defaulting to `true`, gated by `inputs.cache != 'false'` across both the Swatinem step and mise's toolchain write-back

- Rewrites `ci-summary.md.j2` as a single-paragraph narrative and simplifies `summary.py`'s `ci()` to read `CHECK` alone

- Drops the dead env globals `commit_url`, `run_url`, and `tree_link` from `summary.py`

---

### ☕ Implementation Notes

Rationale for the spec departures (*Coverage folded into the check matrix rather than a sibling job, `provision-cargo`'s single `cache` input*) lives in [this issue comment](https://github.com/Jybbs/prose/issues/112#issuecomment-4467522086).

---

### 🧵 Related Issues

- Closes #112