### PR TITLE
[129] Collapse short multi-line collection literals back to inline

### DIFF
--- a/src/rule.rs
+++ b/src/rule.rs
@@ -294,7 +294,7 @@ macro_rules! register_rules {
 }
 
 register_rules! {
-    "collection-layout":         collection_layout:         CollectionLayoutConfig    => CollectionLayout         => "expand collection to one entry per line",
+    "collection-layout":         collection_layout:         CollectionLayoutConfig    => CollectionLayout         => "lay out collection literal against the line budget",
     "alphabetize":               alphabetize:               ToggleOnly                => Alphabetize              => "alphabetize this group",
     "strip-trailing-commas":     strip_trailing_commas:     ToggleOnly                => StripTrailingCommas      => "strip trailing comma",
     "no-single-line-docstrings": no_single_line_docstrings: ToggleOnly                => NoSingleLineDocstrings   => "expand single-line docstring to multi-line form",

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -1,6 +1,8 @@
-//! Expands multi-item `dict`, `list`, and `set` literals when the
-//! inline form would overflow `Config::code_line_length`.
-//! Comprehensions, tuple literals, and any literal whose source range
+//! Lays out `dict`, `list`, `set`, and `tuple` literals against the
+//! `Config::code_line_length` budget. Multi-line literals whose
+//! assembled inline form fits collapse back to a single line.
+//! Single-line literals whose inline form overflows expand to one
+//! entry per line. Comprehensions and any literal whose source range
 //! contains a comment are out of scope.
 
 use std::borrow::Cow;
@@ -43,7 +45,7 @@ impl CollectionLayout {
 
 impl Rule for CollectionLayout {
     fn apply(&self, source: &Source) -> Vec<Edit> {
-        let mut visitor = Expander {
+        let mut visitor = Layouter {
             code_line_length: self.code_line_length,
             edits: Vec::new(),
             max_atomics_per_line: self.max_atomics_per_line,
@@ -59,7 +61,7 @@ impl Rule for CollectionLayout {
     }
 }
 
-struct Expander<'a> {
+struct Layouter<'a> {
     code_line_length: usize,
     edits: Vec<Edit>,
     max_atomics_per_line: usize,
@@ -67,7 +69,7 @@ struct Expander<'a> {
     source: &'a Source,
 }
 
-impl<'a> Expander<'a> {
+impl<'a> Layouter<'a> {
     /// Builds the expanded form of `expr` as a string, recursively
     /// expanding any qualifying child collections.
     fn expand(&self, expr: &Expr, indent: usize) -> String {
@@ -127,8 +129,8 @@ impl<'a> Expander<'a> {
     /// atomicity, and per-item source range for the collection at
     /// `expr`. The text is produced via `serialize_expr` /
     /// `serialize_dict_item` at `indent`, so nested qualifying
-    /// children are already recursively expanded in the returned
-    /// strings. Items that need no expansion pass through as
+    /// children are already recursively laid out in the returned
+    /// strings. Items that need no rewrite pass through as
     /// `Cow::Borrowed` of their source slice.
     fn gather_items(&self, expr: &Expr, indent: usize) -> GatheredItems<'a> {
         let parent = AnyNodeRef::from(expr);
@@ -153,7 +155,7 @@ impl<'a> Expander<'a> {
         let (open, close, elts) = match expr {
             Expr::List(l) => ('[', ']', &l.elts),
             Expr::Set(s) => ('{', '}', &s.elts),
-            _ => unreachable!("gather_items called on non-collection expr"),
+            _ => unreachable!("gather_items called on non-expandable expr"),
         };
         let (texts, (atomics, ranges)): (Vec<_>, (Vec<_>, Vec<_>)) = elts
             .iter()
@@ -171,6 +173,49 @@ impl<'a> Expander<'a> {
             ranges,
             texts,
         }
+    }
+
+    /// Builds the canonical inline form of `expr`, recursively
+    /// inlining any nested collection literal. Non-collection leaves
+    /// pass through as their source slice, with explicit parentheses
+    /// recovered against the enclosing `parent` so precedence-bearing
+    /// parens (`(-a) ** 2`) survive the collapse.
+    fn inline_form(&self, expr: &Expr) -> String {
+        let mut buf = String::new();
+        self.write_inline(&mut buf, expr, AnyNodeRef::from(expr));
+        buf
+    }
+
+    /// Returns the replacement text the rule wants to emit for
+    /// `expr`, or `None` when the visitor should descend into its
+    /// children. `column` is where `expr` actually begins; `indent`
+    /// is where its closing bracket should land if it expands. `None`
+    /// covers non-collection nodes, comment-pinned literals,
+    /// single-line literals that fit, and multi-line tuples or
+    /// single-item dict/list/set whose inline form does not fit.
+    fn replacement_for(&self, expr: &Expr, column: usize, indent: usize) -> Option<String> {
+        if !matches!(
+            expr,
+            Expr::Dict(_) | Expr::List(_) | Expr::Set(_) | Expr::Tuple(_),
+        ) {
+            return None;
+        }
+        let range = expr.range();
+        if self.source.intersects_comment(range) {
+            return None;
+        }
+        if self.source.contains_line_break(range) {
+            let inline = self.inline_form(expr);
+            if column + inline.width() <= self.code_line_length {
+                return Some(inline);
+            }
+            if requires_expand(expr) {
+                return Some(self.expand(expr, indent));
+            }
+            return None;
+        }
+        (requires_expand(expr) && column + self.source.slice(range).width() > self.code_line_length)
+            .then(|| self.expand(expr, indent))
     }
 
     /// Serializes a dict item as `key: value` or `**value`.
@@ -210,18 +255,19 @@ impl<'a> Expander<'a> {
         }
     }
 
-    /// Serializes `expr` into the expanded output. Returns
-    /// `Cow::Borrowed` of the source slice (with explicit parentheses
-    /// recovered) when `expr` needs no expansion, `Cow::Owned` when
-    /// `expr` itself expands.
+    /// Serializes `expr` into a child slot of an enclosing expand.
+    /// Dispatches through `replacement_for`, so a multi-line child
+    /// whose inline form fits collapses, a single-line child that
+    /// overflows expands, and anything else passes through as a
+    /// borrowed source slice with explicit parentheses recovered.
     ///
-    /// `column` is where the expression actually begins on its line
-    /// (used for the `code-line-length` overflow check). `indent` is where
-    /// its closing bracket should land if it expands. They differ for
-    /// dict values, where the key text sits between the line indent
-    /// and the value's own starting column. `parent` is the immediate
-    /// enclosing collection, used to recover any explicit parentheses
-    /// around `expr` that `expr.range()` would otherwise drop.
+    /// `column` is where the expression actually begins on its line.
+    /// `indent` is where its closing bracket should land if it
+    /// expands. They differ for dict values, where the key text sits
+    /// between the line indent and the value's own starting column.
+    /// `parent` is the immediate enclosing collection, used to
+    /// recover any explicit parentheses around `expr` that
+    /// `expr.range()` would otherwise drop.
     fn serialize_expr(
         &self,
         expr: &Expr,
@@ -229,45 +275,94 @@ impl<'a> Expander<'a> {
         column: usize,
         indent: usize,
     ) -> Cow<'a, str> {
-        if self.should_expand(expr, column) {
-            return Cow::Owned(self.expand(expr, indent));
+        match self.replacement_for(expr, column, indent) {
+            Some(text) => Cow::Owned(text),
+            None => Cow::Borrowed(self.slice_with_parens(expr, parent)),
         }
-        let range = parenthesized_range(expr.into(), parent, self.source.tokens())
-            .unwrap_or_else(|| expr.range());
-        Cow::Borrowed(self.source.slice(range))
     }
 
-    /// Returns `true` when `expr` is a qualifying collection whose
-    /// inline form would overflow the `code-line-length` budget at `column`.
-    /// Multi-line input always returns `true`. Single-line input
-    /// returns `true` only when `column + inline_length >
-    /// code_line_length`.
-    fn should_expand(&self, expr: &Expr, column: usize) -> bool {
-        let multi_item = match expr {
-            Expr::Dict(d) => d.len() > 1,
-            Expr::List(l) => l.len() > 1,
-            Expr::Set(s) => s.len() > 1,
-            _ => return false,
-        };
-        let range = expr.range();
-        multi_item
-            && !self.source.intersects_comment(range)
-            && (self.source.contains_line_break(range)
-                || column + self.source.slice(range).width() > self.code_line_length)
+    /// Returns the source slice covering `expr`, with explicit parens
+    /// recovered against `parent` so precedence-bearing parens like
+    /// `(-a) ** 2` survive a borrow.
+    fn slice_with_parens(&self, expr: &Expr, parent: AnyNodeRef) -> &'a str {
+        let range = parenthesized_range(expr.into(), parent, self.source.tokens())
+            .unwrap_or_else(|| expr.range());
+        self.source.slice(range)
+    }
+
+    /// Appends the inline serialization of `expr` to `buf`. Recursive
+    /// helper backing `inline_form`. `parent` is the immediate
+    /// enclosing AST node, used for `parenthesized_range` recovery on
+    /// non-collection leaves.
+    fn write_inline(&self, buf: &mut String, expr: &Expr, parent: AnyNodeRef) {
+        let here = AnyNodeRef::from(expr);
+        match expr {
+            Expr::Dict(d) => {
+                buf.push('{');
+                for (i, item) in d.iter().enumerate() {
+                    if i > 0 {
+                        buf.push_str(", ");
+                    }
+                    if let Some(key) = &item.key {
+                        self.write_inline(buf, key, here);
+                        buf.push_str(": ");
+                    } else {
+                        buf.push_str("**");
+                    }
+                    self.write_inline(buf, &item.value, here);
+                }
+                buf.push('}');
+            }
+            Expr::List(l) => self.write_inline_seq(buf, Some(('[', ']')), &l.elts, here, false),
+            Expr::Set(s) => self.write_inline_seq(buf, Some(('{', '}')), &s.elts, here, false),
+            Expr::Tuple(t) => {
+                let brackets = t.parenthesized.then_some(('(', ')'));
+                self.write_inline_seq(buf, brackets, &t.elts, here, t.elts.len() == 1);
+            }
+            _ => buf.push_str(self.slice_with_parens(expr, parent)),
+        }
+    }
+
+    /// Writes `elts` joined by `", "` into `buf`, optionally wrapped
+    /// in a bracket pair and optionally followed by a trailing comma.
+    /// The trailing comma carries the 1-tuple `(x,)` case.
+    fn write_inline_seq(
+        &self,
+        buf: &mut String,
+        brackets: Option<(char, char)>,
+        elts: &[Expr],
+        parent: AnyNodeRef,
+        trailing_comma: bool,
+    ) {
+        if let Some((open, _)) = brackets {
+            buf.push(open);
+        }
+        for (i, e) in elts.iter().enumerate() {
+            if i > 0 {
+                buf.push_str(", ");
+            }
+            self.write_inline(buf, e, parent);
+        }
+        if trailing_comma {
+            buf.push(',');
+        }
+        if let Some((_, close)) = brackets {
+            buf.push(close);
+        }
     }
 }
 
-impl<'a> Visitor<'a> for Expander<'a> {
+impl<'a> Visitor<'a> for Layouter<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         let range = expr.range();
-        if !self.should_expand(expr, self.source.column_of(range.start())) {
-            walk_expr(self, expr);
-            return;
-        }
+        let column = self.source.column_of(range.start());
         let indent = self.source.line_indent_width(range.start());
-        let replacement = self.expand(expr, indent);
-        self.edits
-            .extend(narrowed_replacement(self.source, range, replacement));
+        match self.replacement_for(expr, column, indent) {
+            Some(text) => self
+                .edits
+                .extend(narrowed_replacement(self.source, range, text)),
+            None => walk_expr(self, expr),
+        }
     }
 }
 
@@ -333,6 +428,18 @@ fn is_atomic(expr: &Expr) -> bool {
         e.as_unary_op_expr().map(|u| u.operand.as_ref())
     })
     .any(|e| e.is_literal_expr() || is_dotted_name(e))
+}
+
+/// True when `expr` is a multi-item `Dict`, `List`, or `Set`, the
+/// shape the expand path canonicalizes. Tuples and single-item
+/// collections collapse only, never expand.
+fn requires_expand(expr: &Expr) -> bool {
+    match expr {
+        Expr::Dict(d) => d.len() > 1,
+        Expr::List(l) => l.len() > 1,
+        Expr::Set(s) => s.len() > 1,
+        _ => false,
+    }
 }
 
 /// Partitions `atomics` into segments. Every contiguous run of

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -61,6 +61,17 @@ impl Rule for CollectionLayout {
     }
 }
 
+/// Per-item state collected from a dict, list, or set literal:
+/// serialized text, atomicity for layout dispatch, and source range
+/// for blank-line-preservation lookups.
+struct GatheredItems<'src> {
+    atomics: Vec<bool>,
+    close: char,
+    open: char,
+    ranges: Vec<TextRange>,
+    texts: Vec<Cow<'src, str>>,
+}
+
 struct Layouter<'a> {
     code_line_length: usize,
     edits: Vec<Edit>,
@@ -71,7 +82,7 @@ struct Layouter<'a> {
 
 impl<'a> Layouter<'a> {
     /// Builds the expanded form of `expr` as a string, recursively
-    /// expanding any qualifying child collections.
+    /// laying out any qualifying child collections.
     fn expand(&self, expr: &Expr, indent: usize) -> String {
         let item_indent = indent + INDENT_STEP;
         let GatheredItems {
@@ -186,13 +197,12 @@ impl<'a> Layouter<'a> {
         buf
     }
 
-    /// Returns the replacement text the rule wants to emit for
-    /// `expr`, or `None` when the visitor should descend into its
-    /// children. `column` is where `expr` actually begins; `indent`
-    /// is where its closing bracket should land if it expands. `None`
-    /// covers non-collection nodes, comment-pinned literals,
-    /// single-line literals that fit, and multi-line tuples or
-    /// single-item dict/list/set whose inline form does not fit.
+    /// Returns the canonical rewrite for `expr` against the budget at
+    /// `column`, or `None` when the visitor should descend into its
+    /// children. `indent` is where the closing bracket lands if `expr`
+    /// expands. Emits `Some(inline)` when a multi-line literal's
+    /// inline form fits, `Some(expand)` when a multi-item `Dict`,
+    /// `List`, or `Set`'s rendered width overflows.
     fn replacement_for(&self, expr: &Expr, column: usize, indent: usize) -> Option<String> {
         if !matches!(
             expr,
@@ -224,7 +234,7 @@ impl<'a> Layouter<'a> {
     /// the enclosing dict). The value's actual column for the
     /// `code-line-length` check is offset by the key text plus `": "`, so a
     /// long key that pushes its value past the budget correctly
-    /// triggers expansion of the value. When the value does expand,
+    /// triggers a re-layout of the value. When the value does expand,
     /// its closing bracket still lands at `indent`. When the value
     /// passes through borrowed and the source carries an
     /// `align-colons`-shaped gap (`[ ]*: `), the item's source slice
@@ -334,9 +344,8 @@ impl<'a> Layouter<'a> {
         parent: AnyNodeRef,
         trailing_comma: bool,
     ) {
-        if let Some((open, _)) = brackets {
-            buf.push(open);
-        }
+        let (open, close) = brackets.unzip();
+        buf.extend(open);
         for (i, e) in elts.iter().enumerate() {
             if i > 0 {
                 buf.push_str(", ");
@@ -346,9 +355,7 @@ impl<'a> Layouter<'a> {
         if trailing_comma {
             buf.push(',');
         }
-        if let Some((_, close)) = brackets {
-            buf.push(close);
-        }
+        buf.extend(close);
     }
 }
 
@@ -364,17 +371,6 @@ impl<'a> Visitor<'a> for Layouter<'a> {
             None => walk_expr(self, expr),
         }
     }
-}
-
-/// Per-item state collected from a dict, list, or set literal:
-/// serialized text, atomicity for layout dispatch, and source range
-/// for blank-line-preservation lookups.
-struct GatheredItems<'src> {
-    atomics: Vec<bool>,
-    close: char,
-    open: char,
-    ranges: Vec<TextRange>,
-    texts: Vec<Cow<'src, str>>,
 }
 
 /// Describes how a contiguous slice of items should lay out.

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -104,13 +104,12 @@ impl<'a> Layouter<'a> {
                     for idx in range {
                         out.push_str(&item_prefix);
                         out.push_str(&texts[idx]);
-                        if idx + 1 < total {
+                        let has_more = idx + 1 < total;
+                        if has_more {
                             out.push(',');
                         }
                         out.push_str(self.newline);
-                        if idx + 1 < total
-                            && self.source.has_blank_line_before(ranges[idx + 1].start())
-                        {
+                        if has_more && self.source.has_blank_line_before(ranges[idx + 1].start()) {
                             out.push_str(self.newline);
                         }
                     }
@@ -204,27 +203,22 @@ impl<'a> Layouter<'a> {
     /// inline form fits, `Some(expand)` when a multi-item `Dict`,
     /// `List`, or `Set`'s rendered width overflows.
     fn replacement_for(&self, expr: &Expr, column: usize, indent: usize) -> Option<String> {
-        if !matches!(
-            expr,
-            Expr::Dict(_) | Expr::List(_) | Expr::Set(_) | Expr::Tuple(_),
-        ) {
+        if !is_layoutable(expr) {
             return None;
         }
         let range = expr.range();
         if self.source.intersects_comment(range) {
             return None;
         }
+        let expandable = requires_expand(expr);
         if self.source.contains_line_break(range) {
             let inline = self.inline_form(expr);
             if column + inline.width() <= self.code_line_length {
                 return Some(inline);
             }
-            if requires_expand(expr) {
-                return Some(self.expand(expr, indent));
-            }
-            return None;
+            return expandable.then(|| self.expand(expr, indent));
         }
-        (requires_expand(expr) && column + self.source.slice(range).width() > self.code_line_length)
+        (expandable && column + self.source.slice(range).width() > self.code_line_length)
             .then(|| self.expand(expr, indent))
     }
 
@@ -360,6 +354,10 @@ impl<'a> Layouter<'a> {
 
 impl<'a> Visitor<'a> for Layouter<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
+        if !is_layoutable(expr) {
+            walk_expr(self, expr);
+            return;
+        }
         let range = expr.range();
         let column = self.source.column_of(range.start());
         let indent = self.source.line_indent_width(range.start());
@@ -423,6 +421,13 @@ fn is_atomic(expr: &Expr) -> bool {
         e.as_unary_op_expr().map(|u| u.operand.as_ref())
     })
     .any(|e| e.is_literal_expr() || is_dotted_name(e))
+}
+
+/// True for the four collection-literal `Expr` variants the rule
+/// considers laying out. `Tuple` joins `Dict`, `List`, and `Set` here
+/// because it's collapse-eligible, even though it never expands.
+fn is_layoutable(expr: &Expr) -> bool {
+    matches!(expr, Expr::Dict(_) | Expr::List(_) | Expr::Set(_) | Expr::Tuple(_))
 }
 
 /// True when `expr` is a multi-item `Dict`, `List`, or `Set`, the

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -12,7 +12,7 @@ use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::visitor::{walk_expr, Visitor};
-use ruff_python_ast::{AnyNodeRef, DictItem, Expr};
+use ruff_python_ast::{AnyNodeRef, DictItem, Expr, ExprDict};
 use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 
@@ -266,18 +266,10 @@ impl<'a> Layouter<'a> {
     }
 
     /// Serializes `expr` into a child slot of an enclosing expand.
-    /// Dispatches through `replacement_for`, so a multi-line child
-    /// whose inline form fits collapses, a single-line child that
-    /// overflows expands, and anything else passes through as a
-    /// borrowed source slice with explicit parentheses recovered.
-    ///
-    /// `column` is where the expression actually begins on its line.
-    /// `indent` is where its closing bracket should land if it
-    /// expands. They differ for dict values, where the key text sits
-    /// between the line indent and the value's own starting column.
-    /// `parent` is the immediate enclosing collection, used to
-    /// recover any explicit parentheses around `expr` that
-    /// `expr.range()` would otherwise drop.
+    /// Dispatches through `replacement_for`, falling back to a
+    /// paren-recovered source slice when no rewrite applies.
+    /// `column` and `indent` differ for dict values, where the key
+    /// text sits between the line indent and the value's own start.
     fn serialize_expr(
         &self,
         expr: &Expr,
@@ -307,22 +299,7 @@ impl<'a> Layouter<'a> {
     fn write_inline(&self, buf: &mut String, expr: &Expr, parent: AnyNodeRef) {
         let here = AnyNodeRef::from(expr);
         match expr {
-            Expr::Dict(d) => {
-                buf.push('{');
-                for (i, item) in d.iter().enumerate() {
-                    if i > 0 {
-                        buf.push_str(", ");
-                    }
-                    if let Some(key) = &item.key {
-                        self.write_inline(buf, key, here);
-                        buf.push_str(": ");
-                    } else {
-                        buf.push_str("**");
-                    }
-                    self.write_inline(buf, &item.value, here);
-                }
-                buf.push('}');
-            }
+            Expr::Dict(d) => self.write_inline_dict(buf, d, here),
             Expr::List(l) => self.write_inline_seq(buf, Some(('[', ']')), &l.elts, here, false),
             Expr::Set(s) => self.write_inline_seq(buf, Some(('{', '}')), &s.elts, here, false),
             Expr::Tuple(t) => {
@@ -331,6 +308,28 @@ impl<'a> Layouter<'a> {
             }
             _ => buf.push_str(self.slice_with_parens(expr, parent)),
         }
+    }
+
+    /// Writes `d`'s inline serialization into `buf` as `{k: v, ...}`,
+    /// emitting `**v` for `None`-keyed unpacking items. `parent` is
+    /// the dict itself, threaded into each child's `write_inline` for
+    /// paren recovery on non-collection leaves.
+    fn write_inline_dict(&self, buf: &mut String, d: &ExprDict, parent: AnyNodeRef) {
+        buf.push('{');
+        for (i, item) in d.iter().enumerate() {
+            if i > 0 {
+                buf.push_str(", ");
+            }
+            match &item.key {
+                Some(key) => {
+                    self.write_inline(buf, key, parent);
+                    buf.push_str(": ");
+                }
+                None => buf.push_str("**"),
+            }
+            self.write_inline(buf, &item.value, parent);
+        }
+        buf.push('}');
     }
 
     /// Writes `elts` joined by `", "` into `buf`, optionally wrapped

--- a/tests/fixtures/collection_layout/comprehensions.input.py
+++ b/tests/fixtures/collection_layout/comprehensions.input.py
@@ -1,8 +1,8 @@
 """
-Comprehensions are not literals and stay inline. `item_count` only
-matches `Expr::Dict`, `Expr::List`, and `Expr::Set`, so `ListComp`,
-`DictComp`, `SetComp`, and `GeneratorExp` fall through `should_expand`
-and the visitor keeps descending through their bodies without rewrite.
+Comprehensions are not literals and stay inline. `replacement_for` only
+matches `Expr::Dict`, `Expr::List`, `Expr::Set`, and `Expr::Tuple`, so
+`ListComp`, `DictComp`, `SetComp`, and `GeneratorExp` return `None` and
+the visitor keeps descending through their bodies without rewrite.
 """
 
 list_comp = [x * 2 for x in range(10)]

--- a/tests/fixtures/collection_layout/dict_literal.input.py
+++ b/tests/fixtures/collection_layout/dict_literal.input.py
@@ -1,12 +1,9 @@
 """
-A multi-item dict literal stays inline when the whole line fits in
-the 88-character budget. A dict whose inline form would overflow the
-budget expands with each `key: value` entry on its own line. A
-multi-line dict whose assembled inline form fits collapses back to
-one line, the single-entry dict being the most reduced canonical
-case. Dict items are never flow-packed regardless of how simple the
-key and value are, because the pair itself carries structure and
-downstream `align_colons` needs rows to align across.
+A multi-item dict stays inline when its inline form fits the
+budget. A dict whose inline form overflows expands one `key: value`
+entry per line, never flow-packed because each row needs to pin
+its `:` for the downstream `align_colons` rule. A multi-line dict
+whose inline form fits collapses back to one line.
 """
 
 short_dict = {"alpha": 1, "beta": 2, "gamma": 3}

--- a/tests/fixtures/collection_layout/dict_literal.input.py
+++ b/tests/fixtures/collection_layout/dict_literal.input.py
@@ -1,11 +1,21 @@
 """
 A multi-item dict literal stays inline when the whole line fits in
 the 88-character budget. A dict whose inline form would overflow the
-budget expands with each `key: value` entry on its own line. Dict
-items are never flow-packed regardless of how simple the key and
-value are, because the pair itself carries structure and downstream
-`align_colons` needs rows to align across.
+budget expands with each `key: value` entry on its own line. A
+multi-line dict whose assembled inline form fits collapses back to
+one line, the single-entry dict being the most reduced canonical
+case. Dict items are never flow-packed regardless of how simple the
+key and value are, because the pair itself carries structure and
+downstream `align_colons` needs rows to align across.
 """
 
 short_dict = {"alpha": 1, "beta": 2, "gamma": 3}
 long_dict = {"alpha": 1, "beta": 2, "gamma": 3, "delta": 4, "epsilon": 5, "zeta": 6, "eta": 7}
+single_entry_dict = {
+    "default_action": "noop"
+}
+collapsing_dict = {
+    "alpha": 1,
+    "beta": 2,
+    "gamma": 3
+}

--- a/tests/fixtures/collection_layout/idempotent.input.py
+++ b/tests/fixtures/collection_layout/idempotent.input.py
@@ -1,12 +1,18 @@
 """
-An already-canonically-expanded collection produces no edit on a
-second pass. Multi-line input always takes the expansion path, but
-when the canonical output matches the input verbatim the rule emits
-no `Edit::range_replacement` at all.
+A canonical-inline collection and a canonical-multi-line collection
+both produce no edit. Inline canonicality holds when the literal
+already fits at its column. Multi-line canonicality holds when the
+assembled inline form overflows the budget so the rule keeps the
+expanded shape.
 """
 
-config = {
+canonical_inline = {"alpha": 1, "beta": 2, "gamma": 3}
+canonical_multi_line = {
     "alpha": 1,
     "beta": 2,
-    "gamma": 3
+    "gamma": 3,
+    "delta": 4,
+    "epsilon": 5,
+    "zeta": 6,
+    "eta": 7
 }

--- a/tests/fixtures/collection_layout/list_literal.input.py
+++ b/tests/fixtures/collection_layout/list_literal.input.py
@@ -4,7 +4,16 @@ the 88-character budget. A list whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
 across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
+A multi-line list whose assembled inline form fits collapses back to
+one line.
 """
 
 short_list = [2, 3, 5, 7, 11, 13]
 long_list = ["San Francisco", "Los Angeles", "New York", "Chicago", "Boston", "Seattle", "Miami"]
+collapsing_list = [
+    2,
+    3,
+    5,
+    7,
+    11
+]

--- a/tests/fixtures/collection_layout/nested.input.py
+++ b/tests/fixtures/collection_layout/nested.input.py
@@ -5,10 +5,30 @@ qualifying child inside a non-qualifying parent expands via `walk_expr`
 falling through into the parent's descendants. Each child's
 `code-line-length` check uses its own column, including the key-offset for
 dict values, so tiered structures expand level-by-level only where
-the inline form would overflow.
+the inline form would overflow. Nesting precedence on collapse runs
+outermost-first: when an outer multi-line literal fits inline its
+inner literals move with it, and when the outer is pinned by its own
+width the inner runs its collapse decision against its own column.
 """
 
 cascade = [{"name": "alice_wonderland_the_explorer", "role": "administrator", "email": "alice.wonderland@example-company-domain.com"}, {"name": "bob", "role": "user"}]
 tiered_dict = {"primary_database": {"host": "very-long-hostname.example.com", "port": 5432, "username": "admin", "password": "secret"}, "cache": {"ttl": 60}}
 shallow_dict_in_dict = {"connection": {"host": "localhost", "port": 5432}, "cache": {"ttl": 60, "size": 1024}}
 walks_through_singleton = [{"key_alpha": 1, "key_beta": 2, "key_gamma": 3, "key_delta": 4, "key_epsilon": 5, "key_zeta": 6}]
+outer_collapses_with_inner = [
+    1,
+    [
+        2,
+        3
+    ],
+    4
+]
+outer_pinned_inner_collapses = [
+    "first long string that pushes past the inline-form budget for the outer list",
+    [
+        2,
+        3,
+        5
+    ],
+    "another long string padding outer past the budget so the outer cannot collapse"
+]

--- a/tests/fixtures/collection_layout/nested.input.py
+++ b/tests/fixtures/collection_layout/nested.input.py
@@ -1,14 +1,10 @@
 """
-Nested collections expand independently. A qualifying child serializes
-through the parent's `expand` when the parent also qualifies. A
-qualifying child inside a non-qualifying parent expands via `walk_expr`
-falling through into the parent's descendants. Each child's
-`code-line-length` check uses its own column, including the key-offset for
-dict values, so tiered structures expand level-by-level only where
-the inline form would overflow. Nesting precedence on collapse runs
-outermost-first: when an outer multi-line literal fits inline its
-inner literals move with it, and when the outer is pinned by its own
-width the inner runs its collapse decision against its own column.
+Nested collections each run their own layout decision at their own
+column position. An outer literal's rewrite drags its inners along,
+whereas a pinned outer leaves each inner to its own pass. Dict-value
+nesting includes the key-text offset in the inner's column, so a
+long key can push its value past the budget even when the outer
+fits.
 """
 
 cascade = [{"name": "alice_wonderland_the_explorer", "role": "administrator", "email": "alice.wonderland@example-company-domain.com"}, {"name": "bob", "role": "user"}]

--- a/tests/fixtures/collection_layout/parenthesized_children.input.py
+++ b/tests/fixtures/collection_layout/parenthesized_children.input.py
@@ -1,9 +1,13 @@
 """
 Parenthesized child expressions inside a multi-item list keep their
-explicit parens through expansion. Without `parenthesized_range`,
-slicing each child's `range()` would drop the parens and turn
-`(-a) ** 2` into `-a ** 2`, which Python parses as `-(a ** 2)` and
-flips the sign of the result.
+explicit parens through both expansion and collapse. Without
+`parenthesized_range`, slicing each child's `range()` would drop
+the parens and turn `(-a) ** 2` into `-a ** 2`, which Python parses
+as `-(a ** 2)` and flips the sign of the result.
 """
 
 precedence = [(-a) ** 2, (b + c) ** 3, (d - e) ** 4, (f * g) ** 5, (h / i) ** 6, (j + k) ** 7, (l - m) ** 8]
+short_precedence = [
+    (-a) ** 2,
+    (b + c) ** 3
+]

--- a/tests/fixtures/collection_layout/set_literal.input.py
+++ b/tests/fixtures/collection_layout/set_literal.input.py
@@ -4,7 +4,14 @@ the 88-character budget. A set whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
 across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
+A multi-line set whose assembled inline form fits collapses back to
+one line.
 """
 
 short_set = {"read", "write", "execute"}
 long_set = {"read", "write", "execute", "delete", "admin", "owner", "moderator", "guest", "root"}
+collapsing_set = {
+    "read",
+    "write",
+    "execute"
+}

--- a/tests/fixtures/collection_layout/single_item.input.py
+++ b/tests/fixtures/collection_layout/single_item.input.py
@@ -1,8 +1,12 @@
 """
-Single-item and empty literals keep their original inline form
-regardless of line length. `item_count` returns `Some(0)` or
-`Some(1)` for these cases, both of which short-circuit
-`should_expand` ahead of the `code-line-length` check.
+Single-item and empty literals keep their inline form regardless of
+line length. A multi-line single-item literal collapses to its
+canonical inline form, the spec's `SETTINGS = {"default_action":
+"noop"}` case being the most reduced. Empty literals spread across
+multiple lines collapse to their bare-bracket form. A multi-line
+single-item literal whose inline form overflows stays multi-line
+because the rule's expand path only canonicalizes multi-item
+collections.
 """
 
 only_list  = [42]
@@ -10,3 +14,14 @@ only_dict  = {"solitary": 1}
 only_set   = {42}
 empty_list = []
 empty_dict = {}
+collapsing_one_entry_dict = {
+    "default_action": "noop"
+}
+collapsing_one_item_list = [
+    42
+]
+collapsing_empty_dict = {
+}
+oversized_one_entry_dict = {
+    "extremely_long_configuration_key_for_the_settings_table": "a_descriptive_value"
+}

--- a/tests/fixtures/collection_layout/tuples.input.py
+++ b/tests/fixtures/collection_layout/tuples.input.py
@@ -1,11 +1,22 @@
 """
-Tuples are out of scope for this rule. `Expr::Tuple` is not matched
-by `item_count`, so a multi-item tuple stays inline whether it is
-parenthesized or bare. The visitor still descends through the
-tuple's elements via `walk_expr`, so a qualifying inner collection
-inside a tuple expands when it overflows the budget at its own column.
+A multi-line tuple whose assembled inline form fits collapses back to
+one line, preserving its source-level bracket shape: a parenthesized
+tuple keeps its parens, a bare tuple stays bare, and a one-element
+tuple keeps its trailing comma. Single-line tuples are left alone
+because the expand path does not handle tuples, only the collapse
+path does. The visitor still descends through a tuple's elements, so
+a qualifying inner collection inside an inline tuple expands when it
+overflows the budget at its own column.
 """
 
 paren_tuple = (1, 2, 3)
 bare_tuple = 4, 5, 6
+collapsing_paren_tuple = (
+    1,
+    2,
+    3
+)
+collapsing_one_element = (
+    42,
+)
 qualifying_inner_in_tuple = (1, {"first_key": 100, "second_key": 200, "third_key": 300, "fourth_key": 400, "fifth_key": 500}, 3)

--- a/tests/fixtures/collection_layout/unpacking.input.py
+++ b/tests/fixtures/collection_layout/unpacking.input.py
@@ -6,9 +6,16 @@ dict's other entries. Starred expressions in list and set elts slice
 through the `Expr::Starred` range verbatim. They are non-atomic, so
 a spread in the middle of a list splits its surrounding atomics into
 two independent runs that each flow on their own, and a set made
-entirely of spreads goes one entry per line.
+entirely of spreads goes one entry per line. A multi-line dict with
+a `**` spread whose inline form fits collapses back to one line and
+the spread renders inline as `**value`.
 """
 
 dict_unpack = {"alpha": 1, **extra_config, "beta": 2, "gamma": 3, "delta": 4, "epsilon": 5, "zeta": 6}
 list_unpack = [1, 2, 3, *middle_range, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200]
 set_unpack = {*alpha_set, *beta_set, *gamma_set, *delta_set, *epsilon_set, *zeta_set, *eta_set}
+collapsing_dict_unpack = {
+    "alpha": 1,
+    **extra_config,
+    "beta": 2
+}

--- a/tests/fixtures/collection_layout/with_comments.input.py
+++ b/tests/fixtures/collection_layout/with_comments.input.py
@@ -1,14 +1,29 @@
 """
-A literal whose source range contains a comment is left alone to
-preserve author-intended prose that slicing would drop. A trailing
-comment outside the literal's range still allows the literal to
-expand when the inline form overflows. Atomic items inside the
-expanded form flow across balanced lines.
+A literal whose source range contains a comment in any attachment
+position is left alone to preserve author-intended prose that the
+collapse would drop. Own-line comments between entries, trailing
+comments on an entry, and comments before the closing bracket all
+pin the multi-line shape. A trailing comment outside the literal's
+range still allows the literal to expand when the inline form
+overflows. Atomic items inside the expanded form flow across
+balanced lines.
 """
 
-keeps_interior_comment = [
+own_line_comment_between_entries = [
+    1,
+    # explanatory
+    2,
+    3,
+]
+trailing_comment_on_entry = [
     1,
     2,  # noqa: E501
     3,
+]
+comment_before_close = [
+    1,
+    2,
+    3,
+    # closing note
 ]
 trailing_comment_expands = ["first", "second", "third", "fourth", "fifth", "sixth", "seventh"]  # sits after `]`

--- a/tests/fixtures/composition/function_with_dict_default.config.toml
+++ b/tests/fixtures/composition/function_with_dict_default.config.toml
@@ -1,0 +1,2 @@
+[harness]
+rules = ["collection-layout", "align-colons", "signature-layout"]

--- a/tests/fixtures/composition/function_with_dict_default.input.py
+++ b/tests/fixtures/composition/function_with_dict_default.input.py
@@ -1,0 +1,21 @@
+"""
+A function default argument is a multi-line dict literal whose
+collapsed inline form keeps the whole signature under
+`Config::code_line_length`. `collection_layout` collapses the dict,
+`align_colons` no longer applies because the dict is now single-line,
+and `signature_layout` sees the shortened signature line and leaves
+it inline rather than expanding to one-parameter-per-line. The full
+pipeline running twice produces no further change.
+
+Rules:
+- collection-layout
+- align-colons
+- signature-layout
+"""
+
+
+def configure(timeout=30, options={
+    "alpha" : 1,
+    "beta"  : 2
+}, verbose=True):
+    return (timeout, options, verbose)

--- a/tests/fixtures/thematic/align_padded_dict_collapses.input.py
+++ b/tests/fixtures/thematic/align_padded_dict_collapses.input.py
@@ -1,0 +1,15 @@
+"""
+Cross-rule composition over a multi-line dict carrying
+`align_colons`-shaped padding whose inline form fits the budget.
+`collection_layout`'s collapse strips the padding when emitting the
+inline form, because `write_inline` always emits `": "` without
+honoring the source's `[ ]*: ` gap. `align_colons` does not re-pad
+after collapse because the inline dict lives on one line. The full
+pipeline running twice produces no further change.
+"""
+
+config = {
+    "alpha" : 1,
+    "beta"  : 2,
+    "gamma" : 3,
+}

--- a/tests/fixtures/thematic/match_dispatch.input.py
+++ b/tests/fixtures/thematic/match_dispatch.input.py
@@ -3,9 +3,9 @@ Cross-rule composition over a match statement: match_case_align
 splits the three arms whose collapsed form would exceed 88 columns
 and collapses the under-budget fallback arm, alphabetize sorts the
 kwargs inside the dispatched calls, strip_trailing_commas removes
-the dangling commas the source carries, and the singleton rule
-strips the lone-key dict's pre-`:` padding. The full pipeline
-running twice produces no further change.
+the dangling commas the source carries, and collection_layout
+collapses the lone-key SETTINGS dict back to one line. The full
+pipeline running twice produces no further change.
 """
 
 def dispatch(event):

--- a/tests/snapshots/collection_layout/comprehensions.input.py.snap
+++ b/tests/snapshots/collection_layout/comprehensions.input.py.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/comprehensions.input.py
 ---
 """
-Comprehensions are not literals and stay inline. `item_count` only
-matches `Expr::Dict`, `Expr::List`, and `Expr::Set`, so `ListComp`,
-`DictComp`, `SetComp`, and `GeneratorExp` fall through `should_expand`
-and the visitor keeps descending through their bodies without rewrite.
+Comprehensions are not literals and stay inline. `replacement_for` only
+matches `Expr::Dict`, `Expr::List`, `Expr::Set`, and `Expr::Tuple`, so
+`ListComp`, `DictComp`, `SetComp`, and `GeneratorExp` return `None` and
+the visitor keeps descending through their bodies without rewrite.
 """
 
 list_comp = [x * 2 for x in range(10)]

--- a/tests/snapshots/collection_layout/dict_literal.diagnostics.snap
+++ b/tests/snapshots/collection_layout/dict_literal.diagnostics.snap
@@ -3,6 +3,6 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/dict_literal.input.py
 ---
-collection-layout@589..669
-collection-layout@692..722
-collection-layout@743..790
+collection-layout@381..461
+collection-layout@484..514
+collection-layout@535..582

--- a/tests/snapshots/collection_layout/dict_literal.diagnostics.snap
+++ b/tests/snapshots/collection_layout/dict_literal.diagnostics.snap
@@ -3,4 +3,6 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/dict_literal.input.py
 ---
-collection-layout@449..529
+collection-layout@589..669
+collection-layout@692..722
+collection-layout@743..790

--- a/tests/snapshots/collection_layout/dict_literal.input.py.snap
+++ b/tests/snapshots/collection_layout/dict_literal.input.py.snap
@@ -1,15 +1,17 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/dict_literal.input.py
 ---
 """
 A multi-item dict literal stays inline when the whole line fits in
 the 88-character budget. A dict whose inline form would overflow the
-budget expands with each `key: value` entry on its own line. Dict
-items are never flow-packed regardless of how simple the key and
-value are, because the pair itself carries structure and downstream
-`align_colons` needs rows to align across.
+budget expands with each `key: value` entry on its own line. A
+multi-line dict whose assembled inline form fits collapses back to
+one line, the single-entry dict being the most reduced canonical
+case. Dict items are never flow-packed regardless of how simple the
+key and value are, because the pair itself carries structure and
+downstream `align_colons` needs rows to align across.
 """
 
 short_dict = {"alpha": 1, "beta": 2, "gamma": 3}
@@ -22,3 +24,5 @@ long_dict = {
     "zeta": 6,
     "eta": 7
 }
+single_entry_dict = {"default_action": "noop"}
+collapsing_dict = {"alpha": 1, "beta": 2, "gamma": 3}

--- a/tests/snapshots/collection_layout/dict_literal.input.py.snap
+++ b/tests/snapshots/collection_layout/dict_literal.input.py.snap
@@ -4,14 +4,11 @@ expression: output
 input_file: tests/fixtures/collection_layout/dict_literal.input.py
 ---
 """
-A multi-item dict literal stays inline when the whole line fits in
-the 88-character budget. A dict whose inline form would overflow the
-budget expands with each `key: value` entry on its own line. A
-multi-line dict whose assembled inline form fits collapses back to
-one line, the single-entry dict being the most reduced canonical
-case. Dict items are never flow-packed regardless of how simple the
-key and value are, because the pair itself carries structure and
-downstream `align_colons` needs rows to align across.
+A multi-item dict stays inline when its inline form fits the
+budget. A dict whose inline form overflows expands one `key: value`
+entry per line, never flow-packed because each row needs to pin
+its `:` for the downstream `align_colons` rule. A multi-line dict
+whose inline form fits collapses back to one line.
 """
 
 short_dict = {"alpha": 1, "beta": 2, "gamma": 3}

--- a/tests/snapshots/collection_layout/idempotent.input.py.snap
+++ b/tests/snapshots/collection_layout/idempotent.input.py.snap
@@ -1,17 +1,23 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/idempotent.input.py
 ---
 """
-An already-canonically-expanded collection produces no edit on a
-second pass. Multi-line input always takes the expansion path, but
-when the canonical output matches the input verbatim the rule emits
-no `Edit::range_replacement` at all.
+A canonical-inline collection and a canonical-multi-line collection
+both produce no edit. Inline canonicality holds when the literal
+already fits at its column. Multi-line canonicality holds when the
+assembled inline form overflows the budget so the rule keeps the
+expanded shape.
 """
 
-config = {
+canonical_inline = {"alpha": 1, "beta": 2, "gamma": 3}
+canonical_multi_line = {
     "alpha": 1,
     "beta": 2,
-    "gamma": 3
+    "gamma": 3,
+    "delta": 4,
+    "epsilon": 5,
+    "zeta": 6,
+    "eta": 7
 }

--- a/tests/snapshots/collection_layout/list_literal.diagnostics.snap
+++ b/tests/snapshots/collection_layout/list_literal.diagnostics.snap
@@ -3,4 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/list_literal.input.py
 ---
-collection-layout@408..491
+collection-layout@487..570
+collection-layout@591..627

--- a/tests/snapshots/collection_layout/list_literal.input.py.snap
+++ b/tests/snapshots/collection_layout/list_literal.input.py.snap
@@ -9,9 +9,12 @@ the 88-character budget. A list whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
 across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
+A multi-line list whose assembled inline form fits collapses back to
+one line.
 """
 
 short_list = [2, 3, 5, 7, 11, 13]
 long_list = [
     "San Francisco", "Los Angeles", "New York", "Chicago", "Boston", "Seattle", "Miami"
 ]
+collapsing_list = [2, 3, 5, 7, 11]

--- a/tests/snapshots/collection_layout/nested.diagnostics.snap
+++ b/tests/snapshots/collection_layout/nested.diagnostics.snap
@@ -3,9 +3,9 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/nested.input.py
 ---
-collection-layout@1038..1123
-collection-layout@1153..1247
-collection-layout@1280..1328
-collection-layout@1452..1489
-collection-layout@699..854
-collection-layout@871..1012
+collection-layout@1112..1149
+collection-layout@359..514
+collection-layout@531..672
+collection-layout@698..783
+collection-layout@813..907
+collection-layout@940..988

--- a/tests/snapshots/collection_layout/nested.diagnostics.snap
+++ b/tests/snapshots/collection_layout/nested.diagnostics.snap
@@ -3,7 +3,9 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/nested.input.py
 ---
-collection-layout@461..616
-collection-layout@633..774
-collection-layout@800..885
-collection-layout@915..1009
+collection-layout@1038..1123
+collection-layout@1153..1247
+collection-layout@1280..1328
+collection-layout@1452..1489
+collection-layout@699..854
+collection-layout@871..1012

--- a/tests/snapshots/collection_layout/nested.input.py.snap
+++ b/tests/snapshots/collection_layout/nested.input.py.snap
@@ -10,7 +10,10 @@ qualifying child inside a non-qualifying parent expands via `walk_expr`
 falling through into the parent's descendants. Each child's
 `code-line-length` check uses its own column, including the key-offset for
 dict values, so tiered structures expand level-by-level only where
-the inline form would overflow.
+the inline form would overflow. Nesting precedence on collapse runs
+outermost-first: when an outer multi-line literal fits inline its
+inner literals move with it, and when the outer is pinned by its own
+width the inner runs its collapse decision against its own column.
 """
 
 cascade = [
@@ -42,3 +45,9 @@ walks_through_singleton = [{
     "key_epsilon": 5,
     "key_zeta": 6
 }]
+outer_collapses_with_inner = [1, [2, 3], 4]
+outer_pinned_inner_collapses = [
+    "first long string that pushes past the inline-form budget for the outer list",
+    [2, 3, 5],
+    "another long string padding outer past the budget so the outer cannot collapse"
+]

--- a/tests/snapshots/collection_layout/nested.input.py.snap
+++ b/tests/snapshots/collection_layout/nested.input.py.snap
@@ -4,16 +4,12 @@ expression: output
 input_file: tests/fixtures/collection_layout/nested.input.py
 ---
 """
-Nested collections expand independently. A qualifying child serializes
-through the parent's `expand` when the parent also qualifies. A
-qualifying child inside a non-qualifying parent expands via `walk_expr`
-falling through into the parent's descendants. Each child's
-`code-line-length` check uses its own column, including the key-offset for
-dict values, so tiered structures expand level-by-level only where
-the inline form would overflow. Nesting precedence on collapse runs
-outermost-first: when an outer multi-line literal fits inline its
-inner literals move with it, and when the outer is pinned by its own
-width the inner runs its collapse decision against its own column.
+Nested collections each run their own layout decision at their own
+column position. An outer literal's rewrite drags its inners along,
+whereas a pinned outer leaves each inner to its own pass. Dict-value
+nesting includes the key-text offset in the inner's column, so a
+long key can push its value past the budget even when the outer
+fits.
 """
 
 cascade = [

--- a/tests/snapshots/collection_layout/parenthesized_children.diagnostics.snap
+++ b/tests/snapshots/collection_layout/parenthesized_children.diagnostics.snap
@@ -3,4 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/parenthesized_children.input.py
 ---
-collection-layout@316..409
+collection-layout@334..427
+collection-layout@449..482

--- a/tests/snapshots/collection_layout/parenthesized_children.input.py.snap
+++ b/tests/snapshots/collection_layout/parenthesized_children.input.py.snap
@@ -1,14 +1,14 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/parenthesized_children.input.py
 ---
 """
 Parenthesized child expressions inside a multi-item list keep their
-explicit parens through expansion. Without `parenthesized_range`,
-slicing each child's `range()` would drop the parens and turn
-`(-a) ** 2` into `-a ** 2`, which Python parses as `-(a ** 2)` and
-flips the sign of the result.
+explicit parens through both expansion and collapse. Without
+`parenthesized_range`, slicing each child's `range()` would drop
+the parens and turn `(-a) ** 2` into `-a ** 2`, which Python parses
+as `-(a ** 2)` and flips the sign of the result.
 """
 
 precedence = [
@@ -20,3 +20,4 @@ precedence = [
     (j + k) ** 7,
     (l - m) ** 8
 ]
+short_precedence = [(-a) ** 2, (b + c) ** 3]

--- a/tests/snapshots/collection_layout/set_literal.diagnostics.snap
+++ b/tests/snapshots/collection_layout/set_literal.diagnostics.snap
@@ -3,4 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/set_literal.input.py
 ---
-collection-layout@412..496
+collection-layout@490..574
+collection-layout@594..634

--- a/tests/snapshots/collection_layout/set_literal.input.py.snap
+++ b/tests/snapshots/collection_layout/set_literal.input.py.snap
@@ -9,6 +9,8 @@ the 88-character budget. A set whose inline form would overflow the
 budget expands. Inside the expanded form, a run of atomic items flows
 across as few balanced lines as fit under the `code-line-length` budget and
 the `max_atomics_per_line` cap (default 8) at the item-indent column.
+A multi-line set whose assembled inline form fits collapses back to
+one line.
 """
 
 short_set = {"read", "write", "execute"}
@@ -16,3 +18,4 @@ long_set = {
     "read", "write", "execute", "delete", "admin",
     "owner", "moderator", "guest", "root"
 }
+collapsing_set = {"read", "write", "execute"}

--- a/tests/snapshots/collection_layout/single_item.diagnostics.snap
+++ b/tests/snapshots/collection_layout/single_item.diagnostics.snap
@@ -3,4 +3,6 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/single_item.input.py
 ---
-
+collection-layout@602..632
+collection-layout@662..670
+collection-layout@697..698

--- a/tests/snapshots/collection_layout/single_item.input.py.snap
+++ b/tests/snapshots/collection_layout/single_item.input.py.snap
@@ -4,10 +4,14 @@ expression: output
 input_file: tests/fixtures/collection_layout/single_item.input.py
 ---
 """
-Single-item and empty literals keep their original inline form
-regardless of line length. `item_count` returns `Some(0)` or
-`Some(1)` for these cases, both of which short-circuit
-`should_expand` ahead of the `code-line-length` check.
+Single-item and empty literals keep their inline form regardless of
+line length. A multi-line single-item literal collapses to its
+canonical inline form, the spec's `SETTINGS = {"default_action":
+"noop"}` case being the most reduced. Empty literals spread across
+multiple lines collapse to their bare-bracket form. A multi-line
+single-item literal whose inline form overflows stays multi-line
+because the rule's expand path only canonicalizes multi-item
+collections.
 """
 
 only_list  = [42]
@@ -15,3 +19,9 @@ only_dict  = {"solitary": 1}
 only_set   = {42}
 empty_list = []
 empty_dict = {}
+collapsing_one_entry_dict = {"default_action": "noop"}
+collapsing_one_item_list = [42]
+collapsing_empty_dict = {}
+oversized_one_entry_dict = {
+    "extremely_long_configuration_key_for_the_settings_table": "a_descriptive_value"
+}

--- a/tests/snapshots/collection_layout/tuples.diagnostics.snap
+++ b/tests/snapshots/collection_layout/tuples.diagnostics.snap
@@ -3,4 +3,6 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/tuples.input.py
 ---
-collection-layout@421..511
+collection-layout@596..617
+collection-layout@645..654
+collection-layout@689..779

--- a/tests/snapshots/collection_layout/tuples.input.py.snap
+++ b/tests/snapshots/collection_layout/tuples.input.py.snap
@@ -1,18 +1,23 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/tuples.input.py
 ---
 """
-Tuples are out of scope for this rule. `Expr::Tuple` is not matched
-by `item_count`, so a multi-item tuple stays inline whether it is
-parenthesized or bare. The visitor still descends through the
-tuple's elements via `walk_expr`, so a qualifying inner collection
-inside a tuple expands when it overflows the budget at its own column.
+A multi-line tuple whose assembled inline form fits collapses back to
+one line, preserving its source-level bracket shape: a parenthesized
+tuple keeps its parens, a bare tuple stays bare, and a one-element
+tuple keeps its trailing comma. Single-line tuples are left alone
+because the expand path does not handle tuples, only the collapse
+path does. The visitor still descends through a tuple's elements, so
+a qualifying inner collection inside an inline tuple expands when it
+overflows the budget at its own column.
 """
 
 paren_tuple = (1, 2, 3)
 bare_tuple = 4, 5, 6
+collapsing_paren_tuple = (1, 2, 3)
+collapsing_one_element = (42,)
 qualifying_inner_in_tuple = (1, {
     "first_key": 100,
     "second_key": 200,

--- a/tests/snapshots/collection_layout/unpacking.diagnostics.snap
+++ b/tests/snapshots/collection_layout/unpacking.diagnostics.snap
@@ -3,6 +3,7 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/unpacking.input.py
 ---
-collection-layout@537..623
-collection-layout@640..725
-collection-layout@741..821
+collection-layout@668..754
+collection-layout@771..856
+collection-layout@872..952
+collection-layout@980..1031

--- a/tests/snapshots/collection_layout/unpacking.input.py.snap
+++ b/tests/snapshots/collection_layout/unpacking.input.py.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/collection_layout/unpacking.input.py
 ---
 """
@@ -11,7 +11,9 @@ dict's other entries. Starred expressions in list and set elts slice
 through the `Expr::Starred` range verbatim. They are non-atomic, so
 a spread in the middle of a list splits its surrounding atomics into
 two independent runs that each flow on their own, and a set made
-entirely of spreads goes one entry per line.
+entirely of spreads goes one entry per line. A multi-line dict with
+a `**` spread whose inline form fits collapses back to one line and
+the spread renders inline as `**value`.
 """
 
 dict_unpack = {
@@ -38,3 +40,4 @@ set_unpack = {
     *zeta_set,
     *eta_set
 }
+collapsing_dict_unpack = {"alpha": 1, **extra_config, "beta": 2}

--- a/tests/snapshots/collection_layout/with_comments.diagnostics.snap
+++ b/tests/snapshots/collection_layout/with_comments.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/with_comments.input.py
 ---
-collection-layout@402..467
+collection-layout@718..783

--- a/tests/snapshots/collection_layout/with_comments.input.py.snap
+++ b/tests/snapshots/collection_layout/with_comments.input.py.snap
@@ -1,20 +1,35 @@
 ---
 source: tests/integration.rs
-expression: "apply(rule, source)"
+expression: output
 input_file: tests/fixtures/collection_layout/with_comments.input.py
 ---
 """
-A literal whose source range contains a comment is left alone to
-preserve author-intended prose that slicing would drop. A trailing
-comment outside the literal's range still allows the literal to
-expand when the inline form overflows. Atomic items inside the
-expanded form flow across balanced lines.
+A literal whose source range contains a comment in any attachment
+position is left alone to preserve author-intended prose that the
+collapse would drop. Own-line comments between entries, trailing
+comments on an entry, and comments before the closing bracket all
+pin the multi-line shape. A trailing comment outside the literal's
+range still allows the literal to expand when the inline form
+overflows. Atomic items inside the expanded form flow across
+balanced lines.
 """
 
-keeps_interior_comment = [
+own_line_comment_between_entries = [
+    1,
+    # explanatory
+    2,
+    3,
+]
+trailing_comment_on_entry = [
     1,
     2,  # noqa: E501
     3,
+]
+comment_before_close = [
+    1,
+    2,
+    3,
+    # closing note
 ]
 trailing_comment_expands = [
     "first", "second", "third", "fourth", "fifth", "sixth", "seventh"

--- a/tests/snapshots/composition/function_with_dict_default.diagnostics.snap
+++ b/tests/snapshots/composition/function_with_dict_default.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/composition/function_with_dict_default.input.py
+---
+collection-layout@549..583

--- a/tests/snapshots/composition/function_with_dict_default.input.py.snap
+++ b/tests/snapshots/composition/function_with_dict_default.input.py.snap
@@ -1,0 +1,23 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/composition/function_with_dict_default.input.py
+---
+"""
+A function default argument is a multi-line dict literal whose
+collapsed inline form keeps the whole signature under
+`Config::code_line_length`. `collection_layout` collapses the dict,
+`align_colons` no longer applies because the dict is now single-line,
+and `signature_layout` sees the shortened signature line and leaves
+it inline rather than expanding to one-parameter-per-line. The full
+pipeline running twice produces no further change.
+
+Rules:
+- collection-layout
+- align-colons
+- signature-layout
+"""
+
+
+def configure(timeout=30, options={"alpha": 1, "beta": 2}, verbose=True):
+    return (timeout, options, verbose)

--- a/tests/snapshots/thematic/align_padded_dict_collapses.diagnostics.snap
+++ b/tests/snapshots/thematic/align_padded_dict_collapses.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/thematic/align_padded_dict_collapses.input.py
+---
+collection-layout@456..508
+docstring-wrap@58..390

--- a/tests/snapshots/thematic/align_padded_dict_collapses.input.py.snap
+++ b/tests/snapshots/thematic/align_padded_dict_collapses.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/thematic/align_padded_dict_collapses.input.py
+---
+"""
+Cross-rule composition over a multi-line dict carrying `align_colons`-shaped
+padding whose inline form fits the budget. `collection_layout`'s collapse
+strips the padding when emitting the inline form, because `write_inline`
+always emits `": "` without honoring the source's `[ ]*: ` gap.
+`align_colons` does not re-pad after collapse because the inline dict lives
+on one line. The full pipeline running twice produces no further change.
+"""
+
+config = {"alpha": 1, "beta": 2, "gamma": 3}

--- a/tests/snapshots/thematic/match_dispatch.diagnostics.snap
+++ b/tests/snapshots/thematic/match_dispatch.diagnostics.snap
@@ -1,17 +1,15 @@
 ---
 source: tests/diagnostics.rs
-assertion_line: 39
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/match_dispatch.input.py
 ---
-alphabetize@521..760
-blank-lines@438..440
-docstring-wrap@67..393
-loose-constants@829..872
-match-case-align@506..507
-match-case-align@599..600
-match-case-align@692..693
-match-case-align@777..783
-singleton-rule@862..863
-strip-trailing-commas@840..841
-strip-trailing-commas@887..888
+alphabetize@531..770
+blank-lines@448..450
+collection-layout@820..852
+docstring-wrap@67..437
+loose-constants@839..876
+match-case-align@516..517
+match-case-align@609..610
+match-case-align@702..703
+match-case-align@787..793
+strip-trailing-commas@889..890

--- a/tests/snapshots/thematic/match_dispatch.input.py.snap
+++ b/tests/snapshots/thematic/match_dispatch.input.py.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration.rs
-assertion_line: 28
 expression: output
 input_file: tests/fixtures/thematic/match_dispatch.input.py
 ---
@@ -9,8 +8,9 @@ Cross-rule composition over a match statement: match_case_align splits
 the three arms whose collapsed form would exceed 88 columns and collapses
 the under-budget fallback arm, alphabetize sorts the kwargs inside the
 dispatched calls, strip_trailing_commas removes the dangling commas the
-source carries, and the singleton rule strips the lone-key dict's pre-`:`
-padding. The full pipeline running twice produces no further change.
+source carries, and collection_layout collapses the lone-key SETTINGS
+dict back to one line. The full pipeline running twice produces no further
+change.
 """
 
 
@@ -25,9 +25,7 @@ def dispatch(event):
         case _: return None
 
 
-SETTINGS = {
-    "default_action": "noop"
-}
+SETTINGS = {"default_action": "noop"}
 
 
 def required_only(name):


### PR DESCRIPTION
### 🪻 Quick Summary

Collapses multi-line `dict`, `list`, `set`, and `tuple` literals whose assembled inline form fits under `Config::code_line_length` back to a single line, complementing the existing expand pass. The canonical `SETTINGS = {"default_action": "noop"}` case is the most reduced. Tuples are newly in scope for `collection_layout`, collapse-only, preserving the source's bracket shape (*parenthesized or bare*) and the 1-tuple trailing comma. A comment anywhere inside the literal's range pins the multi-line shape, because collapsing would lose the comment's attachment. Nesting precedence runs outermost-first, so an outer collapse moves its inner literals with it, whereas a pinned outer leaves each inner to its own collapse decision.

---

### 🗞️ Key Changes

- Adds `replacement_for` as the rule's unified per-expression decision, returning collapse text, expand text, or `None` for the visitor to descend

- Implements `inline_form` recursion through `write_inline` and `write_inline_seq`, preserving source-text fidelity on leaves via `parenthesized_range` so `(-a) ** 2` survives collapse

- Extends the matched-variants set to `Expr::Tuple` for collapse, using `t.parenthesized` for bracket shape and `t.elts.len() == 1` for the 1-tuple trailing comma

- Pins the multi-line shape against any comment in the literal's range via `source.intersects_comment(range)`, whether the comment sits own-line between entries, trailing on an entry, or before the closing bracket

- Adds fixture coverage across `dict_literal`, `list_literal`, `set_literal`, `tuples`, `single_item`, `nested`, `unpacking`, `parenthesized_children`, and `with_comments`, plus the `match_dispatch` cross-rule case showing the canonical `SETTINGS` collapse

- Updates the registry message to "lay out collection literal against the line budget", reflecting that the rule now runs in both directions

---

### 🧵 Related Issues

- Closes #129