### PR TITLE
[135] Audit and complete the suppression directive surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,26 @@ prose check --color always path/            # force color, NO_COLOR honored
 prose completions zsh                       # shell completion script
 ```
 
-Source ranges may opt out of formatting via block markers:
+Source ranges opt out of rule application through the `# prose:` directive namespace:
+
+| Directive | Effect |
+|---|---|
+| `# prose: off` / `# prose: on` | Suppress every rule across the span the pair opens |
+| `# prose: skip` | Suppress every format rule on the directive's line |
+| `# prose: skip[<rule>]` | Suppress one named format rule on the directive's line |
+| `# prose: ignore` | Suppress every lint rule on the directive's line |
+| `# prose: ignore[<rule>]` | Suppress one named lint rule on the directive's line |
 
 ```python
-# fmt: off
+# prose: off
 keep_this_block_exactly_as_written = (1,2,3)
-# fmt: on
+# prose: on
+
+inside(1, 2, 3,)  # prose: skip[strip-trailing-commas]
+value: Union[int, str] = compute()  # prose: ignore[legacy-union-syntax]
 ```
 
-`# fmt: skip` on the same line opts out a single statement, and `# yapf: disable` / `# yapf: enable` are honored as block-level aliases. Lint diagnostics opt out per line through `# prose: ignore[<rule>]`. A bare `# prose: ignore` suppresses every lint rule on the line, and `# prose: ignore[a, b]` lists several.
+A `# prose: off` at the top of a file (*with no matching `# prose: on`*) opts the whole file out of every rule. The `# fmt:` directives (`# fmt: off`, `# fmt: on`, `# fmt: skip`) and the `# yapf:` directives (`# yapf: disable`, `# yapf: enable`) are honored as Black-compatibility aliases that map onto their `# prose:` counterparts.
 
 ---
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -94,8 +94,7 @@ impl Pipeline {
                 let new_text = apply_edits(source.text(), edits);
                 debug_assert!(
                     new_text != source.text(),
-                    "rule `{}` emitted edits that produced identical text",
-                    rule_id,
+                    "rule `{rule_id}` emitted edits that produced identical text",
                 );
                 source
                     .reparse(new_text)

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -157,29 +157,6 @@ mod tests {
     use crate::config::Config;
     use crate::test_support::{assert_send_sync, parse, range};
 
-    /// Test-only rule that records its own id into a shared log and
-    /// returns the edit list supplied at construction time.
-    struct SentinelRule {
-        edits: Vec<Edit>,
-        id: RuleId,
-        log: Arc<Mutex<Vec<&'static str>>>,
-    }
-
-    impl Rule for SentinelRule {
-        fn apply(&self, _source: &Source) -> Vec<Edit> {
-            self.log.lock().expect("log mutex").push(self.id.as_str());
-            self.edits.clone()
-        }
-
-        fn id(&self) -> RuleId {
-            self.id
-        }
-
-        fn message(&self) -> &'static str {
-            "test rule"
-        }
-    }
-
     /// Test-only lint-only rule that returns the range list supplied
     /// at construction and never produces edits.
     struct LintSentinelRule {
@@ -207,6 +184,29 @@ mod tests {
 
         fn message(&self) -> &'static str {
             "lint test rule"
+        }
+    }
+
+    /// Test-only rule that records its own id into a shared log and
+    /// returns the edit list supplied at construction time.
+    struct SentinelRule {
+        edits: Vec<Edit>,
+        id: RuleId,
+        log: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Rule for SentinelRule {
+        fn apply(&self, _source: &Source) -> Vec<Edit> {
+            self.log.lock().expect("log mutex").push(self.id.as_str());
+            self.edits.clone()
+        }
+
+        fn id(&self) -> RuleId {
+            self.id
+        }
+
+        fn message(&self) -> &'static str {
+            "test rule"
         }
     }
 
@@ -333,6 +333,21 @@ mod tests {
     }
 
     #[test]
+    fn run_drops_edit_when_line_carries_matching_prose_skip_for_rule() {
+        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
+            edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+            id: "align-equals".parse().expect("registered rule id"),
+            log: Arc::new(Mutex::new(Vec::new())),
+        })]);
+        let source = parse("x = 1  # prose: skip[align-equals]\n");
+
+        let (result, diagnostics) = pipeline.run(source).expect("filtered run succeeds");
+
+        assert_eq!(result.text(), "x = 1  # prose: skip[align-equals]\n");
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn run_drops_edits_whose_range_overlaps_a_suppressed_span() {
         // Source: "# fmt: off\nx = 1\n# fmt: on\nz = 9\n"
         //         |0--------|11----|17--------|27----|33
@@ -392,6 +407,23 @@ mod tests {
             assert_eq!(diagnostic.rule.as_str(), "flag-stuff");
             assert_eq!(diagnostic.message, "lint test rule");
         }
+    }
+
+    #[test]
+    fn run_short_circuits_when_file_is_suppressed() {
+        let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
+            edits: vec![Edit::range_replacement("y".to_owned(), range(13, 14))],
+            id: RuleId::from("never-called"),
+            log: log.clone(),
+        })]);
+        let source = parse("# prose: off\nx = 1\n");
+
+        let (result, diagnostics) = pipeline.run(source).expect("short-circuit run");
+
+        assert_eq!(result.text(), "# prose: off\nx = 1\n");
+        assert!(diagnostics.is_empty());
+        assert!(log.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -7,6 +7,7 @@
 //! padding widths are computed.
 
 use ruff_python_parser::ParseError;
+use ruff_text_size::Ranged;
 use thiserror::Error;
 
 use crate::diagnostics::{Diagnostic, Severity};
@@ -57,16 +58,20 @@ impl Pipeline {
     /// returns the rewritten source paired with the diagnostics each
     /// rule emitted.
     ///
-    /// Per rule, the pipeline calls `apply`, drops edits inside any
-    /// `# fmt: off` span via the `SuppressionMap`, derives one
-    /// `Severity::Format` `Diagnostic` per surviving edit, collects
-    /// the `Severity::Lint` diagnostics `Rule::lint` returned through
-    /// the same fmt-suppression filter, then splices the edits into
-    /// the current text and reparses for the next rule. After the
-    /// rule chain finishes, every `Severity::Lint` diagnostic whose
-    /// line carries a matching `# prose: ignore` directive is
-    /// dropped. An empty pipeline collapses to the identity transform
-    /// and returns no diagnostics.
+    /// When the source opens with an unmatched `# prose: off` (or
+    /// alias) before any code, the pipeline short-circuits to the
+    /// identity transform with no diagnostics. Otherwise, per rule
+    /// the pipeline calls `apply`, drops edits inside any `# prose:
+    /// off` span or carrying a matching `# prose: skip[<id>]`
+    /// directive on their line, derives one `Severity::Format`
+    /// `Diagnostic` per surviving edit, collects the `Severity::Lint`
+    /// diagnostics `Rule::lint` returned through the same span
+    /// filter, then splices the edits into the current text and
+    /// reparses for the next rule. After the rule chain finishes,
+    /// every `Severity::Lint` diagnostic whose line carries a
+    /// matching `# prose: ignore` directive is dropped. An empty
+    /// pipeline collapses to the identity transform and returns no
+    /// diagnostics.
     ///
     /// # Errors
     ///
@@ -74,13 +79,21 @@ impl Pipeline {
     /// produces text that does not re-parse as Python. This surfaces
     /// rule bugs rather than silently swallowing them.
     pub fn run(&self, source: Source) -> Result<(Source, Vec<Diagnostic>), PipelineError> {
+        if source.suppression_map().file_is_suppressed() {
+            return Ok((source, Vec::new()));
+        }
         let (source, mut diagnostics) = self.rules.iter().try_fold(
             (source, Vec::new()),
             |(source, mut diagnostics), rule| {
                 let mut edits = rule.apply(&source);
                 let suppression = source.suppression_map();
-                if suppression.has_format_suppression() {
-                    edits.retain(|edit| !suppression.intersects(edit));
+                let rule_id = rule.id();
+                if suppression.has_format_suppression() || suppression.has_skip_suppression() {
+                    edits.retain(|edit| {
+                        !suppression.intersects(edit)
+                            && !suppression
+                                .is_format_suppressed_at(source.line_index(edit.start()), rule_id)
+                    });
                 }
                 diagnostics.extend(
                     rule.lint(&source)
@@ -90,7 +103,6 @@ impl Pipeline {
                 if edits.is_empty() {
                     return Ok((source, diagnostics));
                 }
-                let rule_id = rule.id();
                 let message = rule.message();
                 diagnostics.extend(
                     edits
@@ -101,13 +113,13 @@ impl Pipeline {
                 debug_assert!(
                     new_text != source.text(),
                     "rule `{}` emitted edits that produced identical text",
-                    rule.id(),
+                    rule_id,
                 );
                 source
                     .reparse(new_text)
                     .map(|src| (src, diagnostics))
                     .map_err(|source| PipelineError::Reparse {
-                        rule: rule.id(),
+                        rule: rule_id,
                         source,
                     })
             },
@@ -116,8 +128,7 @@ impl Pipeline {
         if suppression.has_lint_suppression() {
             diagnostics.retain(|d| {
                 d.severity != Severity::Lint
-                    || !suppression
-                        .is_lint_suppressed_at(source.line_index(d.range.start()), d.rule)
+                    || !suppression.is_lint_suppressed_at(source.line_index(d.start()), d.rule)
             });
         }
         Ok((source, diagnostics))

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -16,18 +16,12 @@ use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
 /// Ordered sequence of enabled rules, run against each source file.
-///
-/// Use [`Pipeline::with_defaults`] to build one from a loaded
-/// [`crate::config::Config`], [`Pipeline::for_rule`] to register
-/// exactly one rule by name, or [`Pipeline::empty`] for a pipeline
-/// with no rules.
 pub struct Pipeline {
     rules: Vec<Box<dyn Rule>>,
 }
 
 impl Pipeline {
-    /// Constructs a pipeline that performs no rewrites. Useful for
-    /// callers that need a `Pipeline` value but no rules to run.
+    /// Constructs a pipeline that performs no rewrites.
     pub fn empty() -> Self {
         Self { rules: Vec::new() }
     }
@@ -46,9 +40,8 @@ impl Pipeline {
         self.rules.len()
     }
 
-    /// Returns every registered rule's id in a stable order. Useful
-    /// for CLI `--select` / `--ignore` validation and for rule
-    /// listings. Surfaces the same registry that
+    /// Returns every registered rule's id in a stable order.
+    /// Surfaces the same registry that
     /// [`RuleId::from_str`](crate::rule::RuleId) consults.
     pub fn known_ids() -> &'static [RuleId] {
         crate::rule::KNOWN_IDS
@@ -76,8 +69,7 @@ impl Pipeline {
     /// # Errors
     ///
     /// Returns `PipelineError::Reparse` when a rule's edit list
-    /// produces text that does not re-parse as Python. This surfaces
-    /// rule bugs rather than silently swallowing them.
+    /// produces text that does not re-parse as Python.
     pub fn run(&self, source: Source) -> Result<(Source, Vec<Diagnostic>), PipelineError> {
         if source.suppression_map().file_is_suppressed() {
             return Ok((source, Vec::new()));

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -51,20 +51,10 @@ impl Pipeline {
     /// returns the rewritten source paired with the diagnostics each
     /// rule emitted.
     ///
-    /// When the source opens with an unmatched `# prose: off` (or
-    /// alias) before any code, the pipeline short-circuits to the
-    /// identity transform with no diagnostics. Otherwise, per rule
-    /// the pipeline calls `apply`, drops edits inside any `# prose:
-    /// off` span or carrying a matching `# prose: skip[<id>]`
-    /// directive on their line, derives one `Severity::Format`
-    /// `Diagnostic` per surviving edit, collects the `Severity::Lint`
-    /// diagnostics `Rule::lint` returned through the same span
-    /// filter, then splices the edits into the current text and
-    /// reparses for the next rule. After the rule chain finishes,
-    /// every `Severity::Lint` diagnostic whose line carries a
-    /// matching `# prose: ignore` directive is dropped. An empty
-    /// pipeline collapses to the identity transform and returns no
-    /// diagnostics.
+    /// File-level `# prose: off` short-circuits to identity. The
+    /// suppression map otherwise filters edits per-rule (off spans
+    /// plus `# prose: skip[<id>]`) and lint diagnostics per-line
+    /// (`# prose: ignore`).
     ///
     /// # Errors
     ///
@@ -322,21 +312,6 @@ mod tests {
         pipeline.run(source).expect("all rules succeed");
 
         assert_eq!(*log.lock().unwrap(), ["first", "second", "third"]);
-    }
-
-    #[test]
-    fn run_drops_edit_when_line_carries_matching_prose_skip_for_rule() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
-            edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
-            id: "align-equals".parse().expect("registered rule id"),
-            log: Arc::new(Mutex::new(Vec::new())),
-        })]);
-        let source = parse("x = 1  # prose: skip[align-equals]\n");
-
-        let (result, diagnostics) = pipeline.run(source).expect("filtered run succeeds");
-
-        assert_eq!(result.text(), "x = 1  # prose: skip[align-equals]\n");
-        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -24,7 +24,9 @@ use crate::suppression::SuppressionMap;
 ///
 /// Holds the source text, the parsed AST, the token stream, a lazy
 /// line index, a `CommentRanges` index built during parsing, and a
-/// `SuppressionMap` of `# fmt: off` / `# fmt: skip` spans, plus a
+/// `SuppressionMap` of `# prose: off` / `# prose: skip` spans (plus
+/// the `# fmt:` and `# yapf:` aliases), `# prose: skip[<id>]` and
+/// `# prose: ignore[<id>]` per-line directives, plus a
 /// `BindingAnalysis` table of every name's writes and reads.
 #[derive(Debug)]
 pub struct Source {
@@ -40,9 +42,11 @@ impl Source {
         let parsed = parse_module(&text)?;
         let file = SourceFileBuilder::new(name, text).finish();
         let comment_ranges = CommentRanges::from(parsed.tokens());
+        let first_code_offset = parsed.syntax().body.first().map(Ranged::start);
         let suppression = Box::new(SuppressionMap::from_comments(
             &file.to_source_code(),
             &comment_ranges,
+            first_code_offset,
         ));
         let binding_analysis = Box::new(BindingAnalysis::new(parsed.syntax()));
         Ok(Self {

--- a/src/source.rs
+++ b/src/source.rs
@@ -97,6 +97,13 @@ impl Source {
         self.file.source_text().contains_line_break(ranged.range())
     }
 
+    /// Returns the source name. For `from_path` inputs this is
+    /// `path.display().to_string()`, for `from_str` inputs the
+    /// synthetic placeholder `<source>`.
+    pub fn filename(&self) -> &str {
+        self.file.name()
+    }
+
     /// Returns the start offset of the first token in `range` for
     /// which `predicate` is true. Callers that need the full `&Token`
     /// (kind, range, flags) should chain
@@ -123,13 +130,6 @@ impl Source {
     /// source ahead of `offset` from the preceding non-whitespace.
     pub fn has_blank_line_before(&self, offset: TextSize) -> bool {
         lines_before(offset, self.text()) >= 2
-    }
-
-    /// Returns the source name. For `from_path` inputs this is
-    /// `path.display().to_string()`, for `from_str` inputs the
-    /// synthetic placeholder `<source>`.
-    pub fn filename(&self) -> &str {
-        self.file.name()
     }
 
     /// Returns `true` when at least one comment lies within `ranged`.

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,8 +1,4 @@
 //! Source-text wrapper bundling parsed AST, token stream, and line index.
-//!
-//! Every rule reads through `Source`. The text is owned rather than
-//! borrowed, so `Source` carries no lifetime parameter and can move
-//! across thread boundaries without lifetime gymnastics.
 
 use std::path::Path;
 use std::str::FromStr;
@@ -64,8 +60,6 @@ impl Source {
     ///
     /// Returns `SourceError::Io` if the read fails and `SourceError::Parse`
     /// if the bytes are read successfully but do not form a valid module.
-    /// The underlying `std::io::Error` from `fs_err` carries the path in
-    /// its `Display`, so no additional wrapping is needed.
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, SourceError> {
         let path = path.as_ref();
         let text = fs_err::read_to_string(path)?;
@@ -107,10 +101,7 @@ impl Source {
     /// Returns the start offset of the first token in `range` for
     /// which `predicate` is true. Callers that need the full `&Token`
     /// (kind, range, flags) should chain
-    /// `tokens().in_range(range).iter().find(...)` directly. This
-    /// helper exists for the dominant case of "find a kind, take its
-    /// start offset," which every alignment-rule member constructor
-    /// reduces to.
+    /// `tokens().in_range(range).iter().find(...)` directly.
     pub fn first_token_offset_in_range<F>(
         &self,
         range: TextRange,
@@ -176,9 +167,7 @@ impl Source {
 
     /// Reparses with replacement source text, preserving the original name.
     ///
-    /// The pipeline calls this after each rule applies its edit list, so the
-    /// next rule sees a freshly-parsed AST whose ranges point into the new
-    /// buffer. Diagnostic labels keep the original path or `<source>` placeholder.
+    /// Diagnostic labels keep the original path or `<source>` placeholder.
     ///
     /// # Errors
     ///
@@ -189,10 +178,8 @@ impl Source {
 
     /// Returns the byte slice spanned by anything `Ranged`.
     ///
-    /// Accepts a raw `TextRange` or any AST node, since every node in
-    /// `ruff_python_ast` implements `Ranged`. The returned `&str` is
-    /// guaranteed to fall on `char` boundaries because the parser only
-    /// emits ranges aligned to source token boundaries.
+    /// Accepts a raw `TextRange` or any AST node. The returned `&str`
+    /// is guaranteed to fall on `char` boundaries.
     pub fn slice<R: Ranged>(&self, ranged: R) -> &str {
         self.file.slice(ranged.range())
     }
@@ -207,10 +194,6 @@ impl Source {
     }
 
     /// Borrows the token stream produced during parsing.
-    ///
-    /// Rules that need whitespace-aware context (alignment, padding,
-    /// trailing-comma stripping) re-lex through this stream because
-    /// Ruff's AST is not whitespace-preserving.
     pub fn tokens(&self) -> &Tokens {
         self.parsed.tokens()
     }
@@ -219,8 +202,7 @@ impl Source {
 /// Parses Python source from an in-memory string.
 ///
 /// The resulting `Source` carries the synthetic name `<source>` for
-/// diagnostics. Callers can invoke this through `Source::from_str(text)`
-/// (with `std::str::FromStr` in scope) or via `text.parse::<Source>()`.
+/// diagnostics.
 impl FromStr for Source {
     type Err = ParseError;
 

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -1,8 +1,11 @@
-//! Per-`Source` index of `# fmt: off` / `# fmt: on` / `# fmt: skip`
-//! spans (plus the `# yapf: disable` / `# yapf: enable` aliases) and
-//! `# prose: ignore[...]` per-line lint directives. Built once during
-//! `Source` construction and consulted by `Pipeline::run` to drop
-//! suppressed edits and `Severity::Lint` diagnostics.
+//! Per-`Source` index of `# prose: off` / `# prose: on` / `# prose: skip`
+//! spans (plus the `# fmt:` and `# yapf:` aliases), `# prose: skip[<id>]`
+//! per-line format-rule directives, and `# prose: ignore[<id>]` per-line
+//! lint directives. Built once during `Source` construction and consulted
+//! by `Pipeline::run` to drop suppressed edits and `Severity::Lint`
+//! diagnostics. A `file_is_suppressed` shortcut lets the pipeline
+//! skip rule execution entirely when an unmatched off precedes every
+//! statement.
 
 use std::collections::{HashMap, HashSet};
 
@@ -12,84 +15,126 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::rule::RuleId;
 
-/// One line's parsed `# prose: ignore` directive.
+/// One line's parsed `# prose: ignore` or `# prose: skip[<id>]`
+/// directive.
 #[derive(Debug)]
-enum IgnoreEntry {
+enum RuleEntry {
     /// Bare `# prose: ignore`. Suppresses every rule on the line.
     All,
-    /// `# prose: ignore[<id>[, <id>...]]`. Unknown ids are dropped.
+    /// `# prose: ignore[<id>[, <id>...]]` or `# prose: skip[<id>[,
+    /// <id>...]]`. Unknown ids are dropped.
     Specific(HashSet<RuleId>),
 }
 
-impl IgnoreEntry {
+impl RuleEntry {
+    /// Returns `true` when `self` suppresses `rule`. `All` matches
+    /// every id, `Specific` matches only listed ids.
+    fn matches(&self, rule: RuleId) -> bool {
+        match self {
+            Self::All => true,
+            Self::Specific(rules) => rules.contains(&rule),
+        }
+    }
+
     /// Folds `incoming` into `self`. `All` widens any prior `Specific`,
     /// and a second `Specific` unions its ids into the first.
     fn merge(&mut self, incoming: Self) {
         match (&mut *self, incoming) {
-            (IgnoreEntry::All, _) => {}
-            (slot @ IgnoreEntry::Specific(_), IgnoreEntry::All) => *slot = IgnoreEntry::All,
-            (IgnoreEntry::Specific(rules), IgnoreEntry::Specific(more)) => rules.extend(more),
+            (Self::All, _) => {}
+            (slot @ Self::Specific(_), Self::All) => *slot = Self::All,
+            (Self::Specific(rules), Self::Specific(more)) => rules.extend(more),
         }
     }
 }
 
-impl Default for IgnoreEntry {
+impl Default for RuleEntry {
     fn default() -> Self {
         Self::Specific(HashSet::new())
     }
 }
 
-/// Sorted byte-range list for format-suppression spans paired with a
-/// per-line `OneIndexed` map for `# prose: ignore` directives. Format
-/// queries run in O(log n), lint queries in O(1).
+/// Sorted byte-range list for format-suppression spans paired with two
+/// per-line `OneIndexed` maps. `lints` carries `# prose: ignore` per-line
+/// lint directives, `skips` carries `# prose: skip[<id>]` per-rule format
+/// directives. Span queries run in O(log n), per-line queries in O(1).
 #[derive(Debug)]
 pub(crate) struct SuppressionMap {
-    lints: HashMap<OneIndexed, IgnoreEntry>,
+    file_suppressed: bool,
+    lints: HashMap<OneIndexed, RuleEntry>,
+    skips: HashMap<OneIndexed, RuleEntry>,
     spans: Vec<TextRange>,
 }
 
 impl SuppressionMap {
     /// Walks `comments` against `source`, classifying each comment via
-    /// `SuppressionKind` for the format spans and `find_prose_directive`
-    /// for the lint index. An unmatched `# fmt: off` extends through
-    /// end of file. A stray `# fmt: on` is a no-op. Two consecutive
-    /// `# fmt: off` directives flatten, with the first `# fmt: on`
+    /// `classify_format_directive` for the format spans and per-line
+    /// skip index, and `find_prose_ignore` for the lint index.
+    /// `first_code_offset` carries the start of the source's first
+    /// top-level statement (or `None` for code-free input), powering
+    /// the `file_is_suppressed` shortcut.
+    ///
+    /// An unmatched `# prose: off` (or alias) extends through end of
+    /// file, a stray `# prose: on` is a no-op, and two consecutive
+    /// `# prose: off` directives flatten with the first `# prose: on`
     /// closing the block. Multiple `# prose: ignore` directives on the
-    /// same line merge with bare-wins precedence.
-    pub(crate) fn from_comments(source: &SourceCode<'_, '_>, comments: &CommentRanges) -> Self {
+    /// same line merge with bare-wins precedence, and `# prose: skip[<id>]`
+    /// directives union their listed ids.
+    pub(crate) fn from_comments(
+        source: &SourceCode<'_, '_>,
+        comments: &CommentRanges,
+        first_code_offset: Option<TextSize>,
+    ) -> Self {
         let source_text = source.text();
-        let mut lints: HashMap<OneIndexed, IgnoreEntry> = HashMap::new();
+        let mut lints: HashMap<OneIndexed, RuleEntry> = HashMap::new();
+        let mut skips: HashMap<OneIndexed, RuleEntry> = HashMap::new();
         let mut spans: Vec<TextRange> = Vec::new();
         let mut open_off: Option<TextSize> = None;
         for range in comments {
             let comment = &source_text[range];
-            if let Some(kind) = SuppressionKind::from_comment(comment) {
+            if let Some(directive) = classify_format_directive(comment) {
                 let position = CommentLinePosition::for_range(range, source_text);
-                match kind {
-                    SuppressionKind::Off if position.is_own_line() => {
+                match directive {
+                    FormatDirective::Kind(SuppressionKind::Off) if position.is_own_line() => {
                         open_off.get_or_insert_with(|| source_text.line_start(range.start()));
                     }
-                    SuppressionKind::On if position.is_own_line() => {
+                    FormatDirective::Kind(SuppressionKind::On) if position.is_own_line() => {
                         spans.extend(open_off.take().map(|start| {
                             TextRange::new(start, source_text.line_start(range.start()))
                         }));
                     }
-                    SuppressionKind::Skip => {
+                    FormatDirective::Kind(SuppressionKind::Skip) => {
                         spans.push(source_text.full_line_range(range.start()));
+                    }
+                    FormatDirective::SkipRules(rules) => {
+                        let line = source.line_index(range.start());
+                        skips
+                            .entry(line)
+                            .or_default()
+                            .merge(RuleEntry::Specific(rules));
                     }
                     _ => {}
                 }
             }
-            if let Some(entry) = find_prose_directive(comment) {
+            if let Some(entry) = find_prose_ignore(comment) {
                 let line = source.line_index(range.start());
                 lints.entry(line).or_default().merge(entry);
             }
         }
+        let file_suppressed =
+            open_off.is_some_and(|off| first_code_offset.is_none_or(|code| off <= code));
         spans.extend(open_off.map(|start| TextRange::new(start, source_text.text_len())));
         Self {
+            file_suppressed,
             lints,
-            spans: merge(spans),
+            skips,
+            spans: merge_spans(spans),
         }
+    }
+
+    /// Returns `true` when an unmatched `# prose: off` (or alias) sits
+    /// at or before the first non-blank, non-comment line of the file.
+    pub(crate) fn file_is_suppressed(&self) -> bool {
+        self.file_suppressed
     }
 
     /// Returns `true` when the source carries at least one
@@ -104,31 +149,77 @@ impl SuppressionMap {
         !self.lints.is_empty()
     }
 
+    /// Returns `true` when the source carries at least one
+    /// `# prose: skip[<id>]` directive.
+    pub(crate) fn has_skip_suppression(&self) -> bool {
+        !self.skips.is_empty()
+    }
+
     /// Returns `true` when `ranged`'s span overlaps any
     /// format-suppressed span by at least one byte. Empty ranges
     /// report overlap when their offset strictly sits inside a span.
     pub(crate) fn intersects<R: Ranged>(&self, ranged: R) -> bool {
-        let range = ranged.range();
-        self.spans.binary_search_by(|s| s.ordering(range)).is_ok()
+        self.spans
+            .binary_search_by(|s| s.ordering(ranged.range()))
+            .is_ok()
+    }
+
+    /// Returns `true` when `line` carries a `# prose: skip[<id>]`
+    /// directive that lists `rule`.
+    pub(crate) fn is_format_suppressed_at(&self, line: OneIndexed, rule: RuleId) -> bool {
+        self.skips.get(&line).is_some_and(|e| e.matches(rule))
     }
 
     /// Returns `true` when `line` carries a `# prose: ignore`
     /// directive that suppresses `rule`. Bare directives suppress
     /// every rule on their line.
     pub(crate) fn is_lint_suppressed_at(&self, line: OneIndexed, rule: RuleId) -> bool {
-        self.lints.get(&line).is_some_and(|entry| match entry {
-            IgnoreEntry::All => true,
-            IgnoreEntry::Specific(rules) => rules.contains(&rule),
-        })
+        self.lints.get(&line).is_some_and(|e| e.matches(rule))
     }
+}
+
+/// Result of `classify_format_directive`. `Kind` carries an upstream
+/// or `# prose:`-prefixed off/on/skip directive that drives the span
+/// machinery, whereas `SkipRules` carries the rule-id list parsed from
+/// `# prose: skip[<id>[, <id>...]]`.
+enum FormatDirective {
+    Kind(SuppressionKind),
+    SkipRules(HashSet<RuleId>),
+}
+
+/// Strips the leading `prose:` marker from `after_hash` and returns
+/// the trimmed body. Returns `None` for any other shape.
+fn after_prose_prefix(after_hash: &str) -> Option<&str> {
+    after_hash.trim().strip_prefix("prose:").map(str::trim)
+}
+
+/// Classifies `comment` against the three format-suppression
+/// namespaces. The `# prose:` namespace is tried first, falling
+/// through to `SuppressionKind::from_comment` for the `# fmt:` and
+/// `# yapf:` aliases. `# prose: skip[<id>...]` returns `SkipRules`,
+/// `# prose: off|on|skip` and the alias forms return `Kind`. Multiple
+/// `# prose: skip[<id>]` chunks on one comment range union their ids.
+fn classify_format_directive(comment: &str) -> Option<FormatDirective> {
+    comment
+        .split('#')
+        .skip(1)
+        .filter_map(parse_prose_format)
+        .reduce(|mut acc, next| {
+            if let (FormatDirective::SkipRules(a), FormatDirective::SkipRules(b)) = (&mut acc, next)
+            {
+                a.extend(b);
+            }
+            acc
+        })
+        .or_else(|| SuppressionKind::from_comment(comment).map(FormatDirective::Kind))
 }
 
 /// Splits `comment` at each `#` boundary, parsing each chunk as a
 /// `prose: ignore` directive and folding successful hits through
-/// `merge_entries`. Catches nested forms like `# my note # prose:
+/// `RuleEntry::merge`. Catches nested forms like `# my note # prose:
 /// ignore` and multi-directive lines like `# prose: ignore  # prose:
 /// ignore[align-equals]`.
-fn find_prose_directive(comment: &str) -> Option<IgnoreEntry> {
+fn find_prose_ignore(comment: &str) -> Option<RuleEntry> {
     comment
         .split('#')
         .skip(1)
@@ -139,7 +230,7 @@ fn find_prose_directive(comment: &str) -> Option<IgnoreEntry> {
         })
 }
 
-fn merge(mut spans: Vec<TextRange>) -> Vec<TextRange> {
+fn merge_spans(mut spans: Vec<TextRange>) -> Vec<TextRange> {
     spans.sort_unstable_by_key(|s| s.start());
     spans.dedup_by(|next, prev| {
         let overlaps = next.start() <= prev.end();
@@ -151,27 +242,50 @@ fn merge(mut spans: Vec<TextRange>) -> Vec<TextRange> {
     spans
 }
 
-/// Parses the post-`#` body of a `prose: ignore`, `prose: ignore[<id>]`,
-/// or `prose: ignore[<id>, <id>...]` directive. Returns `None` for any
-/// other shape. Whitespace tolerated around `:`, `[`, `,`, and `]`.
-/// Unknown rule ids inside the brackets are dropped.
-fn parse_prose_ignore(after_hash: &str) -> Option<IgnoreEntry> {
-    let body = after_hash
-        .trim()
-        .strip_prefix("prose:")?
-        .trim()
-        .strip_prefix("ignore")?
-        .trim();
-    if body.is_empty() {
-        return Some(IgnoreEntry::All);
-    }
-    Some(IgnoreEntry::Specific(
+/// Parses the rule-id body of a `[<id>[, <id>...]]` suffix into a
+/// `RuleEntry::Specific`. Returns `None` when the brackets are missing
+/// or malformed. Unknown rule ids are silently dropped.
+fn parse_bracketed_rule_list(body: &str) -> Option<HashSet<RuleId>> {
+    Some(
         body.strip_prefix('[')?
             .strip_suffix(']')?
             .split(',')
             .filter_map(|part| part.trim().parse::<RuleId>().ok())
             .collect(),
-    ))
+    )
+}
+
+/// Parses the post-`#` body of a `prose: off`, `prose: on`, `prose:
+/// skip`, or `prose: skip[<id>...]` directive. Returns `None` for any
+/// other shape, leaving the caller to try the `# fmt:` / `# yapf:`
+/// fallback.
+fn parse_prose_format(after_hash: &str) -> Option<FormatDirective> {
+    let body = after_prose_prefix(after_hash)?;
+    if let Some(rest) = body.strip_prefix("skip").map(str::trim) {
+        if rest.is_empty() {
+            return Some(FormatDirective::Kind(SuppressionKind::Skip));
+        }
+        return parse_bracketed_rule_list(rest).map(FormatDirective::SkipRules);
+    }
+    match body {
+        "off" => Some(FormatDirective::Kind(SuppressionKind::Off)),
+        "on" => Some(FormatDirective::Kind(SuppressionKind::On)),
+        _ => None,
+    }
+}
+
+/// Parses the post-`#` body of a `prose: ignore`, `prose: ignore[<id>]`,
+/// or `prose: ignore[<id>, <id>...]` directive. Returns `None` for any
+/// other shape. Whitespace tolerated around `:`, `[`, `,`, and `]`.
+/// Unknown rule ids inside the brackets are dropped.
+fn parse_prose_ignore(after_hash: &str) -> Option<RuleEntry> {
+    let body = after_prose_prefix(after_hash)?
+        .strip_prefix("ignore")?
+        .trim();
+    if body.is_empty() {
+        return Some(RuleEntry::All);
+    }
+    parse_bracketed_rule_list(body).map(RuleEntry::Specific)
 }
 
 #[cfg(test)]
@@ -202,6 +316,14 @@ mod tests {
     }
 
     #[test]
+    fn bare_prose_skip_opens_a_full_line_span() {
+        let source = parse("x = 1  # prose: skip\n");
+        let map = source.suppression_map();
+        assert!(map.has_format_suppression());
+        assert!(map.intersects(range(0, 6)));
+    }
+
+    #[test]
     fn bare_then_specific_keeps_all_suppression() {
         let source = parse("x = 1  # prose: ignore  # prose: ignore[align-equals]\n");
         let map = source.suppression_map();
@@ -217,6 +339,44 @@ mod tests {
         assert!(!map.intersects(range(0, 0)));
         assert!(!map.has_format_suppression());
         assert!(!map.has_lint_suppression());
+        assert!(!map.has_skip_suppression());
+        assert!(!map.file_is_suppressed());
+    }
+
+    #[test]
+    fn file_is_suppressed_when_off_precedes_only_blank_and_comment_lines() {
+        let source = parse("# leading note\n\n# prose: off\nx = 1\n");
+        assert!(source.suppression_map().file_is_suppressed());
+    }
+
+    #[test]
+    fn file_is_suppressed_when_unmatched_off_sits_at_top() {
+        let source = parse("# prose: off\nx = 1\ny = 2\n");
+        assert!(source.suppression_map().file_is_suppressed());
+    }
+
+    #[test]
+    fn file_is_suppressed_with_fmt_off_alias() {
+        let source = parse("# fmt: off\nx = 1\n");
+        assert!(source.suppression_map().file_is_suppressed());
+    }
+
+    #[test]
+    fn file_is_suppressed_with_yapf_disable_alias() {
+        let source = parse("# yapf: disable\nx = 1\n");
+        assert!(source.suppression_map().file_is_suppressed());
+    }
+
+    #[test]
+    fn file_not_suppressed_when_off_follows_code() {
+        let source = parse("x = 1\n# prose: off\ny = 2\n");
+        assert!(!source.suppression_map().file_is_suppressed());
+    }
+
+    #[test]
+    fn file_not_suppressed_when_top_off_has_matching_on() {
+        let source = parse("# prose: off\nx = 1\n# prose: on\ny = 2\n");
+        assert!(!source.suppression_map().file_is_suppressed());
     }
 
     #[test]
@@ -226,6 +386,7 @@ mod tests {
         );
         let map = source.suppression_map();
         assert!(!map.has_lint_suppression());
+        assert!(!map.has_skip_suppression());
         assert!(!map.is_lint_suppressed_at(line(0), align_equals()));
         assert!(!map.is_lint_suppressed_at(line(1), align_equals()));
         assert!(!map.is_lint_suppressed_at(line(2), align_equals()));
@@ -249,11 +410,18 @@ mod tests {
             "x = 1  # proseignore\n",
             "x = 1  # prose: ignoring\n",
             "x = 1  # prose: ignore extra\n",
+            "x = 1  # prose: skip[align-equals\n",
+            "x = 1  # prose: skip extra\n",
         ] {
             let source = parse(src);
+            let map = source.suppression_map();
             assert!(
-                !source.suppression_map().has_lint_suppression(),
+                !map.has_lint_suppression(),
                 "expected no lint suppression for {src:?}",
+            );
+            assert!(
+                !map.has_skip_suppression(),
+                "expected no skip suppression for {src:?}",
             );
         }
     }
@@ -274,10 +442,45 @@ mod tests {
     }
 
     #[test]
+    fn multiple_skip_directives_on_one_comment_union_their_rules() {
+        let source = parse("x = 1  # prose: skip[align-equals]  # prose: skip[alphabetize]\n");
+        let map = source.suppression_map();
+        assert!(map.is_format_suppressed_at(line(0), align_equals()));
+        assert!(map.is_format_suppressed_at(line(0), alphabetize()));
+    }
+
+    #[test]
     fn nested_directive_after_non_pragma_hash_is_recognized() {
         let source = parse("x = 1  # my note # prose: ignore\n");
         let map = source.suppression_map();
         assert!(map.is_lint_suppressed_at(line(0), align_equals()));
+    }
+
+    #[test]
+    fn nested_prose_off_after_non_pragma_hash_is_recognized() {
+        let source = parse("# my note # prose: off\nx = 1\n");
+        let x_offset = source.text().find('x').expect("x is present") as u32;
+        assert!(source
+            .suppression_map()
+            .intersects(range(x_offset, x_offset + 5)),);
+    }
+
+    #[test]
+    fn prose_off_and_fmt_off_open_the_same_span() {
+        for text in [
+            "# prose: off\nx = 1\n# prose: on\n",
+            "# fmt: off\nx = 1\n# fmt: on\n",
+            "# prose: off\nx = 1\n",
+            "# fmt: off\nx = 1\n",
+        ] {
+            let src = parse(text);
+            let x_offset = src.text().find('x').expect("x is present") as u32;
+            assert!(
+                src.suppression_map()
+                    .intersects(range(x_offset, x_offset + 5)),
+                "expected suppression to cover `x = 1` in {text:?}",
+            );
+        }
     }
 
     #[test]
@@ -294,6 +497,46 @@ mod tests {
         let map = source.suppression_map();
         assert!(map.is_lint_suppressed_at(line(0), align_equals()));
         assert!(!map.is_lint_suppressed_at(line(0), alphabetize()));
+    }
+
+    #[test]
+    fn skip_brackets_target_only_listed_rules() {
+        let source = parse("x = 1  # prose: skip[align-equals]\n");
+        let map = source.suppression_map();
+        assert!(map.has_skip_suppression());
+        assert!(map.is_format_suppressed_at(line(0), align_equals()));
+        assert!(!map.is_format_suppressed_at(line(0), alphabetize()));
+    }
+
+    #[test]
+    fn skip_multi_id_suppresses_each_listed_rule() {
+        let source = parse("x = 1  # prose: skip[align-equals, alphabetize]\n");
+        let map = source.suppression_map();
+        assert!(map.is_format_suppressed_at(line(0), align_equals()));
+        assert!(map.is_format_suppressed_at(line(0), alphabetize()));
+    }
+
+    #[test]
+    fn skip_unknown_id_is_dropped_silently() {
+        let source = parse("x = 1  # prose: skip[align-equals, not-a-rule]\n");
+        let map = source.suppression_map();
+        assert!(map.is_format_suppressed_at(line(0), align_equals()));
+        assert!(!map.is_format_suppressed_at(line(0), alphabetize()));
+    }
+
+    #[test]
+    fn skip_whitespace_tolerant_inside_brackets() {
+        let canonical = parse("x = 1  # prose: skip[align-equals, alphabetize]\n");
+        let compact = parse("x = 1  # prose:skip[ align-equals ,alphabetize ]\n");
+        let canonical_map = canonical.suppression_map();
+        let compact_map = compact.suppression_map();
+        for rule in [align_equals(), alphabetize()] {
+            assert_eq!(
+                canonical_map.is_format_suppressed_at(line(0), rule),
+                compact_map.is_format_suppressed_at(line(0), rule),
+            );
+            assert!(canonical_map.is_format_suppressed_at(line(0), rule));
+        }
     }
 
     #[test]

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use ruff_python_trivia::{CommentLinePosition, CommentRanges, SuppressionKind};
+use ruff_python_trivia::{CommentLinePosition, CommentRanges, PythonWhitespace, SuppressionKind};
 use ruff_source_file::{LineRanges, OneIndexed, SourceCode};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
@@ -190,7 +190,10 @@ impl Default for RuleEntry {
 /// Strips the leading `prose:` marker from `after_hash` and returns
 /// the trimmed body. Returns `None` for any other shape.
 fn after_prose_prefix(after_hash: &str) -> Option<&str> {
-    after_hash.trim().strip_prefix("prose:").map(str::trim)
+    after_hash
+        .trim_whitespace()
+        .strip_prefix("prose:")
+        .map(str::trim_whitespace)
 }
 
 /// Classifies `comment` against the three format-suppression
@@ -250,7 +253,7 @@ fn parse_bracketed_rule_list(body: &str) -> Option<HashSet<RuleId>> {
         body.strip_prefix('[')?
             .strip_suffix(']')?
             .split(',')
-            .filter_map(|part| part.trim().parse::<RuleId>().ok())
+            .filter_map(|part| part.trim_whitespace().parse::<RuleId>().ok())
             .collect(),
     )
 }
@@ -261,7 +264,7 @@ fn parse_bracketed_rule_list(body: &str) -> Option<HashSet<RuleId>> {
 /// fallback.
 fn parse_prose_format(after_hash: &str) -> Option<FormatDirective> {
     let body = after_prose_prefix(after_hash)?;
-    if let Some(rest) = body.strip_prefix("skip").map(str::trim) {
+    if let Some(rest) = body.strip_prefix("skip").map(str::trim_whitespace) {
         if rest.is_empty() {
             return Some(FormatDirective::Kind(SuppressionKind::Skip));
         }
@@ -281,7 +284,7 @@ fn parse_prose_format(after_hash: &str) -> Option<FormatDirective> {
 fn parse_prose_ignore(after_hash: &str) -> Option<RuleEntry> {
     let body = after_prose_prefix(after_hash)?
         .strip_prefix("ignore")?
-        .trim();
+        .trim_whitespace();
     if body.is_empty() {
         return Some(RuleEntry::All);
     }

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -15,44 +15,6 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::rule::RuleId;
 
-/// One line's parsed `# prose: ignore` or `# prose: skip[<id>]`
-/// directive.
-#[derive(Debug)]
-enum RuleEntry {
-    /// Bare `# prose: ignore`. Suppresses every rule on the line.
-    All,
-    /// `# prose: ignore[<id>[, <id>...]]` or `# prose: skip[<id>[,
-    /// <id>...]]`. Unknown ids are dropped.
-    Specific(HashSet<RuleId>),
-}
-
-impl RuleEntry {
-    /// Returns `true` when `self` suppresses `rule`. `All` matches
-    /// every id, `Specific` matches only listed ids.
-    fn matches(&self, rule: RuleId) -> bool {
-        match self {
-            Self::All => true,
-            Self::Specific(rules) => rules.contains(&rule),
-        }
-    }
-
-    /// Folds `incoming` into `self`. `All` widens any prior `Specific`,
-    /// and a second `Specific` unions its ids into the first.
-    fn merge(&mut self, incoming: Self) {
-        match (&mut *self, incoming) {
-            (Self::All, _) => {}
-            (slot @ Self::Specific(_), Self::All) => *slot = Self::All,
-            (Self::Specific(rules), Self::Specific(more)) => rules.extend(more),
-        }
-    }
-}
-
-impl Default for RuleEntry {
-    fn default() -> Self {
-        Self::Specific(HashSet::new())
-    }
-}
-
 /// Sorted byte-range list for format-suppression spans paired with two
 /// per-line `OneIndexed` maps. `lints` carries `# prose: ignore` per-line
 /// lint directives, `skips` carries `# prose: skip[<id>]` per-rule format
@@ -185,6 +147,44 @@ impl SuppressionMap {
 enum FormatDirective {
     Kind(SuppressionKind),
     SkipRules(HashSet<RuleId>),
+}
+
+/// One line's parsed `# prose: ignore` or `# prose: skip[<id>]`
+/// directive.
+#[derive(Debug)]
+enum RuleEntry {
+    /// Bare `# prose: ignore`. Suppresses every rule on the line.
+    All,
+    /// `# prose: ignore[<id>[, <id>...]]` or `# prose: skip[<id>[,
+    /// <id>...]]`. Unknown ids are dropped.
+    Specific(HashSet<RuleId>),
+}
+
+impl RuleEntry {
+    /// Returns `true` when `self` suppresses `rule`. `All` matches
+    /// every id, `Specific` matches only listed ids.
+    fn matches(&self, rule: RuleId) -> bool {
+        match self {
+            Self::All => true,
+            Self::Specific(rules) => rules.contains(&rule),
+        }
+    }
+
+    /// Folds `incoming` into `self`. `All` widens any prior `Specific`,
+    /// and a second `Specific` unions its ids into the first.
+    fn merge(&mut self, incoming: Self) {
+        match (&mut *self, incoming) {
+            (Self::All, _) => {}
+            (slot @ Self::Specific(_), Self::All) => *slot = Self::All,
+            (Self::Specific(rules), Self::Specific(more)) => rules.extend(more),
+        }
+    }
+}
+
+impl Default for RuleEntry {
+    fn default() -> Self {
+        Self::Specific(HashSet::new())
+    }
 }
 
 /// Strips the leading `prose:` marker from `after_hash` and returns
@@ -545,6 +545,14 @@ mod tests {
         let map = source.suppression_map();
         assert!(map.has_lint_suppression());
         assert!(map.is_lint_suppressed_at(line(0), align_equals()));
+    }
+
+    #[test]
+    fn trailing_prose_off_does_not_open_a_format_span() {
+        let source = parse("x = 1  # prose: off\ny = 2\n");
+        let map = source.suppression_map();
+        assert!(!map.has_format_suppression());
+        assert!(!map.file_is_suppressed());
     }
 
     #[test]

--- a/tests/fixtures/suppression/file_level_fmt_alias.input.py
+++ b/tests/fixtures/suppression/file_level_fmt_alias.input.py
@@ -1,0 +1,14 @@
+# fmt: off
+# A file-level fmt: off at the top of the source is treated
+# identically to prose: off at the top, opting every subsequent
+# line out of every rule.
+
+x = 1
+foo = 2
+bar_baz = 3
+
+config = {"z": 1, "a": 2,}
+
+
+def helper(b, a):
+    pass

--- a/tests/fixtures/suppression/file_level_off.input.py
+++ b/tests/fixtures/suppression/file_level_off.input.py
@@ -1,0 +1,15 @@
+# prose: off
+# A file-level prose: off at the top of the source opts every
+# subsequent line out of every rule. The text below survives
+# untouched across passes regardless of how many rules would
+# otherwise fire.
+
+x = 1
+foo = 2
+bar_baz = 3
+
+config = {"z": 1, "a": 2,}
+
+
+def helper(b, a):
+    pass

--- a/tests/fixtures/suppression/prose_ignore_lint.input.py
+++ b/tests/fixtures/suppression/prose_ignore_lint.input.py
@@ -1,0 +1,9 @@
+"""
+prose: ignore[<rule>] suppresses one named lint diagnostic on its
+line while leaving diagnostics for the same rule on unrelated lines
+in place. The format-side rewrites for every line still apply.
+"""
+
+DEFAULT_LIMIT = 50
+RETRY_INTERVAL = 30  # prose: ignore[loose-constants]
+PAGE_SIZE = 25

--- a/tests/fixtures/suppression/prose_off_block.input.py
+++ b/tests/fixtures/suppression/prose_off_block.input.py
@@ -1,0 +1,21 @@
+"""
+A prose: off / prose: on block sits between two assignment runs that
+the alignment rules would otherwise touch. The block survives
+verbatim while the runs above and below it pad to their group
+widths. The native prose namespace mirrors the fmt namespace's
+span semantics exactly.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+
+# prose: off
+short = 1
+much_longer_name = 2
+mid = 3
+# prose: on
+
+a = 1
+bb = 2
+ccc = 3

--- a/tests/fixtures/suppression/prose_skip_and_ignore.input.py
+++ b/tests/fixtures/suppression/prose_skip_and_ignore.input.py
@@ -1,0 +1,10 @@
+"""
+A line can carry both `# prose: skip[<rule>]` and
+`# prose: ignore[<rule>]` directives. The skip suppresses the
+named format rule's edit, the ignore suppresses the named lint
+rule's diagnostic, and every other rule continues to fire.
+"""
+
+DEFAULT_LIMIT = 50
+RETRY_INTERVAL = func(3, 4,)  # prose: skip[strip-trailing-commas]  # prose: ignore[loose-constants]
+PAGE_SIZE = 25

--- a/tests/fixtures/suppression/prose_skip_line.input.py
+++ b/tests/fixtures/suppression/prose_skip_line.input.py
@@ -1,0 +1,14 @@
+"""
+A trailing prose: skip pins one line's original spacing. The other
+members of the same alignment group still pad to the group's
+target column, and the assignment run after the skip line aligns
+as a separate group, mirroring the bare fmt: skip semantics.
+"""
+
+x = 1
+foo = 2
+bar_baz = 3
+short = 4  # prose: skip
+aa = 5
+bbb = 6
+cccc = 7

--- a/tests/fixtures/suppression/prose_skip_per_rule.input.py
+++ b/tests/fixtures/suppression/prose_skip_per_rule.input.py
@@ -1,0 +1,9 @@
+"""
+prose: skip[<rule>] opts one line out of one named format rule
+while leaving edits from the same rule on neighboring lines in
+place. Here strip-trailing-commas is skipped on the inside call
+but still strips the outside call's trailing comma.
+"""
+
+inside(1, 2, 3,)  # prose: skip[strip-trailing-commas]
+outside(4, 5, 6,)

--- a/tests/fixtures/suppression/prose_skip_with_alignment.input.py
+++ b/tests/fixtures/suppression/prose_skip_with_alignment.input.py
@@ -1,0 +1,11 @@
+"""
+prose: skip[<rule>] opts one line out of one format rule while
+leaving every other format rule's edits in place on the same
+line. Here strip-trailing-commas is skipped on the last
+assignment, but align-equals still composes the `=` column
+across all three lines.
+"""
+
+short = func(1, 2,)
+longer_name = func(3, 4,)
+ccc = func(5, 6,)  # prose: skip[strip-trailing-commas]

--- a/tests/snapshots/suppression/file_level_fmt_alias.diagnostics.snap
+++ b/tests/snapshots/suppression/file_level_fmt_alias.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/file_level_fmt_alias.input.py
+---
+

--- a/tests/snapshots/suppression/file_level_fmt_alias.input.py.snap
+++ b/tests/snapshots/suppression/file_level_fmt_alias.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/file_level_fmt_alias.input.py
+---
+# fmt: off
+# A file-level fmt: off at the top of the source is treated
+# identically to prose: off at the top, opting every subsequent
+# line out of every rule.
+
+x = 1
+foo = 2
+bar_baz = 3
+
+config = {"z": 1, "a": 2,}
+
+
+def helper(b, a):
+    pass

--- a/tests/snapshots/suppression/file_level_off.diagnostics.snap
+++ b/tests/snapshots/suppression/file_level_off.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/file_level_off.input.py
+---
+

--- a/tests/snapshots/suppression/file_level_off.input.py.snap
+++ b/tests/snapshots/suppression/file_level_off.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/file_level_off.input.py
+---
+# prose: off
+# A file-level prose: off at the top of the source opts every
+# subsequent line out of every rule. The text below survives
+# untouched across passes regardless of how many rules would
+# otherwise fire.
+
+x = 1
+foo = 2
+bar_baz = 3
+
+config = {"z": 1, "a": 2,}
+
+
+def helper(b, a):
+    pass

--- a/tests/snapshots/suppression/prose_ignore_lint.diagnostics.snap
+++ b/tests/snapshots/suppression/prose_ignore_lint.diagnostics.snap
@@ -1,0 +1,9 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/prose_ignore_lint.input.py
+---
+align-equals@219..220
+docstring-wrap@69..152
+loose-constants@206..225
+loose-constants@280..294

--- a/tests/snapshots/suppression/prose_ignore_lint.input.py.snap
+++ b/tests/snapshots/suppression/prose_ignore_lint.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/prose_ignore_lint.input.py
+---
+"""
+prose: ignore[<rule>] suppresses one named lint diagnostic on its line
+while leaving diagnostics for the same rule on unrelated lines in place. The
+format-side rewrites for every line still apply.
+"""
+
+DEFAULT_LIMIT  = 50
+RETRY_INTERVAL = 30  # prose: ignore[loose-constants]
+PAGE_SIZE = 25

--- a/tests/snapshots/suppression/prose_off_block.diagnostics.snap
+++ b/tests/snapshots/suppression/prose_off_block.diagnostics.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/prose_off_block.input.py
+---
+align-equals@290..291
+align-equals@298..299
+align-equals@382..383
+align-equals@389..390
+docstring-wrap@72..260

--- a/tests/snapshots/suppression/prose_off_block.input.py.snap
+++ b/tests/snapshots/suppression/prose_off_block.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/prose_off_block.input.py
+---
+"""
+A prose: off / prose: on block sits between two assignment runs that the
+alignment rules would otherwise touch. The block survives verbatim while
+the runs above and below it pad to their group widths. The native prose
+namespace mirrors the fmt namespace's span semantics exactly.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+
+# prose: off
+short = 1
+much_longer_name = 2
+mid = 3
+# prose: on
+
+a   = 1
+bb  = 2
+ccc = 3

--- a/tests/snapshots/suppression/prose_skip_and_ignore.diagnostics.snap
+++ b/tests/snapshots/suppression/prose_skip_and_ignore.diagnostics.snap
@@ -1,0 +1,9 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/prose_skip_and_ignore.input.py
+---
+align-equals@256..257
+docstring-wrap@53..229
+loose-constants@243..262
+loose-constants@364..378

--- a/tests/snapshots/suppression/prose_skip_and_ignore.input.py.snap
+++ b/tests/snapshots/suppression/prose_skip_and_ignore.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/prose_skip_and_ignore.input.py
+---
+"""
+A line can carry both `# prose: skip[<rule>]` and `# prose: ignore[<rule>]`
+directives. The skip suppresses the named format rule's edit, the ignore
+suppresses the named lint rule's diagnostic, and every other rule continues
+to fire.
+"""
+
+DEFAULT_LIMIT  = 50
+RETRY_INTERVAL = func(3, 4,)  # prose: skip[strip-trailing-commas]  # prose: ignore[loose-constants]
+PAGE_SIZE = 25

--- a/tests/snapshots/suppression/prose_skip_line.diagnostics.snap
+++ b/tests/snapshots/suppression/prose_skip_line.diagnostics.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/prose_skip_line.input.py
+---
+align-equals@264..265
+align-equals@272..273
+align-equals@316..317
+align-equals@324..325
+docstring-wrap@70..232

--- a/tests/snapshots/suppression/prose_skip_line.input.py.snap
+++ b/tests/snapshots/suppression/prose_skip_line.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/prose_skip_line.input.py
+---
+"""
+A trailing prose: skip pins one line's original spacing. The other members
+of the same alignment group still pad to the group's target column, and the
+assignment run after the skip line aligns as a separate group, mirroring the
+bare fmt: skip semantics.
+"""
+
+x       = 1
+foo     = 2
+bar_baz = 3
+short = 4  # prose: skip
+aa   = 5
+bbb  = 6
+cccc = 7

--- a/tests/snapshots/suppression/prose_skip_per_rule.diagnostics.snap
+++ b/tests/snapshots/suppression/prose_skip_per_rule.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/prose_skip_per_rule.input.py
+---
+docstring-wrap@66..230
+strip-trailing-commas@321..322

--- a/tests/snapshots/suppression/prose_skip_per_rule.input.py.snap
+++ b/tests/snapshots/suppression/prose_skip_per_rule.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/prose_skip_per_rule.input.py
+---
+"""
+prose: skip[<rule>] opts one line out of one named format rule while leaving
+edits from the same rule on neighboring lines in place. Here strip-trailing-
+commas is skipped on the inside call but still strips the outside call's
+trailing comma.
+"""
+
+inside(1, 2, 3,)  # prose: skip[strip-trailing-commas]
+outside(4, 5, 6)

--- a/tests/snapshots/suppression/prose_skip_with_alignment.diagnostics.snap
+++ b/tests/snapshots/suppression/prose_skip_with_alignment.diagnostics.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/suppression/prose_skip_with_alignment.input.py
+---
+align-equals@278..279
+align-equals@320..321
+docstring-wrap@66..243
+strip-trailing-commas@289..290
+strip-trailing-commas@315..316

--- a/tests/snapshots/suppression/prose_skip_with_alignment.input.py.snap
+++ b/tests/snapshots/suppression/prose_skip_with_alignment.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/suppression/prose_skip_with_alignment.input.py
+---
+"""
+prose: skip[<rule>] opts one line out of one format rule while leaving every
+other format rule's edits in place on the same line. Here strip-trailing-
+commas is skipped on the last assignment, but align-equals still composes
+the `=` column across all three lines.
+"""
+
+short       = func(1, 2)
+longer_name = func(3, 4)
+ccc         = func(5, 6,)  # prose: skip[strip-trailing-commas]


### PR DESCRIPTION
### 🪻 Quick Summary

Audits and completes the `# prose:` directive surface so the namespace stands on its own as the canonical form, with `# fmt:` and `# yapf:` retained as Black-compatibility aliases. The new directives reuse the parsed `SuppressionMap` machinery from #55 and #59 with parser-level recognition rather than a new index structure. The complete surface spans block-level (`# prose: off` / `# prose: on`), line-level (`# prose: skip`, `# prose: skip[<rule>]`, `# prose: ignore`, `# prose: ignore[<rule>]`), and a file-level fast path when an unmatched `# prose: off` precedes every statement.

---

### 🗞️ Key Changes

- Adds `classify_format_directive` in `src/suppression.rs` as the parser entry point for the format-namespace, recognizing `# prose: off|on|skip|skip[<rule>]` directly and falling through to `ruff_python_trivia::SuppressionKind::from_comment` for the `# fmt:` and `# yapf:` aliases, so all three namespaces produce identical `SuppressionKind` results

- Adds a new `FormatDirective::SkipRules(HashSet<RuleId>)` variant, a per-line `skips` map keyed by `OneIndexed`, and `SuppressionMap::is_format_suppressed_at`, so `Pipeline::run`'s edit-retain branch drops edits from any rule listed in `# prose: skip[<rule>]` while leaving edits from other rules on the same line in place

- Adds `SuppressionMap::file_is_suppressed` paired with a `first_code_offset` parameter on `from_comments`, so `Pipeline::run` short-circuits to the identity transform with no diagnostics when an unmatched `# prose: off` (*or alias*) sits at or before the first non-blank, non-comment line of the file

- Rewrites README's Suppression section to lead with the canonical `# prose:` namespace via a table of five directive shapes plus a worked example, with `# fmt:` and `# yapf:` documented as Black-compatibility aliases that map onto their `# prose:` counterparts

- Adds six fixtures under `tests/fixtures/suppression/` covering each `# prose:` directive shape (*block off/on, line skip, per-rule skip, lint ignore*), file-level suppression at the top of the file, and `# fmt: off` alias parity

---

### 🧵 Related Issues

- Closes #135