### PR TITLE
[136] Split CLI into its own release-notes group and sweep the label surface

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,10 +7,12 @@ changelog:
         - 🪉 ordering
         - 🪶 formatting
         - 🧶 lint
-        - 🪄 cli
     - title: 🐞 Bugs
       labels:
         - 🐞 bug
+    - title: 🪄 CLI
+      labels:
+        - 🪄 cli
     - title: 📰 Docs
       labels:
         - 📰 docs


### PR DESCRIPTION
### 🪻 Quick Summary

Splits the `🪄 cli` label out of `.github/release.yml`'s `✨ Features` category into a new top-level `🪄 CLI` category positioned after `🐞 Bugs`, so `0.3.0`'s release notes surface CLI work (*user-level cache #133, JSON envelope #132, suppression audit #135, CLI polish #134*) under its own heading rather than bundled with rule and engine entries. The label-surface audit alongside confirms the ten existing domain labels plus `🐞 bug` and the existing `🗝️ site` cover every `0.3.x` work area without overlap.

---

### 🗞️ Key Changes

- Adds a new top-level `🪄 CLI` category in `.github/release.yml`, positioned after `🐞 Bugs`, carrying the `🪄 cli` label alone

---

### 🧵 Related Issues

- Closes #136