### PR TITLE
[114] Finalize `0.2.2` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.82"
-version      = "0.2.1"
+version      = "0.2.2"
 
 [dependencies]
 annotate-snippets  = "=0.12.13"


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes *Prose* `0.2.2` as the second patch release on the `0.2` line. Bumps `Cargo.toml` from `0.2.1` to `0.2.2` and regenerates `Cargo.lock` against the new version. Patch content covers three release-plumbing items (*#112 per-cell cache scopes in `.github/workflows/ci.yml` and `.github/workflows/warm.yml`, #113 `🪻 Draft` rebrand with auto-fire on `Cargo.toml` version bumps, #117 `SHA` export in `warm.yml`'s `☂️ Coverage` cell*). No rule behavior changes from `0.2.1`. The PyPI development-status classifier stays at `3 - Alpha` for the `0.2.x` line, moving to `4 - Beta` once `0.3.0` ships.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` from `0.2.1` to `0.2.2` and regenerates `Cargo.lock` against the new version

---

### 🧵 Related Issues

- Closes #114