### PR TITLE
[122] Finalize `0.2.3` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.82"
-version      = "0.2.2"
+version      = "0.2.3"
 
 [dependencies]
 annotate-snippets  = "=0.12.13"


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes *Prose* `0.2.3` as the third patch release on the `0.2` line. Bumps `Cargo.toml` from `0.2.2` to `0.2.3` and regenerates `Cargo.lock` against the new version. Patch content covers a single release-plumbing fix (*#120 drops the orphaned `save-cache` argument from `.github/actions/build-wheel/action.yml`'s `Provision cargo` step, quieting the `Unexpected input(s) 'save-cache'` warning that surfaced on every `0.2.2` wheel and `🚢 sdist` cell*). No rule behavior changes from `0.2.2`. The PyPI development-status classifier stays at `3 - Alpha` for the `0.2.x` line, moving to `4 - Beta` once `0.3.0` ships.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` from `0.2.2` to `0.2.3` and regenerates `Cargo.lock` against the new version

---

### 🧵 Related Issues

- Closes #122