### PR TITLE
[120] Drop orphaned `save-cache` arg from `build-wheel` action

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -32,8 +32,7 @@ runs:
     - name : Provision cargo
       uses : ./.github/actions/provision-cargo
       with:
-        save-cache : ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        shared-key : prose-wheel-${{ inputs.name }}
+        shared-key: prose-wheel-${{ inputs.name }}
 
     - name : Run maturin
       uses : PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38


### PR DESCRIPTION
### 🪻 Quick Summary

Drops the `save-cache` argument that `.github/actions/build-wheel/action.yml`'s `Provision cargo` step has been passing into `./.github/actions/provision-cargo` since #112 collapsed the composite's cache inputs into a single `cache` boolean. Every `🪻 Release` wheel cell and the `🚢 sdist` cell surfaced `Unexpected input(s) 'save-cache', valid inputs are ['cache', 'shared-key']` on `0.2.2`'s run, non-fatal (*the wheels published cleanly to PyPI*) but noisy on each release. Swatinem/rust-cache's default `save-if` already restricts saves to the default branch, so the previous main-only-save semantics carry over without an explicit gate.

---

### 🗞️ Key Changes

- Removes the `save-cache: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}` line, leaving `shared-key` as the only argument the `Provision cargo` step passes into the composite

---

### 🧵 Related Issues

- Closes #120