### PR TITLE
[117] Fix empty `--sha` on `warm.yml`'s coverage upload

### DIFF
--- a/.github/workflows/warm.yml
+++ b/.github/workflows/warm.yml
@@ -42,7 +42,9 @@ jobs:
     name    : ${{ matrix.name }}
     runs-on : ubuntu-latest
 
-    env : { CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}" }
+    env:
+      CODECOV_TOKEN : ${{ secrets.CODECOV_TOKEN }}
+      SHA           : ${{ github.sha }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
### 🪻 Quick Summary

Fixes `🪻 Warm`'s `☂️ Coverage` cell on `main`. `mise.toml`'s `[tasks.upload]` task passes `--sha "$SHA"` to `codecovcli upload-process`, but `.github/workflows/warm.yml`'s `checks` job env block exported only `CODECOV_TOKEN`, so the first post-merge run after #112 invoked `--sha ""` and Codecov rejected the upload with `commitid: The string must be non-empty and cannot contain only whitespace`. The fix expands the env block to add `SHA: ${{ github.sha }}` alongside `CODECOV_TOKEN`, mirroring the form `.github/workflows/ci.yml`'s `check` job already uses.

---

### 🗞️ Key Changes

- Expands `.github/workflows/warm.yml`'s `checks` job env block from the inline `{ CODECOV_TOKEN: ... }` form to the multi-line shape `.github/workflows/ci.yml`'s `check` job already uses

- Adds `SHA: ${{ github.sha }}` alongside `CODECOV_TOKEN`, so `mise run upload` invokes `codecovcli upload-process --sha <head-sha>` rather than `--sha ""` and Codecov accepts the upload on `main`

---

### 🧵 Related Issues

- Closes #117