### PR TITLE
[128] Wrap `Args:` / `Returns:` / `Raises:` entries at hanging post-colon column

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,43 +366,34 @@ cd prose
 mise install
 ```
 
-`mise install` provisions:
+`mise install` provisions the base toolchain:
 
 | Tool | Purpose |
 |---|---|
-| `cargo-insta` | Snapshot test review |
 | `maturin` | Rust → Python wheel builder |
 | `python` (3.14) | Python interpreter for wheel builds |
 | `rust` (stable) | Rust toolchain via rustup |
 | `uv` | Python package and venv manager |
 
-### Daily Workflow
+Additional task-scoped tools (*`cargo-insta`, `cargo-machete`, `cargo-llvm-cov`, `codecov-cli`*) install on demand when their owning task first runs, so no second provisioning step is required.
 
-Tasks are defined in `mise.toml` and discoverable via `mise tasks`:
+### Tasks
+
+Tasks live in `mise.toml`. GitHub Actions drives most of them across the CI workflows that gate every push and pull request, so what passes locally with `mise ci` mirrors what runs upstream. The same tasks are available locally for reproducing a failed CI step, accepting snapshot updates after a fixture change, or running an individual check during iteration. List them with `mise tasks`.
 
 | Command | What it does |
 |---|---|
+| `mise audit` | Detect unused dependencies via `cargo machete` |
 | `mise build` | Compile in debug mode |
 | `mise check` | Verify Rust source matches `rustfmt` without rewriting |
-| `mise ci` | Lint + test + wheel (full local sweep) |
+| `mise ci` | Full local sweep: `audit`, `check`, `lint`, `test`, `wheel` |
+| `mise coverage` | Generate an LCOV coverage report at `target/lcov.info` |
 | `mise format` | Format Rust source with `rustfmt` |
 | `mise lint` | Run `clippy` with all warnings as errors |
-| `mise review` | Interactively accept pending snapshot diffs |
+| `mise readme` | Rewrite `README.md` in place to absolute URLs for PyPI |
+| `mise review` | Interactively review pending snapshot diffs |
 | `mise test` | Run all tests including `insta` snapshots |
-| `mise wheel` | Build the wheel and install into `.venv` |
+| `mise upload` | Generate the coverage report and upload it to Codecov |
+| `mise wheel` | Build the `maturin` wheel into the active virtualenv |
 
-### Editor
-
-<details>
-<summary>VSCode</summary>
-
-Install [`rust-analyzer`](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) and [`Even Better TOML`](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml). The `rust-analyzer` extension bundles its own language server, so it works without additional global Rust installs.
-
-Suggested user settings (*apply to any Rust project*):
-
-```json
-"rust-analyzer.check.command": "clippy",
-"rust-analyzer.imports.granularity.group": "module"
-```
-
-</details>
+A common iteration flow on a rule or fixture is to edit, run `mise test`, accept any snapshot diffs with `mise review`, then run `mise ci` before pushing.

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -11,6 +11,9 @@
 //! reStructuredText markup, Sphinx directives, and Numpydoc style
 //! pass through unwrapped.
 
+use std::sync::LazyLock;
+
+use regex_lite::Regex;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::StringLiteral;
 use ruff_python_trivia::leading_indentation;
@@ -21,6 +24,9 @@ use crate::primitives::docstring::{indent_prefix, triple_quoted_body, DocstringH
 use crate::primitives::edit::narrowed_replacement;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
+
+static ENTRY_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\w[\w.]*\s*:\s+\S").expect("static pattern compiles"));
 
 const SECTIONS: &[(&str, bool)] = &[
     ("Args", true),
@@ -44,12 +50,11 @@ impl DocstringWrap {
             .docstring_line_length
             .expect("Config::default synthesizes Some(76)")
             .get();
-        let code_width = config
-            .code_line_length
-            .expect("Config::default synthesizes Some(88)")
-            .get();
         let section_width = match config.docstring_structured_policy {
-            DocstringStructuredPolicy::CodeLineLength => code_width,
+            DocstringStructuredPolicy::CodeLineLength => config
+                .code_line_length
+                .expect("Config::default synthesizes Some(88)")
+                .get(),
             DocstringStructuredPolicy::DocstringLineLength => description_width,
         };
         Self {
@@ -86,7 +91,7 @@ struct Paragraph {
 enum Region {
     Description,
     Section,
-    SectionEntry,
+    SectionEntry(usize),
 }
 
 struct Rewriter<'a> {
@@ -115,7 +120,6 @@ impl DocstringHandler for Rewriter<'_> {
 
 struct Walker<'a> {
     body_indent_chars: usize,
-    entry_hanging_col: usize,
     in_fence: bool,
     list_indent: Option<usize>,
     newline: &'a str,
@@ -185,8 +189,8 @@ impl Walker<'_> {
         }
 
         let text = trimmed.trim_end();
-        if self.region == Region::SectionEntry {
-            if self.is_entry_continuation(indent_chars, text) {
+        if let Region::SectionEntry(hanging_col) = self.region {
+            if self.is_entry_continuation(indent_chars, text, hanging_col) {
                 self.paragraph.lines.push(text.to_owned());
                 return;
             }
@@ -196,7 +200,7 @@ impl Walker<'_> {
         let prose_indent = match self.region {
             Region::Description => self.body_indent_chars,
             Region::Section => self.body_indent_chars + 4,
-            Region::SectionEntry => unreachable!("entries handled above"),
+            Region::SectionEntry(_) => unreachable!("entries handled above"),
         };
         if indent_chars > prose_indent {
             self.flush_paragraph();
@@ -220,7 +224,7 @@ impl Walker<'_> {
                 }
                 self.emit_wrapped(indent_str, indent_str, text, self.rule.section_width);
             }
-            Region::SectionEntry => unreachable!("entries handled above"),
+            Region::SectionEntry(_) => unreachable!("entries handled above"),
         }
     }
 
@@ -250,13 +254,18 @@ impl Walker<'_> {
                 self.rule.description_width,
             );
         }
-        if self.region == Region::SectionEntry {
+        if matches!(self.region, Region::SectionEntry(_)) {
             self.region = Region::Section;
         }
     }
 
-    fn is_entry_continuation(&self, indent_chars: usize, trimmed: &str) -> bool {
-        indent_chars == self.entry_hanging_col
+    fn is_entry_continuation(
+        &self,
+        indent_chars: usize,
+        trimmed: &str,
+        hanging_col: usize,
+    ) -> bool {
+        indent_chars == hanging_col
             || (indent_chars == self.body_indent_chars + 4
                 && entry_description_col(trimmed).is_none())
     }
@@ -266,21 +275,13 @@ impl Walker<'_> {
         self.paragraph.initial_indent = indent_str.to_owned();
         self.paragraph.subsequent_indent = " ".repeat(hanging_col);
         self.paragraph.lines.push(text.to_owned());
-        self.region = Region::SectionEntry;
-        self.entry_hanging_col = hanging_col;
+        self.region = Region::SectionEntry(hanging_col);
     }
 }
 
 fn entry_description_col(trimmed: &str) -> Option<usize> {
-    let mut chars = trimmed.char_indices();
-    chars.next().filter(|(_, c)| is_name_char(*c))?;
-    let (name_end, _) = chars.find(|(_, c)| !(is_name_char(*c) || *c == '.'))?;
-    let post_colon = trimmed[name_end..]
-        .trim_start_matches([' ', '\t'])
-        .strip_prefix(':')?
-        .strip_prefix([' ', '\t'])?
-        .trim_start_matches([' ', '\t']);
-    (!post_colon.is_empty()).then(|| trimmed[..trimmed.len() - post_colon.len()].chars().count())
+    let m = ENTRY_PATTERN.find(trimmed)?;
+    Some(trimmed[..m.end() - 1].chars().count())
 }
 
 fn is_list_marker(trimmed: &str) -> bool {
@@ -294,10 +295,6 @@ fn is_list_marker(trimmed: &str) -> bool {
     after_digits.len() < trimmed.len() && after_digits.starts_with(". ")
 }
 
-fn is_name_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '_'
-}
-
 fn rewrite_body(
     body: &str,
     body_indent: &str,
@@ -308,7 +305,6 @@ fn rewrite_body(
 
     let mut walker = Walker {
         body_indent_chars: body_indent.chars().count(),
-        entry_hanging_col: 0,
         in_fence: false,
         list_indent: None,
         newline,
@@ -334,8 +330,8 @@ fn rewrite_body(
 fn section_heading(trimmed: &str) -> Option<bool> {
     SECTIONS.iter().find_map(|(name, allows_entries)| {
         trimmed
-            .strip_prefix(name)
-            .is_some_and(|rest| rest.starts_with(':'))
+            .strip_prefix(name)?
+            .starts_with(':')
             .then_some(*allows_entries)
     })
 }
@@ -439,18 +435,6 @@ mod tests {
     }
 
     #[test]
-    fn section_heading_returns_entry_flag_per_section() {
-        assert_eq!(section_heading("Args:"), Some(true));
-        assert_eq!(section_heading("Attributes:"), Some(true));
-        assert_eq!(section_heading("Examples:"), Some(false));
-        assert_eq!(section_heading("Note:"), Some(false));
-        assert_eq!(section_heading("Raises:"), Some(true));
-        assert_eq!(section_heading("Returns:"), Some(true));
-        assert_eq!(section_heading("Warning:"), Some(false));
-        assert_eq!(section_heading("Yields:"), Some(true));
-    }
-
-    #[test]
     fn section_heading_matches_recognized_names_with_colon() {
         for (name, _) in SECTIONS {
             assert!(
@@ -464,6 +448,18 @@ mod tests {
         assert!(section_heading("Argz:").is_none());
         assert!(section_heading("Args").is_none());
         assert!(section_heading("Arguments:").is_none());
+    }
+
+    #[test]
+    fn section_heading_returns_entry_flag_per_section() {
+        assert_eq!(section_heading("Args:"), Some(true));
+        assert_eq!(section_heading("Attributes:"), Some(true));
+        assert_eq!(section_heading("Examples:"), Some(false));
+        assert_eq!(section_heading("Note:"), Some(false));
+        assert_eq!(section_heading("Raises:"), Some(true));
+        assert_eq!(section_heading("Returns:"), Some(true));
+        assert_eq!(section_heading("Warning:"), Some(false));
+        assert_eq!(section_heading("Yields:"), Some(true));
     }
 
     #[test]

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -2,9 +2,12 @@
 //! Description prose wraps to `docstring_line_length`. Structured
 //! sections (`Args:`, `Attributes:`, `Examples:`, `Note:`, `Raises:`,
 //! `Returns:`, `Warning:`, `Yields:`) wrap to the budget that
-//! `docstring_structured_policy` selects. Verbatim regions (triple-
-//! backtick fences, blocks indented one step beyond the body, list
-//! items and their continuations) pass through unchanged.
+//! `docstring_structured_policy` selects. Entry-carrying sections
+//! (`Args:`, `Attributes:`, `Raises:`, `Returns:`, `Yields:`) wrap
+//! `name: description` entries to `docstring_line_length` with a
+//! hanging indent at the description's start column. Verbatim regions
+//! (triple-backtick fences, blocks indented one step beyond the body,
+//! list items and their continuations) pass through unchanged.
 //! reStructuredText markup, Sphinx directives, and Numpydoc style
 //! pass through unwrapped.
 
@@ -19,15 +22,15 @@ use crate::primitives::edit::narrowed_replacement;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
-const SECTIONS: &[&str] = &[
-    "Args",
-    "Attributes",
-    "Examples",
-    "Note",
-    "Raises",
-    "Returns",
-    "Warning",
-    "Yields",
+const SECTIONS: &[(&str, bool)] = &[
+    ("Args", true),
+    ("Attributes", true),
+    ("Examples", false),
+    ("Note", false),
+    ("Raises", true),
+    ("Returns", true),
+    ("Warning", false),
+    ("Yields", true),
 ];
 
 pub(crate) struct DocstringWrap {
@@ -72,10 +75,18 @@ impl Rule for DocstringWrap {
     }
 }
 
+#[derive(Default)]
+struct Paragraph {
+    initial_indent: String,
+    lines: Vec<String>,
+    subsequent_indent: String,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Region {
     Description,
     Section,
+    SectionEntry,
 }
 
 struct Rewriter<'a> {
@@ -104,22 +115,24 @@ impl DocstringHandler for Rewriter<'_> {
 
 struct Walker<'a> {
     body_indent_chars: usize,
+    entry_hanging_col: usize,
     in_fence: bool,
     list_indent: Option<usize>,
     newline: &'a str,
     out: String,
-    paragraph: Vec<String>,
-    paragraph_indent: String,
+    paragraph: Paragraph,
     region: Region,
     rule: &'a DocstringWrap,
+    section_allows_entries: bool,
 }
 
 impl Walker<'_> {
-    fn buffer(&mut self, indent: &str, line: &str) {
-        if self.paragraph.is_empty() {
-            self.paragraph_indent = indent.to_owned();
+    fn buffer_description(&mut self, indent: &str, line: &str) {
+        if self.paragraph.lines.is_empty() {
+            self.paragraph.initial_indent = indent.to_owned();
+            self.paragraph.subsequent_indent = indent.to_owned();
         }
-        self.paragraph.push(line.to_owned());
+        self.paragraph.lines.push(line.to_owned());
     }
 
     fn consume(&mut self, line: &str) {
@@ -142,7 +155,6 @@ impl Walker<'_> {
         if trimmed.is_empty() {
             self.flush_paragraph();
             self.list_indent = None;
-            self.region = Region::Description;
             self.out.push_str(self.newline);
             return;
         }
@@ -162,16 +174,29 @@ impl Walker<'_> {
             return;
         }
 
-        if indent_chars == self.body_indent_chars && is_section_heading(trimmed) {
+        if indent_chars == self.body_indent_chars {
+            if let Some(allows_entries) = section_heading(trimmed) {
+                self.flush_paragraph();
+                self.region = Region::Section;
+                self.section_allows_entries = allows_entries;
+                self.emit_verbatim(line);
+                return;
+            }
+        }
+
+        let text = trimmed.trim_end();
+        if self.region == Region::SectionEntry {
+            if self.is_entry_continuation(indent_chars, text) {
+                self.paragraph.lines.push(text.to_owned());
+                return;
+            }
             self.flush_paragraph();
-            self.region = Region::Section;
-            self.emit_verbatim(line);
-            return;
         }
 
         let prose_indent = match self.region {
             Region::Description => self.body_indent_chars,
             Region::Section => self.body_indent_chars + 4,
+            Region::SectionEntry => unreachable!("entries handled above"),
         };
         if indent_chars > prose_indent {
             self.flush_paragraph();
@@ -184,10 +209,18 @@ impl Walker<'_> {
             self.region = Region::Description;
         }
 
-        let text = trimmed.trim_end();
         match self.region {
-            Region::Description => self.buffer(indent_str, text),
-            Region::Section => self.emit_wrapped(indent_str, text, self.rule.section_width),
+            Region::Description => self.buffer_description(indent_str, text),
+            Region::Section => {
+                if self.section_allows_entries {
+                    if let Some(desc_col) = entry_description_col(text) {
+                        self.start_entry(indent_str, indent_chars, text, desc_col);
+                        return;
+                    }
+                }
+                self.emit_wrapped(indent_str, indent_str, text, self.rule.section_width);
+            }
+            Region::SectionEntry => unreachable!("entries handled above"),
         }
     }
 
@@ -196,24 +229,58 @@ impl Walker<'_> {
         self.out.push_str(self.newline);
     }
 
-    fn emit_wrapped(&mut self, indent: &str, text: &str, width: usize) {
+    fn emit_wrapped(&mut self, initial: &str, subsequent: &str, text: &str, width: usize) {
         let opts = Options::new(width)
             .break_words(false)
-            .initial_indent(indent)
-            .subsequent_indent(indent);
+            .initial_indent(initial)
+            .subsequent_indent(subsequent);
         for piece in textwrap::wrap(text, opts) {
             self.emit_verbatim(&piece);
         }
     }
 
     fn flush_paragraph(&mut self) {
-        if self.paragraph.is_empty() {
-            return;
+        if !self.paragraph.lines.is_empty() {
+            let para = std::mem::take(&mut self.paragraph);
+            let text = para.lines.join(" ");
+            self.emit_wrapped(
+                &para.initial_indent,
+                &para.subsequent_indent,
+                &text,
+                self.rule.description_width,
+            );
         }
-        let text = std::mem::take(&mut self.paragraph).join(" ");
-        let indent = std::mem::take(&mut self.paragraph_indent);
-        self.emit_wrapped(&indent, &text, self.rule.description_width);
+        if self.region == Region::SectionEntry {
+            self.region = Region::Section;
+        }
     }
+
+    fn is_entry_continuation(&self, indent_chars: usize, trimmed: &str) -> bool {
+        indent_chars == self.entry_hanging_col
+            || (indent_chars == self.body_indent_chars + 4
+                && entry_description_col(trimmed).is_none())
+    }
+
+    fn start_entry(&mut self, indent_str: &str, indent_chars: usize, text: &str, desc_col: usize) {
+        let hanging_col = indent_chars + desc_col;
+        self.paragraph.initial_indent = indent_str.to_owned();
+        self.paragraph.subsequent_indent = " ".repeat(hanging_col);
+        self.paragraph.lines.push(text.to_owned());
+        self.region = Region::SectionEntry;
+        self.entry_hanging_col = hanging_col;
+    }
+}
+
+fn entry_description_col(trimmed: &str) -> Option<usize> {
+    let mut chars = trimmed.char_indices();
+    chars.next().filter(|(_, c)| is_name_char(*c))?;
+    let (name_end, _) = chars.find(|(_, c)| !(is_name_char(*c) || *c == '.'))?;
+    let post_colon = trimmed[name_end..]
+        .trim_start_matches([' ', '\t'])
+        .strip_prefix(':')?
+        .strip_prefix([' ', '\t'])?
+        .trim_start_matches([' ', '\t']);
+    (!post_colon.is_empty()).then(|| trimmed[..trimmed.len() - post_colon.len()].chars().count())
 }
 
 fn is_list_marker(trimmed: &str) -> bool {
@@ -227,11 +294,8 @@ fn is_list_marker(trimmed: &str) -> bool {
     after_digits.len() < trimmed.len() && after_digits.starts_with(". ")
 }
 
-fn is_section_heading(trimmed: &str) -> bool {
-    SECTIONS
-        .iter()
-        .find_map(|name| trimmed.strip_prefix(name))
-        .is_some_and(|rest| rest.starts_with(':'))
+fn is_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
 }
 
 fn rewrite_body(
@@ -244,14 +308,15 @@ fn rewrite_body(
 
     let mut walker = Walker {
         body_indent_chars: body_indent.chars().count(),
+        entry_hanging_col: 0,
         in_fence: false,
         list_indent: None,
         newline,
         out: String::with_capacity(content.len()),
-        paragraph: Vec::new(),
-        paragraph_indent: String::new(),
+        paragraph: Paragraph::default(),
         region: Region::Description,
         rule,
+        section_allows_entries: false,
     };
     for line in content.split(newline) {
         walker.consume(line);
@@ -264,6 +329,15 @@ fn rewrite_body(
     result.push_str(newline);
     result.push_str(closer_indent);
     Some(result)
+}
+
+fn section_heading(trimmed: &str) -> Option<bool> {
+    SECTIONS.iter().find_map(|(name, allows_entries)| {
+        trimmed
+            .strip_prefix(name)
+            .is_some_and(|rest| rest.starts_with(':'))
+            .then_some(*allows_entries)
+    })
 }
 
 #[cfg(test)]
@@ -309,6 +383,22 @@ mod tests {
     }
 
     #[test]
+    fn entry_description_col_rejects_lines_without_name_colon_shape() {
+        assert!(entry_description_col("just prose with no colon").is_none());
+        assert!(entry_description_col("name:no_space_after_colon").is_none());
+        assert!(entry_description_col(": no name before colon").is_none());
+        assert!(entry_description_col("name: ").is_none());
+        assert!(entry_description_col("123: digits-only name").is_some());
+    }
+
+    #[test]
+    fn entry_description_col_returns_char_column_of_description_start() {
+        assert_eq!(entry_description_col("name: desc"), Some(6));
+        assert_eq!(entry_description_col("name : desc"), Some(7));
+        assert_eq!(entry_description_col("dotted.name: desc"), Some(13));
+    }
+
+    #[test]
     fn fenced_code_block_passes_through_verbatim() {
         let src =
             "\"\"\"\nSummary.\n\n```python\nx = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12\n```\n\"\"\"\n";
@@ -328,22 +418,6 @@ mod tests {
     }
 
     #[test]
-    fn is_section_heading_matches_recognized_names_with_colon() {
-        for name in SECTIONS {
-            assert!(
-                is_section_heading(&format!("{name}:")),
-                "{name}: should match"
-            );
-        }
-        assert!(is_section_heading("Returns: int"));
-        assert!(!is_section_heading("Args :"));
-        assert!(!is_section_heading("args:"));
-        assert!(!is_section_heading("Argz:"));
-        assert!(!is_section_heading("Args"));
-        assert!(!is_section_heading("Arguments:"));
-    }
-
-    #[test]
     fn list_items_and_their_continuations_are_left_alone() {
         let src = "\"\"\"\nA list:\n\n- first item here that runs on with extra words and more padding text\n  continuation indented under the first item\n- second item\n\"\"\"\n";
         assert_eq!(run(src), src);
@@ -356,12 +430,40 @@ mod tests {
     }
 
     #[test]
-    fn section_body_wraps_to_section_budget_under_default_policy() {
-        let src = "\"\"\"\nSummary.\n\nArgs:\n    foo: a very long parameter description that should wrap at eighty eight characters because it lives inside a structured section.\n\"\"\"\n";
+    fn section_body_entry_wraps_at_hanging_column_under_default_policy() {
+        let src = "\"\"\"\nSummary.\n\nArgs:\n    foo: a very long parameter description that should wrap at seventy six characters because it lives inside an entry-carrying section.\n\"\"\"\n";
         let out = run(src);
         for line in out.lines() {
-            assert!(line.chars().count() <= 88, "line over 88: {line:?}");
+            assert!(line.chars().count() <= 76, "line over 76: {line:?}");
         }
+    }
+
+    #[test]
+    fn section_heading_returns_entry_flag_per_section() {
+        assert_eq!(section_heading("Args:"), Some(true));
+        assert_eq!(section_heading("Attributes:"), Some(true));
+        assert_eq!(section_heading("Examples:"), Some(false));
+        assert_eq!(section_heading("Note:"), Some(false));
+        assert_eq!(section_heading("Raises:"), Some(true));
+        assert_eq!(section_heading("Returns:"), Some(true));
+        assert_eq!(section_heading("Warning:"), Some(false));
+        assert_eq!(section_heading("Yields:"), Some(true));
+    }
+
+    #[test]
+    fn section_heading_matches_recognized_names_with_colon() {
+        for (name, _) in SECTIONS {
+            assert!(
+                section_heading(&format!("{name}:")).is_some(),
+                "{name}: should match"
+            );
+        }
+        assert!(section_heading("Returns: int").is_some());
+        assert!(section_heading("Args :").is_none());
+        assert!(section_heading("args:").is_none());
+        assert!(section_heading("Argz:").is_none());
+        assert!(section_heading("Args").is_none());
+        assert!(section_heading("Arguments:").is_none());
     }
 
     #[test]

--- a/tests/fixtures/composition/docstring_args_rewrap_old_style.config.toml
+++ b/tests/fixtures/composition/docstring_args_rewrap_old_style.config.toml
@@ -1,0 +1,2 @@
+[harness]
+rules = ["align-colons", "docstring-wrap"]

--- a/tests/fixtures/composition/docstring_args_rewrap_old_style.input.py
+++ b/tests/fixtures/composition/docstring_args_rewrap_old_style.input.py
@@ -1,0 +1,24 @@
+"""
+Args entries with old-style continuations indented to the section
+body's `body_indent + 4` rather than under the description, and
+names of varying widths. `align_colons` shifts every colon to the
+longest-name column, and `docstring_wrap` then re-flows the
+continuations into the post-align hanging-column shape rather
+than leaving them at `body_indent + 4`.
+
+Rules:
+- align_colons
+- docstring_wrap
+"""
+
+
+def configure(host, encoding):
+    """
+    Summary line.
+
+    Args:
+        host: A descriptive parameter that is already split across two source
+        lines at the section body indent rather than under the description.
+        encoding: The output encoding selected for the configured pipeline.
+    """
+    return host

--- a/tests/fixtures/composition/docstring_args_wrap_after_colon_align.config.toml
+++ b/tests/fixtures/composition/docstring_args_wrap_after_colon_align.config.toml
@@ -1,0 +1,2 @@
+[harness]
+rules = ["alphabetize", "align-colons", "docstring-wrap"]

--- a/tests/fixtures/composition/docstring_args_wrap_after_colon_align.input.py
+++ b/tests/fixtures/composition/docstring_args_wrap_after_colon_align.input.py
@@ -1,0 +1,28 @@
+"""
+Function with parameters and matching Args entries both in
+non-alphabetical source order, with long descriptions.
+`alphabetize` reorders the signature, `align_colons` aligns every
+colon in both the signature and the Args section, and
+`docstring_wrap` wraps each Args description at the post-align
+hanging column. The Args entries themselves stay in source order
+because no current rule reaches into docstring text to reorder
+them, and the resulting signature-vs-Args mismatch pins a known
+gap in the rule suite.
+
+Rules:
+- alphabetize
+- align_colons
+- docstring_wrap
+"""
+
+
+def render(template, context_map, escape_html):
+    """
+    Summary line above the structured section.
+
+    Args:
+        template: A very long description of the template parameter that should wrap at the post-align hanging column with hanging indent under the description.
+        context_map: A mapping of identifier names to values for the rendering context, long enough to also need wrapping at the hanging column.
+        escape_html: Whether to escape HTML output for safety, a description long enough to wrap at the same hanging column as the others.
+    """
+    return template

--- a/tests/fixtures/composition/docstring_signature_and_args_independent_colons.config.toml
+++ b/tests/fixtures/composition/docstring_signature_and_args_independent_colons.config.toml
@@ -1,0 +1,2 @@
+[harness]
+rules = ["align-colons", "docstring-wrap"]

--- a/tests/fixtures/composition/docstring_signature_and_args_independent_colons.input.py
+++ b/tests/fixtures/composition/docstring_signature_and_args_independent_colons.input.py
@@ -1,0 +1,29 @@
+"""
+Function with a typed signature requiring colon alignment in the
+parameter list AND an `Args` section whose entry names align at a
+different column. The parameter names and the Args entry names
+diverge by design to make the two column groups visible.
+`align_colons` handles the two as independent groups, and
+`docstring_wrap` then wraps the Args descriptions at the Args
+hanging column rather than the signature column.
+
+Rules:
+- align_colons
+- docstring_wrap
+"""
+
+
+def write(
+    destination: str,
+    contents: bytes,
+    overwrite: bool,
+) -> int:
+    """
+    Summary line.
+
+    Args:
+        dst: A description of the destination sink long enough to wrap at the Args hanging column under the description.
+        body: The bytes to write, a description long enough to wrap and demonstrate the hanging behavior at the Args column.
+        force: Whether to overwrite any existing target, a description long enough to wrap at the same hanging column as the others.
+    """
+    return 0

--- a/tests/fixtures/docstring_wrap/args_wrap.input.py
+++ b/tests/fixtures/docstring_wrap/args_wrap.input.py
@@ -1,7 +1,8 @@
 """
-A long Args entry wraps to the eighty eight character section budget rather
-than the narrower description budget, so parameter tables retain the same
-horizontal room code lines carry.
+A long Args entry wraps at the seventy six character docstring budget with
+a hanging indent at the description's start column, so continuation lines
+sit under the description they continue rather than at the parameter-list
+indent.
 """
 
 

--- a/tests/fixtures/docstring_wrap/class_docstring.input.py
+++ b/tests/fixtures/docstring_wrap/class_docstring.input.py
@@ -1,7 +1,8 @@
 """
-A class-level docstring with structured sections wraps identically to
-the function-level shape because the walker visits every body holding
-a string literal as its first expression statement.
+A class-level docstring with an Attributes section wraps its entries
+with the same hanging-column shape as a function-level Args entry, since
+the walker visits every body holding a string literal as its first
+expression statement.
 """
 
 

--- a/tests/fixtures/docstring_wrap/entry_idempotent.input.py
+++ b/tests/fixtures/docstring_wrap/entry_idempotent.input.py
@@ -1,0 +1,17 @@
+"""
+An Args entry already wrapped with the hanging-column shape passes
+through unchanged, confirming the rule fires only when re-wrapping would
+change the output.
+"""
+
+
+def configure():
+    """
+    Summary line.
+
+    Args:
+        first: A description already wrapped at the docstring budget with
+               continuation lines sitting at the hanging-column indent
+               under the description.
+        second: A short entry that fits on its line.
+    """

--- a/tests/fixtures/docstring_wrap/entry_multi_paragraph.input.py
+++ b/tests/fixtures/docstring_wrap/entry_multi_paragraph.input.py
@@ -1,0 +1,17 @@
+"""
+A blank line terminates an entry's first paragraph and the following
+non-blank line is checked as a new entry candidate, so a multi-paragraph
+Args section composes from two adjacent entries rather than carrying the
+second paragraph as a continuation.
+"""
+
+
+def configure():
+    """
+    Summary line.
+
+    Args:
+        first: A descriptive entry whose first paragraph fits inside the docstring budget once the hanging indent at the description column kicks in.
+
+        second: A separate entry that follows a blank line and is recognized as a new entry candidate rather than as a continuation of the first.
+    """

--- a/tests/fixtures/docstring_wrap/entry_rewraps_old_style.input.py
+++ b/tests/fixtures/docstring_wrap/entry_rewraps_old_style.input.py
@@ -1,0 +1,16 @@
+"""
+An entry whose continuation lines sit at the section-body indent rather
+than at the hanging column re-wraps into the hanging shape, so adopting
+this rule normalizes both never-wrapped and old-style-wrapped docstrings
+on one pass.
+"""
+
+
+def configure():
+    """
+    Summary line.
+
+    Args:
+        foo: A descriptive parameter that is already split across two source
+        lines at the section body indent rather than under the description.
+    """

--- a/tests/fixtures/docstring_wrap/entry_verbatim_preserved.input.py
+++ b/tests/fixtures/docstring_wrap/entry_verbatim_preserved.input.py
@@ -1,0 +1,19 @@
+"""
+Verbatim regions inside an entry preserve their shape and end the entry
+at the block's boundary, so a triple-backtick fence inside an Args entry
+passes through unchanged and the next entry resumes the hanging-column
+wrap.
+"""
+
+
+def render():
+    """
+    Summary line.
+
+    Args:
+        sample: A leading description that introduces a fenced code block.
+        ```python
+        x = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15
+        ```
+        next_entry: A descriptive entry following the verbatim region that wraps with the hanging-column shape because the entry detection resumes after the block.
+    """

--- a/tests/fixtures/docstring_wrap/mixed_description_and_args.input.py
+++ b/tests/fixtures/docstring_wrap/mixed_description_and_args.input.py
@@ -1,7 +1,8 @@
 """
-A docstring with both shapes wraps each region to its own budget. The
-description paragraph wraps at seventy six and the Args section wraps at
-eighty eight, surfacing the two-budget design in a single fixture.
+A docstring with both shapes wraps each region to its own shape. The
+description paragraph wraps at the docstring budget against the body
+indent, and the Args entry wraps at the same budget with a hanging indent
+at the description's start column.
 """
 
 
@@ -10,7 +11,7 @@ def render(label, count):
     A description paragraph above the structured section that runs past the seventy six character description budget needs to wrap at seventy six.
 
     Args:
-        label: A parameter description that runs past the eighty eight character section budget wraps at eighty eight rather than seventy six because it lives inside Args.
+        label: A parameter description that runs past the seventy six character docstring budget wraps with a hanging indent at the description column because the entry shape was detected.
         count: Number of times to render the label.
     """
     return label * count

--- a/tests/fixtures/docstring_wrap/policy_docstring_line_length.input.py
+++ b/tests/fixtures/docstring_wrap/policy_docstring_line_length.input.py
@@ -1,16 +1,14 @@
 """
 A `.config.toml` sidecar flips `docstring-structured-policy` to the
-docstring budget so structured sections wrap at seventy six rather
+docstring budget so non-entry section bodies wrap at seventy six rather
 than the default eighty eight.
 """
 
 
-def configure(name, retries):
+def configure():
     """
     Summary line.
 
-    Args:
-        name: A descriptive name that exceeds the seventy six character docstring budget when the policy selects that budget for structured sections.
-        retries: Number of retry attempts.
+    Note:
+        A long note paragraph that exceeds the seventy six character docstring budget when the policy selects that budget for structured-section bodies.
     """
-    return name, retries

--- a/tests/fixtures/docstring_wrap/raises_entry_wrap.input.py
+++ b/tests/fixtures/docstring_wrap/raises_entry_wrap.input.py
@@ -1,0 +1,15 @@
+"""
+A Raises entry naming an exception type wraps the description at the
+docstring budget with a hanging indent at the description's start column,
+keeping the exception name flush at the parameter-list indent.
+"""
+
+
+def parse():
+    """
+    Summary line.
+
+    Raises:
+        ValueError: When the input bytes do not form a valid token sequence and the parser cannot recover a structured representation from the surrounding context.
+        IOError: When the underlying stream is closed before the parser reaches a terminating token.
+    """

--- a/tests/fixtures/docstring_wrap/returns_entry_wrap.input.py
+++ b/tests/fixtures/docstring_wrap/returns_entry_wrap.input.py
@@ -1,0 +1,15 @@
+"""
+A long Returns entry with the `name: description` shape wraps at the
+docstring budget with a hanging indent at the description's start column,
+matching the Args entry shape for named-tuple-style return docs.
+"""
+
+
+def lookup():
+    """
+    Summary line.
+
+    Returns:
+        record: The matching row from the database when the lookup succeeds, populated from every selected column and ready for the caller to consume.
+        cached: Whether the record came from the in-memory cache rather than a fresh query.
+    """

--- a/tests/fixtures/docstring_wrap/yields_entry_wrap.input.py
+++ b/tests/fixtures/docstring_wrap/yields_entry_wrap.input.py
@@ -1,0 +1,14 @@
+"""
+A Yields entry naming the yielded value wraps the description at the
+docstring budget with a hanging indent at the description's start column,
+matching every other entry-carrying section.
+"""
+
+
+def stream():
+    """
+    Summary line.
+
+    Yields:
+        chunk: The next decoded chunk of the underlying byte stream, sized to whatever the upstream reader chose to surface in a single read.
+    """

--- a/tests/snapshots/composition/docstring_args_rewrap_old_style.diagnostics.snap
+++ b/tests/snapshots/composition/docstring_args_rewrap_old_style.diagnostics.snap
@@ -1,0 +1,9 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/composition/docstring_args_rewrap_old_style.input.py
+---
+align-colons@488..488
+align-colons@646..646
+docstring-wrap@551..617
+docstring-wrap@69..322

--- a/tests/snapshots/composition/docstring_args_rewrap_old_style.input.py.snap
+++ b/tests/snapshots/composition/docstring_args_rewrap_old_style.input.py.snap
@@ -1,0 +1,29 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/composition/docstring_args_rewrap_old_style.input.py
+---
+"""
+Args entries with old-style continuations indented to the section body's
+`body_indent + 4` rather than under the description, and names of varying
+widths. `align_colons` shifts every colon to the longest-name column,
+and `docstring_wrap` then re-flows the continuations into the post-align
+hanging-column shape rather than leaving them at `body_indent + 4`.
+
+Rules:
+- align_colons
+- docstring_wrap
+"""
+
+
+def configure(host, encoding):
+    """
+    Summary line.
+
+    Args:
+        host     : A descriptive parameter that is already split across two
+                   source lines at the section body indent rather than under
+                   the description.
+        encoding : The output encoding selected for the configured pipeline.
+    """
+    return host

--- a/tests/snapshots/composition/docstring_args_wrap_after_colon_align.diagnostics.snap
+++ b/tests/snapshots/composition/docstring_args_wrap_after_colon_align.diagnostics.snap
@@ -1,0 +1,11 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/composition/docstring_args_wrap_after_colon_align.input.py
+---
+align-colons@1015..1015
+align-colons@706..706
+align-colons@870..870
+alphabetize@587..621
+docstring-wrap@62..493
+docstring-wrap@761..1118

--- a/tests/snapshots/composition/docstring_args_wrap_after_colon_align.input.py.snap
+++ b/tests/snapshots/composition/docstring_args_wrap_after_colon_align.input.py.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/composition/docstring_args_wrap_after_colon_align.input.py
+---
+"""
+Function with parameters and matching Args entries both in non-alphabetical
+source order, with long descriptions. `alphabetize` reorders the signature,
+`align_colons` aligns every colon in both the signature and the Args
+section, and `docstring_wrap` wraps each Args description at the post-align
+hanging column. The Args entries themselves stay in source order because no
+current rule reaches into docstring text to reorder them, and the resulting
+signature-vs-Args mismatch pins a known gap in the rule suite.
+
+Rules:
+- alphabetize
+- align_colons
+- docstring_wrap
+"""
+
+
+def render(context_map, escape_html, template):
+    """
+    Summary line above the structured section.
+
+    Args:
+        template    : A very long description of the template parameter
+                      that should wrap at the post-align hanging column with
+                      hanging indent under the description.
+        context_map : A mapping of identifier names to values for the
+                      rendering context, long enough to also need wrapping
+                      at the hanging column.
+        escape_html : Whether to escape HTML output for safety, a
+                      description long enough to wrap at the same hanging
+                      column as the others.
+    """
+    return template

--- a/tests/snapshots/composition/docstring_signature_and_args_independent_colons.diagnostics.snap
+++ b/tests/snapshots/composition/docstring_signature_and_args_independent_colons.diagnostics.snap
@@ -1,0 +1,13 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/composition/docstring_signature_and_args_independent_colons.input.py
+---
+align-colons@496..496
+align-colons@515..515
+align-colons@537..537
+align-colons@603..603
+align-colons@725..725
+align-colons@851..851
+docstring-wrap@676..927
+docstring-wrap@68..313

--- a/tests/snapshots/composition/docstring_signature_and_args_independent_colons.input.py.snap
+++ b/tests/snapshots/composition/docstring_signature_and_args_independent_colons.input.py.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/composition/docstring_signature_and_args_independent_colons.input.py
+---
+"""
+Function with a typed signature requiring colon alignment in the parameter
+list AND an `Args` section whose entry names align at a different column.
+The parameter names and the Args entry names diverge by design to make the
+two column groups visible. `align_colons` handles the two as independent
+groups, and `docstring_wrap` then wraps the Args descriptions at the Args
+hanging column rather than the signature column.
+
+Rules:
+- align_colons
+- docstring_wrap
+"""
+
+
+def write(
+    destination : str,
+    contents    : bytes,
+    overwrite   : bool,
+) -> int:
+    """
+    Summary line.
+
+    Args:
+        dst   : A description of the destination sink long enough to wrap at
+                the Args hanging column under the description.
+        body  : The bytes to write, a description long enough to wrap and
+                demonstrate the hanging behavior at the Args column.
+        force : Whether to overwrite any existing target, a description long
+                enough to wrap at the same hanging column as the others.
+    """
+    return 0

--- a/tests/snapshots/docstring_wrap/args_wrap.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/args_wrap.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/docstring_wrap/args_wrap.input.py
 ---
-docstring-wrap@347..347
+docstring-wrap@377..440

--- a/tests/snapshots/docstring_wrap/args_wrap.input.py.snap
+++ b/tests/snapshots/docstring_wrap/args_wrap.input.py.snap
@@ -4,9 +4,10 @@ expression: output
 input_file: tests/fixtures/docstring_wrap/args_wrap.input.py
 ---
 """
-A long Args entry wraps to the eighty eight character section budget rather
-than the narrower description budget, so parameter tables retain the same
-horizontal room code lines carry.
+A long Args entry wraps at the seventy six character docstring budget with
+a hanging indent at the description's start column, so continuation lines
+sit under the description they continue rather than at the parameter-list
+indent.
 """
 
 
@@ -15,8 +16,9 @@ def configure(name, retries):
     Summary line.
 
     Args:
-        name: A descriptive name that exceeds the section budget when written out in a
-        single line because it explains the parameter at length.
+        name: A descriptive name that exceeds the section budget when
+              written out in a single line because it explains the parameter
+              at length.
         retries: Number of retry attempts the caller wants before giving up.
     """
     return name, retries

--- a/tests/snapshots/docstring_wrap/class_docstring.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/class_docstring.diagnostics.snap
@@ -3,5 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/docstring_wrap/class_docstring.input.py
 ---
-docstring-wrap@342..342
-docstring-wrap@73..153
+docstring-wrap@373..373
+docstring-wrap@72..224

--- a/tests/snapshots/docstring_wrap/class_docstring.input.py.snap
+++ b/tests/snapshots/docstring_wrap/class_docstring.input.py.snap
@@ -4,9 +4,10 @@ expression: output
 input_file: tests/fixtures/docstring_wrap/class_docstring.input.py
 ---
 """
-A class-level docstring with structured sections wraps identically to the
-function-level shape because the walker visits every body holding a string
-literal as its first expression statement.
+A class-level docstring with an Attributes section wraps its entries with
+the same hanging-column shape as a function-level Args entry, since the
+walker visits every body holding a string literal as its first expression
+statement.
 """
 
 
@@ -15,8 +16,8 @@ class Posting:
     Summary line.
 
     Attributes:
-        title: A descriptive title that exceeds the eighty eight character section
-        budget when written out as a single line.
+        title: A descriptive title that exceeds the eighty eight character
+               section budget when written out as a single line.
         salary: Annual salary in USD.
     """
 

--- a/tests/snapshots/docstring_wrap/entry_idempotent.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/entry_idempotent.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/docstring_wrap/entry_idempotent.input.py
+---
+docstring-wrap@367..388
+docstring-wrap@70..151

--- a/tests/snapshots/docstring_wrap/entry_idempotent.input.py.snap
+++ b/tests/snapshots/docstring_wrap/entry_idempotent.input.py.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/docstring_wrap/entry_idempotent.input.py
+---
+"""
+An Args entry already wrapped with the hanging-column shape passes through
+unchanged, confirming the rule fires only when re-wrapping would change
+the output.
+"""
+
+
+def configure():
+    """
+    Summary line.
+
+    Args:
+        first: A description already wrapped at the docstring budget with
+               continuation lines sitting at the hanging-column indent under
+               the description.
+        second: A short entry that fits on its line.
+    """

--- a/tests/snapshots/docstring_wrap/entry_multi_paragraph.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/entry_multi_paragraph.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/docstring_wrap/entry_multi_paragraph.input.py
+---
+docstring-wrap@387..600
+docstring-wrap@72..226

--- a/tests/snapshots/docstring_wrap/entry_multi_paragraph.input.py.snap
+++ b/tests/snapshots/docstring_wrap/entry_multi_paragraph.input.py.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/docstring_wrap/entry_multi_paragraph.input.py
+---
+"""
+A blank line terminates an entry's first paragraph and the following non-
+blank line is checked as a new entry candidate, so a multi-paragraph Args
+section composes from two adjacent entries rather than carrying the second
+paragraph as a continuation.
+"""
+
+
+def configure():
+    """
+    Summary line.
+
+    Args:
+        first: A descriptive entry whose first paragraph fits inside the
+               docstring budget once the hanging indent at the description
+               column kicks in.
+
+        second: A separate entry that follows a blank line and is recognized
+                as a new entry candidate rather than as a continuation of
+                the first.
+    """

--- a/tests/snapshots/docstring_wrap/entry_rewraps_old_style.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/entry_rewraps_old_style.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/docstring_wrap/entry_rewraps_old_style.input.py
+---
+docstring-wrap@363..433
+docstring-wrap@75..221

--- a/tests/snapshots/docstring_wrap/entry_rewraps_old_style.input.py.snap
+++ b/tests/snapshots/docstring_wrap/entry_rewraps_old_style.input.py.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/docstring_wrap/entry_rewraps_old_style.input.py
+---
+"""
+An entry whose continuation lines sit at the section-body indent rather than
+at the hanging column re-wraps into the hanging shape, so adopting this rule
+normalizes both never-wrapped and old-style-wrapped docstrings on one pass.
+"""
+
+
+def configure():
+    """
+    Summary line.
+
+    Args:
+        foo: A descriptive parameter that is already split across two
+             source lines at the section body indent rather than under the
+             description.
+    """

--- a/tests/snapshots/docstring_wrap/entry_verbatim_preserved.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/entry_verbatim_preserved.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/docstring_wrap/entry_verbatim_preserved.input.py
+---
+docstring-wrap@538..592
+docstring-wrap@75..220

--- a/tests/snapshots/docstring_wrap/entry_verbatim_preserved.input.py.snap
+++ b/tests/snapshots/docstring_wrap/entry_verbatim_preserved.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/docstring_wrap/entry_verbatim_preserved.input.py
+---
+"""
+Verbatim regions inside an entry preserve their shape and end the entry at
+the block's boundary, so a triple-backtick fence inside an Args entry passes
+through unchanged and the next entry resumes the hanging-column wrap.
+"""
+
+
+def render():
+    """
+    Summary line.
+
+    Args:
+        sample: A leading description that introduces a fenced code block.
+        ```python
+        x = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13 + 14 + 15
+        ```
+        next_entry: A descriptive entry following the verbatim region that
+                    wraps with the hanging-column shape because the entry
+                    detection resumes after the block.
+    """

--- a/tests/snapshots/docstring_wrap/mixed_description_and_args.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/mixed_description_and_args.diagnostics.snap
@@ -3,4 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/docstring_wrap/mixed_description_and_args.input.py
 ---
-docstring-wrap@329..577
+docstring-wrap@141..223
+docstring-wrap@366..580

--- a/tests/snapshots/docstring_wrap/mixed_description_and_args.input.py.snap
+++ b/tests/snapshots/docstring_wrap/mixed_description_and_args.input.py.snap
@@ -4,9 +4,10 @@ expression: output
 input_file: tests/fixtures/docstring_wrap/mixed_description_and_args.input.py
 ---
 """
-A docstring with both shapes wraps each region to its own budget. The
-description paragraph wraps at seventy six and the Args section wraps at
-eighty eight, surfacing the two-budget design in a single fixture.
+A docstring with both shapes wraps each region to its own shape. The
+description paragraph wraps at the docstring budget against the body indent,
+and the Args entry wraps at the same budget with a hanging indent at the
+description's start column.
 """
 
 
@@ -16,9 +17,9 @@ def render(label, count):
     seventy six character description budget needs to wrap at seventy six.
 
     Args:
-        label: A parameter description that runs past the eighty eight character section
-        budget wraps at eighty eight rather than seventy six because it lives inside
-        Args.
+        label: A parameter description that runs past the seventy six
+               character docstring budget wraps with a hanging indent at the
+               description column because the entry shape was detected.
         count: Number of times to render the label.
     """
     return label * count

--- a/tests/snapshots/docstring_wrap/policy_docstring_line_length.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/policy_docstring_line_length.diagnostics.snap
@@ -3,5 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/docstring_wrap/policy_docstring_line_length.input.py
 ---
-docstring-wrap@138..148
-docstring-wrap@314..382
+docstring-wrap@143..149
+docstring-wrap@303..372

--- a/tests/snapshots/docstring_wrap/policy_docstring_line_length.input.py.snap
+++ b/tests/snapshots/docstring_wrap/policy_docstring_line_length.input.py.snap
@@ -5,19 +5,17 @@ input_file: tests/fixtures/docstring_wrap/policy_docstring_line_length.input.py
 ---
 """
 A `.config.toml` sidecar flips `docstring-structured-policy` to the
-docstring budget so structured sections wrap at seventy six rather than the
-default eighty eight.
+docstring budget so non-entry section bodies wrap at seventy six rather than
+the default eighty eight.
 """
 
 
-def configure(name, retries):
+def configure():
     """
     Summary line.
 
-    Args:
-        name: A descriptive name that exceeds the seventy six character
-        docstring budget when the policy selects that budget for structured
-        sections.
-        retries: Number of retry attempts.
+    Note:
+        A long note paragraph that exceeds the seventy six character
+        docstring budget when the policy selects that budget for structured-
+        section bodies.
     """
-    return name, retries

--- a/tests/snapshots/docstring_wrap/raises_entry_wrap.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/raises_entry_wrap.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/docstring_wrap/raises_entry_wrap.input.py
+---
+docstring-wrap@334..503

--- a/tests/snapshots/docstring_wrap/raises_entry_wrap.input.py.snap
+++ b/tests/snapshots/docstring_wrap/raises_entry_wrap.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/docstring_wrap/raises_entry_wrap.input.py
+---
+"""
+A Raises entry naming an exception type wraps the description at the
+docstring budget with a hanging indent at the description's start column,
+keeping the exception name flush at the parameter-list indent.
+"""
+
+
+def parse():
+    """
+    Summary line.
+
+    Raises:
+        ValueError: When the input bytes do not form a valid token
+                    sequence and the parser cannot recover a structured
+                    representation from the surrounding context.
+        IOError: When the underlying stream is closed before the parser
+                 reaches a terminating token.
+    """

--- a/tests/snapshots/docstring_wrap/returns_entry_wrap.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/returns_entry_wrap.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/docstring_wrap/returns_entry_wrap.input.py
+---
+docstring-wrap@348..499

--- a/tests/snapshots/docstring_wrap/returns_entry_wrap.input.py.snap
+++ b/tests/snapshots/docstring_wrap/returns_entry_wrap.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/docstring_wrap/returns_entry_wrap.input.py
+---
+"""
+A long Returns entry with the `name: description` shape wraps at the
+docstring budget with a hanging indent at the description's start column,
+matching the Args entry shape for named-tuple-style return docs.
+"""
+
+
+def lookup():
+    """
+    Summary line.
+
+    Returns:
+        record: The matching row from the database when the lookup succeeds,
+                populated from every selected column and ready for the
+                caller to consume.
+        cached: Whether the record came from the in-memory cache rather than
+                a fresh query.
+    """

--- a/tests/snapshots/docstring_wrap/yields_entry_wrap.diagnostics.snap
+++ b/tests/snapshots/docstring_wrap/yields_entry_wrap.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/docstring_wrap/yields_entry_wrap.input.py
+---
+docstring-wrap@325..386

--- a/tests/snapshots/docstring_wrap/yields_entry_wrap.input.py.snap
+++ b/tests/snapshots/docstring_wrap/yields_entry_wrap.input.py.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/docstring_wrap/yields_entry_wrap.input.py
+---
+"""
+A Yields entry naming the yielded value wraps the description at the
+docstring budget with a hanging indent at the description's start column,
+matching every other entry-carrying section.
+"""
+
+
+def stream():
+    """
+    Summary line.
+
+    Yields:
+        chunk: The next decoded chunk of the underlying byte stream, sized
+               to whatever the upstream reader chose to surface in a single
+               read.
+    """


### PR DESCRIPTION
### 🪻 Quick Summary

Wraps `name: description` entries inside the Google-style entry-carrying sections (*`Args`, `Attributes`, `Raises`, `Returns`, `Yields`*) to `Config::docstring_line_length` with a hanging indent at the description's start column, matching the column relationship a reader uses to scan a parameter table. Entries that fail the `^\w[\w.]*\s*:\s+\S` shape continue to wrap as section bodies under the existing `Region::Section` path. Verbatim-region detection from #66 (*fenced code blocks, bulleted lists, blocks indented one step past the body*) carries through unchanged inside the new arm. The post-colon column is the same column `align_colons` (*#101*) settles on for typed signatures, and the pipeline already runs `align_colons` before `docstring_wrap`, so the column is fixed by the time wrap fires.

---

### 🗞️ Key Changes

- Adds a `Region::SectionEntry(usize)` arm whose `usize` carries the hanging column, fired when a body line matches the `name: description` shape inside an entry-carrying section

- Wraps each entry's continuation lines at the hanging column to `Config::docstring_line_length` (*76 by default*), regardless of `docstring_structured_policy`, because the hanging-indent shape reads as prose for the eye even though it sits inside a structured section

- Recognizes entry-carrying sections via the `SECTIONS` lookup, where each row carries the section name plus a bool stating whether the section holds entries (*true for `Args`, `Attributes`, `Raises`, `Returns`, `Yields`; false for `Examples`, `Note`, `Warning`*)

- Re-wraps continuation lines sitting at the section-body indent (*old-style wrap*) into the hanging-column shape, so adopting the rule normalizes both never-wrapped and previously-wrapped docstrings on one pass

- Adds twelve fixtures covering each entry-carrying section (*`args_wrap`, `raises_entry_wrap`, `returns_entry_wrap`, `yields_entry_wrap`*) plus the cross-cutting cases (*`entry_idempotent`, `entry_multi_paragraph`, `entry_rewraps_old_style`, `entry_verbatim_preserved`, `mixed_description_and_args`*)

---

### 🧵 Related Issues

- Closes #128