### PR TITLE
[126] Implement `signature-layout` rule

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -540,6 +540,11 @@ mod tests {
     }
 
     #[test]
+    fn max_inline_params_zero_returns_toml_error() {
+        assert_toml_error("[tool.prose.rules.signature-layout]\nmax-inline-params = 0\n");
+    }
+
+    #[test]
     fn single_use_variables_explicit_allow_pattern_takes_effect() {
         let config = Config::from_pyproject_str(
             "[tool.prose.rules.single-use-variables]\nallow-pattern = \"^tmp_\"\n",

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,6 +206,27 @@ impl Default for LooseConstantsConfig {
     }
 }
 
+/// Configuration for the `signature_layout` rule.
+///
+/// `max_inline_params` caps the count threshold. A positive integer
+/// enforces the cap. `false` disables the count trigger.
+#[derive(Debug, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct SignatureLayoutConfig {
+    pub enabled: bool,
+    #[serde(deserialize_with = "deserialize_max_inline_params")]
+    pub max_inline_params: Option<NonZeroUsize>,
+}
+
+impl Default for SignatureLayoutConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_inline_params: NonZeroUsize::new(3),
+        }
+    }
+}
+
 /// Configuration for the `single_use_variables` rule.
 #[derive(Debug, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
@@ -234,6 +255,25 @@ pub struct ToggleOnly {
 impl Default for ToggleOnly {
     fn default() -> Self {
         Self { enabled: true }
+    }
+}
+
+fn deserialize_max_inline_params<'de, D>(deserializer: D) -> Result<Option<NonZeroUsize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Value {
+        Cap(NonZeroUsize),
+        Off(bool),
+    }
+    match Value::deserialize(deserializer)? {
+        Value::Cap(n) => Ok(Some(n)),
+        Value::Off(false) => Ok(None),
+        Value::Off(true) => Err(serde::de::Error::custom(
+            "`max-inline-params` accepts a positive integer or `false`, not `true`",
+        )),
     }
 }
 
@@ -464,6 +504,39 @@ mod tests {
         let config = Config::load(&nested).expect("loads");
 
         assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+    }
+
+    #[test]
+    fn max_inline_params_explicit_integer_takes_effect() {
+        let config = Config::from_pyproject_str(
+            "[tool.prose.rules.signature-layout]\nmax-inline-params = 5\n",
+        )
+        .expect("parses");
+
+        assert_eq!(
+            config.rules.signature_layout.max_inline_params,
+            NonZeroUsize::new(5),
+        );
+    }
+
+    #[test]
+    fn max_inline_params_false_disables_count_trigger() {
+        let config = Config::from_pyproject_str(
+            "[tool.prose.rules.signature-layout]\nmax-inline-params = false\n",
+        )
+        .expect("parses");
+
+        assert!(config.rules.signature_layout.max_inline_params.is_none());
+    }
+
+    #[test]
+    fn max_inline_params_string_value_returns_toml_error() {
+        assert_toml_error("[tool.prose.rules.signature-layout]\nmax-inline-params = \"off\"\n");
+    }
+
+    #[test]
+    fn max_inline_params_true_returns_toml_error() {
+        assert_toml_error("[tool.prose.rules.signature-layout]\nmax-inline-params = true\n");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -222,7 +222,7 @@ impl Default for SignatureLayoutConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            max_inline_params: NonZeroUsize::new(3),
+            max_inline_params: NonZeroUsize::new(4),
         }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -422,6 +422,7 @@ mod tests {
         config.rules.multi_line_docstrings.enabled = false;
         config.rules.no_single_line_docstrings.enabled = false;
         config.rules.no_step_narration.enabled = false;
+        config.rules.signature_layout.enabled = false;
         config.rules.single_use_variables.enabled = false;
         config.rules.singleton_rule.enabled = false;
         config.rules.strip_trailing_commas.enabled = false;
@@ -464,6 +465,7 @@ mod tests {
         config.rules.loose_constants.enabled = false;
         config.rules.match_case_align.enabled = false;
         config.rules.no_step_narration.enabled = false;
+        config.rules.signature_layout.enabled = false;
         config.rules.single_use_variables.enabled = false;
         config.rules.singleton_rule.enabled = false;
         config.rules.strip_trailing_commas.enabled = false;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 
 use crate::config::{
     AlignmentConfig, BareImportAllowlistConfig, CollectionLayoutConfig, Config,
-    LooseConstantsConfig, SingleUseVariablesConfig, ToggleOnly,
+    LooseConstantsConfig, SignatureLayoutConfig, SingleUseVariablesConfig, ToggleOnly,
 };
 use crate::diagnostics::Diagnostic;
 use crate::pipeline::Pipeline;
@@ -34,6 +34,7 @@ use crate::rules::match_case_align::MatchCaseAlign;
 use crate::rules::multi_line_docstrings::MultiLineDocstrings;
 use crate::rules::no_single_line_docstrings::NoSingleLineDocstrings;
 use crate::rules::no_step_narration::NoStepNarration;
+use crate::rules::signature_layout::SignatureLayout;
 use crate::rules::single_use_variables::SingleUseVariables;
 use crate::rules::singleton_rule::SingletonRule;
 use crate::rules::strip_trailing_commas::StripTrailingCommas;
@@ -303,6 +304,7 @@ register_rules! {
     "blank-lines":               blank_lines:               ToggleOnly                => BlankLines               => "normalize blank-line spacing",
     "bare-import-allowlist":     bare_import_allowlist:     BareImportAllowlistConfig => BareImportAllowlist      => "flag bare import outside allowlist",
     "match-case-align":          match_case_align:          AlignmentConfig           => MatchCaseAlign           => "align match-case arrows",
+    "signature-layout":          signature_layout:          SignatureLayoutConfig     => SignatureLayout          => "normalize function signature to one-line or one-per-line shape",
     "align-imports":             align_imports:             AlignmentConfig           => AlignImports             => "align consecutive `import`s",
     "align-colons":              align_colons:              AlignmentConfig           => AlignColons              => "align consecutive `:` separators",
     "docstring-wrap":            docstring_wrap:            ToggleOnly                => DocstringWrap            => "wrap docstring prose to the configured budget",

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod match_case_align;
 pub(crate) mod multi_line_docstrings;
 pub(crate) mod no_single_line_docstrings;
 pub(crate) mod no_step_narration;
+pub(crate) mod signature_layout;
 pub(crate) mod single_use_variables;
 pub(crate) mod singleton_rule;
 pub(crate) mod strip_trailing_commas;

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -1,18 +1,13 @@
-//! Normalizes function-signature layout to a binary shape. A signature
-//! whose canonical inline form fits under `Config::code_line_length`
-//! and whose parameter count fits under `max_inline_params` collapses
-//! to one line. A signature that trips either threshold expands to
-//! one parameter per line with a trailing comma, opening paren at the
-//! end of the `def` line, and closing paren returning to the `def`'s
-//! own indent. A comment anywhere between `(` and `)` pins the
-//! existing shape.
+//! Normalizes function signatures to a binary shape, one line or one
+//! parameter per line, gated by `code_line_length` and
+//! `max_inline_params`. Comments inside `()` pin the existing shape.
 
 use std::num::NonZeroUsize;
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::{Parameters, Stmt, StmtFunctionDef};
+use ruff_python_ast::{ParameterWithDefault, Parameters, Stmt, StmtFunctionDef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use unicode_width::UnicodeWidthStr;
 
@@ -69,9 +64,7 @@ struct Layout<'a> {
 }
 
 impl Layout<'_> {
-    /// Builds the canonical expanded text starting at `(` and running
-    /// through `:`, with each parameter on its own line at one indent
-    /// step beyond `indent` and the closing `)` at `indent`.
+    /// Builds the canonical expanded text spanning `(` through `:`.
     fn build_expanded(&self, fd: &StmtFunctionDef, indent: usize) -> String {
         let prefix = " ".repeat(indent + INDENT_STEP);
         let mut out = String::from("(");
@@ -88,26 +81,27 @@ impl Layout<'_> {
         out
     }
 
-    /// Builds the canonical inline text starting at `(` and running
-    /// through `:`, joining parameters with `, ` separators.
+    /// Builds the canonical inline text spanning `(` through `:`.
     fn build_inline(&self, fd: &StmtFunctionDef) -> String {
-        let parts: Vec<&str> = self.signature_parts(&fd.parameters).collect();
-        let mut out = format!("({})", parts.join(", "));
+        let mut out = format!(
+            "({})",
+            self.signature_parts(&fd.parameters)
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
         self.push_return_and_colon(&mut out, fd);
         out
     }
 
-    /// Emits one expand or collapse edit for `fd` when its current
-    /// shape diverges from the canonical form implied by the parameter
-    /// count, the spread already in source, and the `code_line_length`
-    /// / `max_inline_params` thresholds.
+    /// Emits one expand or collapse edit when `fd`'s signature
+    /// diverges from the canonical inline-or-expanded form.
     fn process_def(&mut self, fd: &StmtFunctionDef) {
         let params = &fd.parameters;
-        let pin = TextRange::new(
-            params.range().start() + TextSize::from(1u32),
-            params.range().end() - TextSize::from(1u32),
-        );
-        if self.source.intersects_comment(pin) {
+        let one = TextSize::from(1u32);
+        if self
+            .source
+            .intersects_comment(params.range().add_start(one).sub_end(one))
+        {
             return;
         }
         let replacement_range = self.replacement_range(fd);
@@ -170,30 +164,23 @@ impl Layout<'_> {
             .as_deref()
             .map(|va| self.source.slice(va.range()))
             .or((!params.kwonlyargs.is_empty()).then_some("*"));
-        params
-            .posonlyargs
-            .iter()
-            .map(move |p| self.source.slice(p.range()))
+        let kwarg = params
+            .kwarg
+            .as_deref()
+            .map(|kw| self.source.slice(kw.range()));
+        self.slice_params(&params.posonlyargs)
             .chain(posonly_sep)
-            .chain(
-                params
-                    .args
-                    .iter()
-                    .map(move |p| self.source.slice(p.range())),
-            )
+            .chain(self.slice_params(&params.args))
             .chain(star)
-            .chain(
-                params
-                    .kwonlyargs
-                    .iter()
-                    .map(move |p| self.source.slice(p.range())),
-            )
-            .chain(
-                params
-                    .kwarg
-                    .as_deref()
-                    .map(|kw| self.source.slice(kw.range())),
-            )
+            .chain(self.slice_params(&params.kwonlyargs))
+            .chain(kwarg)
+    }
+
+    fn slice_params<'p>(
+        &'p self,
+        params: &'p [ParameterWithDefault],
+    ) -> impl Iterator<Item = &'p str> + 'p {
+        params.iter().map(move |p| self.source.slice(p.range()))
     }
 }
 

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -1,0 +1,207 @@
+//! Normalizes function-signature layout to a binary shape. A signature
+//! whose canonical inline form fits under `Config::code_line_length`
+//! and whose parameter count fits under `max_inline_params` collapses
+//! to one line. A signature that trips either threshold expands to
+//! one parameter per line with a trailing comma, opening paren at the
+//! end of the `def` line, and closing paren returning to the `def`'s
+//! own indent. A comment anywhere between `(` and `)` pins the
+//! existing shape.
+
+use std::num::NonZeroUsize;
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::token::TokenKind;
+use ruff_python_ast::{Parameters, Stmt, StmtFunctionDef};
+use ruff_text_size::{Ranged, TextRange, TextSize};
+use unicode_width::UnicodeWidthStr;
+
+use crate::config::Config;
+use crate::primitives::{edit::narrowed_replacement, INDENT_STEP};
+use crate::rule::{Rule, RuleId};
+use crate::source::Source;
+
+pub(crate) struct SignatureLayout {
+    code_line_length: usize,
+    max_inline_params: Option<usize>,
+}
+
+impl SignatureLayout {
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            code_line_length: config
+                .code_line_length
+                .expect("Config::default synthesizes Some(88)")
+                .get(),
+            max_inline_params: config
+                .rules
+                .signature_layout
+                .max_inline_params
+                .map(NonZeroUsize::get),
+        }
+    }
+}
+
+impl Rule for SignatureLayout {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let mut visitor = Layout {
+            code_line_length: self.code_line_length,
+            edits: Vec::new(),
+            max_inline_params: self.max_inline_params,
+            newline: source.newline_str(),
+            source,
+        };
+        visitor.visit_body(&source.ast().body);
+        visitor.edits
+    }
+
+    fn id(&self) -> RuleId {
+        Self::SLUG
+    }
+}
+
+struct Layout<'a> {
+    code_line_length: usize,
+    edits: Vec<Edit>,
+    max_inline_params: Option<usize>,
+    newline: &'static str,
+    source: &'a Source,
+}
+
+impl Layout<'_> {
+    /// Builds the canonical expanded text starting at `(` and running
+    /// through `:`, with each parameter on its own line at one indent
+    /// step beyond `indent` and the closing `)` at `indent`.
+    fn build_expanded(&self, fd: &StmtFunctionDef, indent: usize) -> String {
+        let prefix = " ".repeat(indent + INDENT_STEP);
+        let mut out = String::from("(");
+        for part in self.signature_parts(&fd.parameters) {
+            out.push_str(self.newline);
+            out.push_str(&prefix);
+            out.push_str(part);
+            out.push(',');
+        }
+        out.push_str(self.newline);
+        out.extend(std::iter::repeat_n(' ', indent));
+        out.push(')');
+        self.push_return_and_colon(&mut out, fd);
+        out
+    }
+
+    /// Builds the canonical inline text starting at `(` and running
+    /// through `:`, joining parameters with `, ` separators.
+    fn build_inline(&self, fd: &StmtFunctionDef) -> String {
+        let parts: Vec<&str> = self.signature_parts(&fd.parameters).collect();
+        let mut out = format!("({})", parts.join(", "));
+        self.push_return_and_colon(&mut out, fd);
+        out
+    }
+
+    /// Emits one expand or collapse edit for `fd` when its current
+    /// shape diverges from the canonical form implied by the parameter
+    /// count, the spread already in source, and the `code_line_length`
+    /// / `max_inline_params` thresholds.
+    fn process_def(&mut self, fd: &StmtFunctionDef) {
+        let params = &fd.parameters;
+        let pin = TextRange::new(
+            params.range().start() + TextSize::from(1u32),
+            params.range().end() - TextSize::from(1u32),
+        );
+        if self.source.intersects_comment(pin) {
+            return;
+        }
+        let replacement_range = self.replacement_range(fd);
+        let inline = self.build_inline(fd);
+        let count_trips = self.max_inline_params.is_some_and(|cap| params.len() > cap);
+        let length_trips =
+            self.source.column_of(params.range().start()) + inline.width() > self.code_line_length;
+        let replacement = if count_trips || length_trips {
+            self.build_expanded(fd, self.source.line_indent_width(fd.start()))
+        } else if self.source.contains_line_break(replacement_range) {
+            inline
+        } else {
+            return;
+        };
+        self.edits.extend(narrowed_replacement(
+            self.source,
+            replacement_range,
+            replacement,
+        ));
+    }
+
+    fn push_return_and_colon(&self, out: &mut String, fd: &StmtFunctionDef) {
+        if let Some(ret) = &fd.returns {
+            out.push_str(" -> ");
+            out.push_str(self.source.slice(ret.range()));
+        }
+        out.push(':');
+    }
+
+    /// Returns the range covering the signature's `(` through `:`,
+    /// the surface this rule rewrites.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `fd.body` is empty or the `:` token cannot be located
+    /// between `)` and the body.
+    fn replacement_range(&self, fd: &StmtFunctionDef) -> TextRange {
+        let body_start = fd
+            .body
+            .first()
+            .expect("function def has a non-empty body")
+            .start();
+        let colon = self
+            .source
+            .first_token_offset_in_range(
+                TextRange::new(fd.parameters.range().end(), body_start),
+                |t| t.kind() == TokenKind::Colon,
+            )
+            .expect("function def carries a `:` between `)` and the body");
+        TextRange::new(fd.parameters.range().start(), colon + TextSize::from(1u32))
+    }
+
+    /// Returns each parameter's source slice in source order, with
+    /// `/` and bare `*` separators inserted at their canonical
+    /// positions. Variadic parameters carry their `*` or `**` prefix.
+    fn signature_parts<'p>(&'p self, params: &'p Parameters) -> impl Iterator<Item = &'p str> + 'p {
+        let posonly_sep = (!params.posonlyargs.is_empty()).then_some("/");
+        let star = params
+            .vararg
+            .as_deref()
+            .map(|va| self.source.slice(va.range()))
+            .or((!params.kwonlyargs.is_empty()).then_some("*"));
+        params
+            .posonlyargs
+            .iter()
+            .map(move |p| self.source.slice(p.range()))
+            .chain(posonly_sep)
+            .chain(
+                params
+                    .args
+                    .iter()
+                    .map(move |p| self.source.slice(p.range())),
+            )
+            .chain(star)
+            .chain(
+                params
+                    .kwonlyargs
+                    .iter()
+                    .map(move |p| self.source.slice(p.range())),
+            )
+            .chain(
+                params
+                    .kwarg
+                    .as_deref()
+                    .map(|kw| self.source.slice(kw.range())),
+            )
+    }
+}
+
+impl<'a> StatementVisitor<'a> for Layout<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        if let Stmt::FunctionDef(fd) = stmt {
+            self.process_def(fd);
+        }
+        walk_stmt(self, stmt);
+    }
+}

--- a/tests/fixtures/composition/signature_with_alignment.config.toml
+++ b/tests/fixtures/composition/signature_with_alignment.config.toml
@@ -1,0 +1,2 @@
+[harness]
+rules = ["alphabetize", "signature-layout", "align-colons", "align-equals"]

--- a/tests/fixtures/composition/signature_with_alignment.input.py
+++ b/tests/fixtures/composition/signature_with_alignment.input.py
@@ -1,0 +1,19 @@
+"""
+A five-parameter signature with out-of-order typed parameters runs
+through `alphabetize` → `signature-layout` → `align-colons` →
+`align-equals` in pipeline order. The composition reorders the
+parameters into required-then-optional alphabetical groups, expands
+the now-long inline form to one parameter per line at the def's
+indent, aligns the type-annotation `:` columns within the expanded
+shape, and aligns the default `=` columns across the optional run.
+
+Rules:
+- alphabetize
+- signature-layout
+- align-colons
+- align-equals
+"""
+
+
+def configure(zebra: str, alpha: int, beta: float, mango: bool = False, delta: float = 0.5):
+    return (zebra, alpha, beta, mango, delta)

--- a/tests/fixtures/config/full_override.toml
+++ b/tests/fixtures/config/full_override.toml
@@ -46,6 +46,10 @@ enabled = false
 [tool.prose.rules.no-step-narration]
 enabled = false
 
+[tool.prose.rules.signature-layout]
+enabled = false
+max-inline-params = false
+
 [tool.prose.rules.single-use-variables]
 allow-pattern = "^tmp_"
 enabled = false

--- a/tests/fixtures/signature_layout/async_and_nested.input.py
+++ b/tests/fixtures/signature_layout/async_and_nested.input.py
@@ -1,10 +1,12 @@
 """
-Async definitions and nested definitions both qualify.
+Async and nested function definitions both walk through the rule.
+The outer `async def` and the inner sync `def` each trip the count
+trigger and expand at their own indents, pinning that the walker
+descends recursively rather than stopping at the outer body.
 """
 
 
-async def outer(target, palette, layout, spread):
-    def inner(host, port, retries, timeout):
-        return (host, port, retries, timeout)
-
-    return await inner(target, palette, layout, spread)
+async def outer(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):
+    def inner(host: str, port: int, retries: int, timeout: float, verbose: bool):
+        return (host, port, retries, timeout, verbose)
+    return await inner(palette, 8080, 3, 10.0, verbose)

--- a/tests/fixtures/signature_layout/async_and_nested.input.py
+++ b/tests/fixtures/signature_layout/async_and_nested.input.py
@@ -6,7 +6,7 @@ descends recursively rather than stopping at the outer body.
 """
 
 
-async def outer(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):
+async def outer(layout: tuple[int, int], palette: str, spread: float, target: int, verbose: bool):
     def inner(host: str, port: int, retries: int, timeout: float, verbose: bool):
         return (host, port, retries, timeout, verbose)
     return await inner(palette, 8080, 3, 10.0, verbose)

--- a/tests/fixtures/signature_layout/async_and_nested.input.py
+++ b/tests/fixtures/signature_layout/async_and_nested.input.py
@@ -1,0 +1,10 @@
+"""
+Async definitions and nested definitions both qualify.
+"""
+
+
+async def outer(target, palette, layout, spread):
+    def inner(host, port, retries, timeout):
+        return (host, port, retries, timeout)
+
+    return await inner(target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/basic.input.py
+++ b/tests/fixtures/signature_layout/basic.input.py
@@ -1,8 +1,9 @@
 """
-Four-parameter signature whose inline form fits the line-length budget
-but exceeds the default `max-inline-params` cap of three.
+A five-parameter signature whose inline form fits the line budget
+pins the count trigger firing alone. The rule expands solely on the
+parameter count exceeding `max-inline-params`.
 """
 
 
-def render(target, source, layout, palette):
-    return (target, source, layout, palette)
+def render(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):
+    return (target, palette, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/basic.input.py
+++ b/tests/fixtures/signature_layout/basic.input.py
@@ -5,5 +5,5 @@ parameter count exceeding `max-inline-params`.
 """
 
 
-def render(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):
-    return (target, palette, layout, spread, verbose)
+def render(layout: tuple[int, int], palette: str, spread: float, target: int, verbose: bool):
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/basic.input.py
+++ b/tests/fixtures/signature_layout/basic.input.py
@@ -1,0 +1,8 @@
+"""
+Four-parameter signature whose inline form fits the line-length budget
+but exceeds the default `max-inline-params` cap of three.
+"""
+
+
+def render(target, source, layout, palette):
+    return (target, source, layout, palette)

--- a/tests/fixtures/signature_layout/class_method.input.py
+++ b/tests/fixtures/signature_layout/class_method.input.py
@@ -1,0 +1,9 @@
+"""
+A four-parameter method inside a class body trips the count trigger
+and expands at the method's own indent.
+"""
+
+
+class Renderer:
+    def render(self, target, palette, layout):
+        return (self, target, palette, layout)

--- a/tests/fixtures/signature_layout/class_method.input.py
+++ b/tests/fixtures/signature_layout/class_method.input.py
@@ -7,5 +7,5 @@ defs, with the indent derived from the method's own `def` position.
 
 
 class Renderer:
-    def render(self, target: int, palette: str, layout: tuple[int, int], spread: float):
-        return (self, target, palette, layout, spread)
+    def render(self, layout: tuple[int, int], palette: str, spread: float, target: int):
+        return (self, layout, palette, spread, target)

--- a/tests/fixtures/signature_layout/class_method.input.py
+++ b/tests/fixtures/signature_layout/class_method.input.py
@@ -1,9 +1,11 @@
 """
-A four-parameter method inside a class body trips the count trigger
-and expands at the method's own indent.
+A class method with `self` and four typed parameters trips the count
+trigger and expands at the class-body indent. Pins the walker
+descending into class bodies the same way it descends into top-level
+defs, with the indent derived from the method's own `def` position.
 """
 
 
 class Renderer:
-    def render(self, target, palette, layout):
-        return (self, target, palette, layout)
+    def render(self, target: int, palette: str, layout: tuple[int, int], spread: float):
+        return (self, target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/collapse.input.py
+++ b/tests/fixtures/signature_layout/collapse.input.py
@@ -1,11 +1,13 @@
 """
-Multi-line signature whose two parameters fit inline under both
-thresholds.
+A two-parameter signature already in expanded shape whose inline form
+fits under both thresholds collapses back to a single line. Pins the
+reverse direction of the rewrite as direction-symmetric with
+expansion.
 """
 
 
 def render(
-    target,
-    palette,
+    target: int,
+    palette: str,
 ):
     return (target, palette)

--- a/tests/fixtures/signature_layout/collapse.input.py
+++ b/tests/fixtures/signature_layout/collapse.input.py
@@ -7,7 +7,7 @@ expansion.
 
 
 def render(
-    target: int,
     palette: str,
+    target: int,
 ):
-    return (target, palette)
+    return (palette, target)

--- a/tests/fixtures/signature_layout/collapse.input.py
+++ b/tests/fixtures/signature_layout/collapse.input.py
@@ -1,0 +1,11 @@
+"""
+Multi-line signature whose two parameters fit inline under both
+thresholds.
+"""
+
+
+def render(
+    target,
+    palette,
+):
+    return (target, palette)

--- a/tests/fixtures/signature_layout/count_trigger_off.config.toml
+++ b/tests/fixtures/signature_layout/count_trigger_off.config.toml
@@ -1,0 +1,2 @@
+[tool.prose.rules.signature-layout]
+max-inline-params = false

--- a/tests/fixtures/signature_layout/count_trigger_off.input.py
+++ b/tests/fixtures/signature_layout/count_trigger_off.input.py
@@ -6,5 +6,5 @@ the disabled-count configuration.
 """
 
 
-def render(target: int, palette: str, layout: int, spread: float, verbose: bool):
-    return (target, palette, layout, spread, verbose)
+def render(layout: int, palette: str, spread: float, target: int, verbose: bool):
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/count_trigger_off.input.py
+++ b/tests/fixtures/signature_layout/count_trigger_off.input.py
@@ -1,8 +1,10 @@
 """
-Five-parameter signature whose inline form fits the line budget. The
-count trigger is disabled via `max-inline-params = false`.
+A five-parameter signature whose inline form fits the line budget
+stays inline when `max-inline-params = false` disables the count
+trigger entirely. Pins line-length as the sole expansion gate under
+the disabled-count configuration.
 """
 
 
-def render(a, b, c, d, e):
-    return (a, b, c, d, e)
+def render(target: int, palette: str, layout: int, spread: float, verbose: bool):
+    return (target, palette, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/count_trigger_off.input.py
+++ b/tests/fixtures/signature_layout/count_trigger_off.input.py
@@ -1,0 +1,8 @@
+"""
+Five-parameter signature whose inline form fits the line budget. The
+count trigger is disabled via `max-inline-params = false`.
+"""
+
+
+def render(a, b, c, d, e):
+    return (a, b, c, d, e)

--- a/tests/fixtures/signature_layout/decorated.input.py
+++ b/tests/fixtures/signature_layout/decorated.input.py
@@ -9,5 +9,5 @@ from functools import cache
 
 
 @cache
-def render(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):
-    return (target, palette, layout, spread, verbose)
+def render(layout: tuple[int, int], palette: str, spread: float, target: int, verbose: bool):
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/decorated.input.py
+++ b/tests/fixtures/signature_layout/decorated.input.py
@@ -1,10 +1,13 @@
 """
-A `@cache` decorator above the `def` and a four-parameter signature.
+A `@cache`-decorated function with a five-parameter signature trips
+the count trigger and expands. The decorator surface stays untouched
+because the rule's replacement range starts at `(`, leaving lines
+above the `def` keyword out of scope.
 """
 
 from functools import cache
 
 
 @cache
-def render(target, palette, layout, spread):
-    return (target, palette, layout, spread)
+def render(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):
+    return (target, palette, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/decorated.input.py
+++ b/tests/fixtures/signature_layout/decorated.input.py
@@ -1,0 +1,10 @@
+"""
+A `@cache` decorator above the `def` and a four-parameter signature.
+"""
+
+from functools import cache
+
+
+@cache
+def render(target, palette, layout, spread):
+    return (target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/empty_params.input.py
+++ b/tests/fixtures/signature_layout/empty_params.input.py
@@ -1,0 +1,7 @@
+"""
+An empty parameter list.
+"""
+
+
+def render():
+    return 1

--- a/tests/fixtures/signature_layout/empty_params.input.py
+++ b/tests/fixtures/signature_layout/empty_params.input.py
@@ -1,5 +1,8 @@
 """
-An empty parameter list.
+A zero-parameter signature trips neither threshold, leaving the def
+untouched. Pins the rule's no-op path on the degenerate input shape,
+confirming the rewrite gates close cleanly when there is nothing to
+count or measure.
 """
 
 

--- a/tests/fixtures/signature_layout/expand_on_length.input.py
+++ b/tests/fixtures/signature_layout/expand_on_length.input.py
@@ -1,8 +1,9 @@
 """
-Three-parameter signature whose inline form sits well past 88 columns
-even though the count threshold is satisfied.
+A three-parameter signature whose inline form overflows the default
+`code-line-length` of 88 columns pins the length trigger firing
+alone, with the parameter count comfortably under the cap.
 """
 
 
-def render(left_descriptor_for_layout, right_descriptor_for_layout, palette_descriptor_for_layout):
-    return (left_descriptor_for_layout, right_descriptor_for_layout, palette_descriptor_for_layout)
+def render(left_descriptor: LayoutLayer, right_descriptor: LayoutLayer, palette_descriptor: PaletteSpec):
+    return (left_descriptor, right_descriptor, palette_descriptor)

--- a/tests/fixtures/signature_layout/expand_on_length.input.py
+++ b/tests/fixtures/signature_layout/expand_on_length.input.py
@@ -1,0 +1,8 @@
+"""
+Three-parameter signature whose inline form sits well past 88 columns
+even though the count threshold is satisfied.
+"""
+
+
+def render(left_descriptor_for_layout, right_descriptor_for_layout, palette_descriptor_for_layout):
+    return (left_descriptor_for_layout, right_descriptor_for_layout, palette_descriptor_for_layout)

--- a/tests/fixtures/signature_layout/expand_on_length.input.py
+++ b/tests/fixtures/signature_layout/expand_on_length.input.py
@@ -5,5 +5,5 @@ alone, with the parameter count comfortably under the cap.
 """
 
 
-def render(left_descriptor: LayoutLayer, right_descriptor: LayoutLayer, palette_descriptor: PaletteSpec):
-    return (left_descriptor, right_descriptor, palette_descriptor)
+def render(left_descriptor: LayoutLayer, palette_descriptor: PaletteSpec, right_descriptor: LayoutLayer):
+    return (left_descriptor, palette_descriptor, right_descriptor)

--- a/tests/fixtures/signature_layout/idempotent.input.py
+++ b/tests/fixtures/signature_layout/idempotent.input.py
@@ -1,0 +1,17 @@
+"""
+Two signatures already at their canonical shape. An inline form with
+two parameters and an expanded form with four.
+"""
+
+
+def already_inline(target, palette):
+    return (target, palette)
+
+
+def already_expanded(
+    target,
+    palette,
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/idempotent.input.py
+++ b/tests/fixtures/signature_layout/idempotent.input.py
@@ -7,15 +7,15 @@ on inputs that match either canonical shape.
 """
 
 
-def already_inline(target: int, palette: str):
-    return (target, palette)
+def already_inline(palette: str, target: int):
+    return (palette, target)
 
 
 def already_expanded(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/idempotent.input.py
+++ b/tests/fixtures/signature_layout/idempotent.input.py
@@ -1,17 +1,21 @@
 """
-Two signatures already at their canonical shape. An inline form with
-two parameters and an expanded form with four.
+Two signatures already at their canonical shape stay untouched. The
+inline form with two parameters fits both thresholds, and the
+expanded form with five parameters trips the count trigger but
+already lands at the rewrite target. Pins the rule's no-op behavior
+on inputs that match either canonical shape.
 """
 
 
-def already_inline(target, palette):
+def already_inline(target: int, palette: str):
     return (target, palette)
 
 
 def already_expanded(
-    target,
-    palette,
-    layout,
-    spread,
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/length_trigger_custom_budget.config.toml
+++ b/tests/fixtures/signature_layout/length_trigger_custom_budget.config.toml
@@ -1,0 +1,2 @@
+[tool.prose]
+code-line-length = 50

--- a/tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
+++ b/tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
@@ -6,5 +6,5 @@ configured threshold rather than a hard-coded one.
 """
 
 
-def render(left: LayoutLayer, right: LayoutLayer, palette: PaletteSpec):
-    return (left, right, palette)
+def render(left: LayoutLayer, palette: PaletteSpec, right: LayoutLayer):
+    return (left, palette, right)

--- a/tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
+++ b/tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
@@ -1,8 +1,10 @@
 """
-Three-parameter signature whose inline form would sit at 71 columns,
-forcing expansion under a `code-line-length` of 50.
+A three-parameter signature whose inline form fits the default
+`code-line-length` of 88 but overflows a custom budget of 50 expands
+under the custom budget. Pins the line-length trigger consuming the
+configured threshold rather than a hard-coded one.
 """
 
 
-def fn(aaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc):
-    return aaaaaaaaaaaaaaaaaaa
+def render(left: LayoutLayer, right: LayoutLayer, palette: PaletteSpec):
+    return (left, right, palette)

--- a/tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
+++ b/tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
@@ -1,0 +1,8 @@
+"""
+Three-parameter signature whose inline form would sit at 71 columns,
+forcing expansion under a `code-line-length` of 50.
+"""
+
+
+def fn(aaaaaaaaaaaaaaaaaaa, bbbbbbbbbbbbbbbbbbb, cccccccccccccccccccc):
+    return aaaaaaaaaaaaaaaaaaa

--- a/tests/fixtures/signature_layout/no_trailing_comma.input.py
+++ b/tests/fixtures/signature_layout/no_trailing_comma.input.py
@@ -1,0 +1,12 @@
+"""
+Multi-line signature whose last parameter carries no trailing comma.
+"""
+
+
+def render(
+    target,
+    palette,
+    layout,
+    spread
+):
+    return (target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/no_trailing_comma.input.py
+++ b/tests/fixtures/signature_layout/no_trailing_comma.input.py
@@ -1,12 +1,16 @@
 """
-Multi-line signature whose last parameter carries no trailing comma.
+A multi-line signature whose last parameter lacks a trailing comma
+gets the trailing comma added in the canonical expansion. Pins the
+rewrite's trailing-comma invariant against source variants that omit
+it.
 """
 
 
 def render(
-    target,
-    palette,
-    layout,
-    spread
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/no_trailing_comma.input.py
+++ b/tests/fixtures/signature_layout/no_trailing_comma.input.py
@@ -7,10 +7,10 @@ it.
 
 
 def render(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/parameter_shapes.input.py
+++ b/tests/fixtures/signature_layout/parameter_shapes.input.py
@@ -7,5 +7,5 @@ synthesizing a different shape.
 """
 
 
-def render(target: int, palette: str, /, *, layout: tuple[int, int], spread: float, verbose: bool = False) -> tuple[int, str]:
-    return (target, palette, layout, spread, verbose)
+def render(palette: str, target: int, /, *, layout: tuple[int, int], spread: float, verbose: bool = False) -> tuple[int, str]:
+    return (palette, target, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/parameter_shapes.input.py
+++ b/tests/fixtures/signature_layout/parameter_shapes.input.py
@@ -1,8 +1,11 @@
 """
-Defaults, `/` and `*` separators, and a return-type annotation
-round-trip through the expansion.
+The expansion preserves every parameter-list shape (*defaults, the
+posonly-only `/` separator, the bare `*` separator, and a return-type
+annotation*) verbatim from source. Pins the slice machinery rendering
+each canonical separator at its source position rather than
+synthesizing a different shape.
 """
 
 
-def render(target, palette, /, *, layout, spread=None) -> tuple[int, str]:
-    return (target, palette, layout, spread)
+def render(target: int, palette: str, /, *, layout: tuple[int, int], spread: float, verbose: bool = False) -> tuple[int, str]:
+    return (target, palette, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/parameter_shapes.input.py
+++ b/tests/fixtures/signature_layout/parameter_shapes.input.py
@@ -1,0 +1,8 @@
+"""
+Defaults, `/` and `*` separators, and a return-type annotation
+round-trip through the expansion.
+"""
+
+
+def render(target, palette, /, *, layout, spread=None) -> tuple[int, str]:
+    return (target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/return_annotation.input.py
+++ b/tests/fixtures/signature_layout/return_annotation.input.py
@@ -1,0 +1,10 @@
+"""
+A single annotated parameter on its own line, with a return
+annotation.
+"""
+
+
+def render(
+    target: int,
+) -> int:
+    return target

--- a/tests/fixtures/signature_layout/return_annotation.input.py
+++ b/tests/fixtures/signature_layout/return_annotation.input.py
@@ -1,6 +1,8 @@
 """
-A single annotated parameter on its own line, with a return
-annotation.
+A single typed parameter in expanded shape collapses to an inline
+signature when the inline form fits under both thresholds. Pins the
+return annotation following the closing `)` on the same line as the
+inline form, rather than landing on its own line.
 """
 
 

--- a/tests/fixtures/signature_layout/trailing_def_line_comment.input.py
+++ b/tests/fixtures/signature_layout/trailing_def_line_comment.input.py
@@ -1,0 +1,8 @@
+"""
+Four-parameter signature with a trailing comment on the `def` line
+after `:`.
+"""
+
+
+def render(target, palette, layout, spread):  # entry point
+    return (target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/trailing_def_line_comment.input.py
+++ b/tests/fixtures/signature_layout/trailing_def_line_comment.input.py
@@ -6,5 +6,5 @@ strictly between the opening `(` and closing `)`.
 """
 
 
-def render(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):  # entry point
-    return (target, palette, layout, spread, verbose)
+def render(layout: tuple[int, int], palette: str, spread: float, target: int, verbose: bool):  # entry point
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/trailing_def_line_comment.input.py
+++ b/tests/fixtures/signature_layout/trailing_def_line_comment.input.py
@@ -1,8 +1,10 @@
 """
-Four-parameter signature with a trailing comment on the `def` line
-after `:`.
+A trailing comment on the `def` line after `:` sits outside `(...)`
+and so does not pin the signature. The rule still expands when count
+or length trips, confirming the pin check covers only comments
+strictly between the opening `(` and closing `)`.
 """
 
 
-def render(target, palette, layout, spread):  # entry point
-    return (target, palette, layout, spread)
+def render(target: int, palette: str, layout: tuple[int, int], spread: float, verbose: bool):  # entry point
+    return (target, palette, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/type_parameters.input.py
+++ b/tests/fixtures/signature_layout/type_parameters.input.py
@@ -1,0 +1,8 @@
+"""
+Generic-syntax type parameters sit between the function name and the
+opening `(`. The return annotation references the type parameter.
+"""
+
+
+def render[T](target: T, palette: T, layout: T, spread: T) -> tuple[T, T]:
+    return (target, palette)

--- a/tests/fixtures/signature_layout/type_parameters.input.py
+++ b/tests/fixtures/signature_layout/type_parameters.input.py
@@ -1,8 +1,11 @@
 """
-Generic-syntax type parameters sit between the function name and the
-opening `(`. The return annotation references the type parameter.
+A generic function with PEP 695 type parameters between the name and
+`(` expands when its parameter count trips the cap. The type
+parameter list, the parameter annotations, and the return annotation
+each survive the rewrite intact because the replacement range starts
+at `(` rather than at the function name.
 """
 
 
-def render[T](target: T, palette: T, layout: T, spread: T) -> tuple[T, T]:
-    return (target, palette)
+def render[T](alpha: T, beta: T, delta: T, gamma: T, target: T) -> tuple[T, T]:
+    return (alpha, beta)

--- a/tests/fixtures/signature_layout/typed_annotations.input.py
+++ b/tests/fixtures/signature_layout/typed_annotations.input.py
@@ -1,0 +1,14 @@
+"""
+A signature carrying a rich variety of type annotations (*a
+`Callable` parameter, a generic `Mapping`, an `Annotated` wrapper, a
+tuple alias, and an `Optional` default*) expands to the one-per-line
+shape with each annotation's source slice preserved verbatim across
+the rewrite.
+"""
+
+from collections.abc import Callable, Mapping
+from typing import Annotated, Any, Optional
+
+
+def configure(callback: Callable[[int, str], bool], config: Mapping[str, Any], metadata: Annotated[dict[str, int], "extra"], tags: tuple[str, ...], timeout: Optional[float] = None) -> tuple[bool, str]:
+    return (True, "ok")

--- a/tests/fixtures/signature_layout/variadics.input.py
+++ b/tests/fixtures/signature_layout/variadics.input.py
@@ -1,9 +1,10 @@
 """
-A signature that mixes positional parameters with `*args` and
-`**kwargs`. Each variadic slot counts as one parameter for the count
-trigger.
+A signature mixing positional parameters, `*args`, kwonly parameters,
+and `**kwargs` pins each variadic's `*` or `**` prefix carrying
+through to the expanded form. Every variadic slot counts as one
+parameter for the count trigger.
 """
 
 
-def dispatch(target, palette, *args, layout, spread=None, **kwargs):
+def dispatch(target: int, palette: str, *args: int, layout: tuple[int, int], spread: float = 0.0, **kwargs: object):
     return (target, palette, layout, spread, args, kwargs)

--- a/tests/fixtures/signature_layout/variadics.input.py
+++ b/tests/fixtures/signature_layout/variadics.input.py
@@ -1,0 +1,9 @@
+"""
+A signature that mixes positional parameters with `*args` and
+`**kwargs`. Each variadic slot counts as one parameter for the count
+trigger.
+"""
+
+
+def dispatch(target, palette, *args, layout, spread=None, **kwargs):
+    return (target, palette, layout, spread, args, kwargs)

--- a/tests/fixtures/signature_layout/variadics.input.py
+++ b/tests/fixtures/signature_layout/variadics.input.py
@@ -6,5 +6,5 @@ parameter for the count trigger.
 """
 
 
-def dispatch(target: int, palette: str, *args: int, layout: tuple[int, int], spread: float = 0.0, **kwargs: object):
-    return (target, palette, layout, spread, args, kwargs)
+def dispatch(palette: str, target: int, *args: int, layout: tuple[int, int], spread: float = 0.0, **kwargs: object):
+    return (palette, target, layout, spread, args, kwargs)

--- a/tests/fixtures/signature_layout/with_comments.input.py
+++ b/tests/fixtures/signature_layout/with_comments.input.py
@@ -7,21 +7,21 @@ Both own-line and trailing-line comment placements anchor.
 
 
 def own_line_pin(
-    target: int,
+    layout: tuple[int, int],
     # comment between parameters
     palette: str,
-    layout: tuple[int, int],
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)
 
 
 def trailing_line_pin(
-    target: int,
-    palette: str,  # trailing on a parameter line
     layout: tuple[int, int],
+    palette: str,  # trailing on a parameter line
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/with_comments.input.py
+++ b/tests/fixtures/signature_layout/with_comments.input.py
@@ -1,0 +1,23 @@
+"""
+Comments between the opening `(` and closing `)` pin the existing
+shape. Both own-line and trailing-line comments anchor each parameter.
+"""
+
+
+def own_line_pin(
+    target,
+    # comment between parameters
+    palette,
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)
+
+
+def trailing_line_pin(
+    target,
+    palette,  # trailing on a parameter line
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)

--- a/tests/fixtures/signature_layout/with_comments.input.py
+++ b/tests/fixtures/signature_layout/with_comments.input.py
@@ -1,23 +1,27 @@
 """
-Comments between the opening `(` and closing `)` pin the existing
-shape. Both own-line and trailing-line comments anchor each parameter.
+A comment anywhere between `(` and `)` pins the existing shape,
+overriding both count and length triggers. Each pinned signature
+keeps its comment in place rather than getting rewritten around.
+Both own-line and trailing-line comment placements anchor.
 """
 
 
 def own_line_pin(
-    target,
+    target: int,
     # comment between parameters
-    palette,
-    layout,
-    spread,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)
 
 
 def trailing_line_pin(
-    target,
-    palette,  # trailing on a parameter line
-    layout,
-    spread,
+    target: int,
+    palette: str,  # trailing on a parameter line
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/composition/signature_with_alignment.diagnostics.snap
+++ b/tests/snapshots/composition/signature_with_alignment.diagnostics.snap
@@ -1,0 +1,13 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/composition/signature_with_alignment.input.py
+---
+align-colons@569..569
+align-colons@584..584
+align-colons@602..602
+align-colons@618..618
+align-colons@642..642
+align-equals@654..655
+alphabetize@559..635
+signature-layout@559..635

--- a/tests/snapshots/composition/signature_with_alignment.input.py.snap
+++ b/tests/snapshots/composition/signature_with_alignment.input.py.snap
@@ -1,0 +1,30 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/composition/signature_with_alignment.input.py
+---
+"""
+A five-parameter signature with out-of-order typed parameters runs
+through `alphabetize` → `signature-layout` → `align-colons` →
+`align-equals` in pipeline order. The composition reorders the
+parameters into required-then-optional alphabetical groups, expands
+the now-long inline form to one parameter per line at the def's
+indent, aligns the type-annotation `:` columns within the expanded
+shape, and aligns the default `=` columns across the optional run.
+
+Rules:
+- alphabetize
+- signature-layout
+- align-colons
+- align-equals
+"""
+
+
+def configure(
+    alpha : int,
+    beta  : float,
+    zebra : str,
+    delta : float = 0.5,
+    mango : bool  = False,
+):
+    return (zebra, alpha, beta, mango, delta)

--- a/tests/snapshots/config/full_override.snap
+++ b/tests/snapshots/config/full_override.snap
@@ -48,6 +48,10 @@ Config {
             max_shift: 8,
             max_shift_policy: Split,
         },
+        signature_layout: SignatureLayoutConfig {
+            enabled: false,
+            max_inline_params: None,
+        },
         align_imports: AlignmentConfig {
             enabled: false,
             max_shift: 8,

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -51,7 +51,7 @@ Config {
         signature_layout: SignatureLayoutConfig {
             enabled: true,
             max_inline_params: Some(
-                3,
+                4,
             ),
         },
         align_imports: AlignmentConfig {

--- a/tests/snapshots/config/target_version_only.snap
+++ b/tests/snapshots/config/target_version_only.snap
@@ -48,6 +48,12 @@ Config {
             max_shift: 8,
             max_shift_policy: Split,
         },
+        signature_layout: SignatureLayoutConfig {
+            enabled: true,
+            max_inline_params: Some(
+                3,
+            ),
+        },
         align_imports: AlignmentConfig {
             enabled: true,
             max_shift: 8,

--- a/tests/snapshots/signature_layout/async_and_nested.diagnostics.snap
+++ b/tests/snapshots/signature_layout/async_and_nested.diagnostics.snap
@@ -3,5 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/async_and_nested.input.py
 ---
-signature-layout@129..157
-signature-layout@81..112
+signature-layout@285..365
+signature-layout@382..447

--- a/tests/snapshots/signature_layout/async_and_nested.diagnostics.snap
+++ b/tests/snapshots/signature_layout/async_and_nested.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/async_and_nested.input.py
+---
+signature-layout@129..157
+signature-layout@81..112

--- a/tests/snapshots/signature_layout/async_and_nested.input.py.snap
+++ b/tests/snapshots/signature_layout/async_and_nested.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/async_and_nested.input.py
+---
+"""
+Async definitions and nested definitions both qualify.
+"""
+
+
+async def outer(
+    target,
+    palette,
+    layout,
+    spread,
+):
+    def inner(
+        host,
+        port,
+        retries,
+        timeout,
+    ):
+        return (host, port, retries, timeout)
+
+    return await inner(target, palette, layout, spread)

--- a/tests/snapshots/signature_layout/async_and_nested.input.py.snap
+++ b/tests/snapshots/signature_layout/async_and_nested.input.py.snap
@@ -12,10 +12,10 @@ descends recursively rather than stopping at the outer body.
 
 
 async def outer(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool,
 ):
     def inner(

--- a/tests/snapshots/signature_layout/async_and_nested.input.py.snap
+++ b/tests/snapshots/signature_layout/async_and_nested.input.py.snap
@@ -4,22 +4,26 @@ expression: output
 input_file: tests/fixtures/signature_layout/async_and_nested.input.py
 ---
 """
-Async definitions and nested definitions both qualify.
+Async and nested function definitions both walk through the rule.
+The outer `async def` and the inner sync `def` each trip the count
+trigger and expand at their own indents, pinning that the walker
+descends recursively rather than stopping at the outer body.
 """
 
 
 async def outer(
-    target,
-    palette,
-    layout,
-    spread,
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
     def inner(
-        host,
-        port,
-        retries,
-        timeout,
+        host: str,
+        port: int,
+        retries: int,
+        timeout: float,
+        verbose: bool,
     ):
-        return (host, port, retries, timeout)
-
-    return await inner(target, palette, layout, spread)
+        return (host, port, retries, timeout, verbose)
+    return await inner(palette, 8080, 3, 10.0, verbose)

--- a/tests/snapshots/signature_layout/basic.diagnostics.snap
+++ b/tests/snapshots/signature_layout/basic.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/basic.input.py
 ---
-signature-layout@150..181
+signature-layout@202..282

--- a/tests/snapshots/signature_layout/basic.diagnostics.snap
+++ b/tests/snapshots/signature_layout/basic.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/basic.input.py
+---
+signature-layout@150..181

--- a/tests/snapshots/signature_layout/basic.input.py.snap
+++ b/tests/snapshots/signature_layout/basic.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/basic.input.py
+---
+"""
+Four-parameter signature whose inline form fits the line-length budget
+but exceeds the default `max-inline-params` cap of three.
+"""
+
+
+def render(
+    target,
+    source,
+    layout,
+    palette,
+):
+    return (target, source, layout, palette)

--- a/tests/snapshots/signature_layout/basic.input.py.snap
+++ b/tests/snapshots/signature_layout/basic.input.py.snap
@@ -11,10 +11,10 @@ parameter count exceeding `max-inline-params`.
 
 
 def render(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/snapshots/signature_layout/basic.input.py.snap
+++ b/tests/snapshots/signature_layout/basic.input.py.snap
@@ -4,15 +4,17 @@ expression: output
 input_file: tests/fixtures/signature_layout/basic.input.py
 ---
 """
-Four-parameter signature whose inline form fits the line-length budget
-but exceeds the default `max-inline-params` cap of three.
+A five-parameter signature whose inline form fits the line budget
+pins the count trigger firing alone. The rule expands solely on the
+parameter count exceeding `max-inline-params`.
 """
 
 
 def render(
-    target,
-    source,
-    layout,
-    palette,
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, source, layout, palette)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/class_method.diagnostics.snap
+++ b/tests/snapshots/signature_layout/class_method.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/class_method.input.py
 ---
-signature-layout@149..178
+signature-layout@309..380

--- a/tests/snapshots/signature_layout/class_method.diagnostics.snap
+++ b/tests/snapshots/signature_layout/class_method.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/class_method.input.py
+---
+signature-layout@149..178

--- a/tests/snapshots/signature_layout/class_method.input.py.snap
+++ b/tests/snapshots/signature_layout/class_method.input.py.snap
@@ -4,16 +4,19 @@ expression: output
 input_file: tests/fixtures/signature_layout/class_method.input.py
 ---
 """
-A four-parameter method inside a class body trips the count trigger
-and expands at the method's own indent.
+A class method with `self` and four typed parameters trips the count
+trigger and expands at the class-body indent. Pins the walker
+descending into class bodies the same way it descends into top-level
+defs, with the indent derived from the method's own `def` position.
 """
 
 
 class Renderer:
     def render(
         self,
-        target,
-        palette,
-        layout,
+        target: int,
+        palette: str,
+        layout: tuple[int, int],
+        spread: float,
     ):
-        return (self, target, palette, layout)
+        return (self, target, palette, layout, spread)

--- a/tests/snapshots/signature_layout/class_method.input.py.snap
+++ b/tests/snapshots/signature_layout/class_method.input.py.snap
@@ -14,9 +14,9 @@ defs, with the indent derived from the method's own `def` position.
 class Renderer:
     def render(
         self,
-        target: int,
-        palette: str,
         layout: tuple[int, int],
+        palette: str,
         spread: float,
+        target: int,
     ):
-        return (self, target, palette, layout, spread)
+        return (self, layout, palette, spread, target)

--- a/tests/snapshots/signature_layout/class_method.input.py.snap
+++ b/tests/snapshots/signature_layout/class_method.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/class_method.input.py
+---
+"""
+A four-parameter method inside a class body trips the count trigger
+and expands at the method's own indent.
+"""
+
+
+class Renderer:
+    def render(
+        self,
+        target,
+        palette,
+        layout,
+    ):
+        return (self, target, palette, layout)

--- a/tests/snapshots/signature_layout/collapse.diagnostics.snap
+++ b/tests/snapshots/signature_layout/collapse.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/collapse.input.py
 ---
-signature-layout@97..123
+signature-layout@232..268

--- a/tests/snapshots/signature_layout/collapse.diagnostics.snap
+++ b/tests/snapshots/signature_layout/collapse.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/collapse.input.py
+---
+signature-layout@97..123

--- a/tests/snapshots/signature_layout/collapse.input.py.snap
+++ b/tests/snapshots/signature_layout/collapse.input.py.snap
@@ -4,10 +4,12 @@ expression: output
 input_file: tests/fixtures/signature_layout/collapse.input.py
 ---
 """
-Multi-line signature whose two parameters fit inline under both
-thresholds.
+A two-parameter signature already in expanded shape whose inline form
+fits under both thresholds collapses back to a single line. Pins the
+reverse direction of the rewrite as direction-symmetric with
+expansion.
 """
 
 
-def render(target, palette):
+def render(target: int, palette: str):
     return (target, palette)

--- a/tests/snapshots/signature_layout/collapse.input.py.snap
+++ b/tests/snapshots/signature_layout/collapse.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/collapse.input.py
+---
+"""
+Multi-line signature whose two parameters fit inline under both
+thresholds.
+"""
+
+
+def render(target, palette):
+    return (target, palette)

--- a/tests/snapshots/signature_layout/collapse.input.py.snap
+++ b/tests/snapshots/signature_layout/collapse.input.py.snap
@@ -11,5 +11,5 @@ expansion.
 """
 
 
-def render(target: int, palette: str):
-    return (target, palette)
+def render(palette: str, target: int):
+    return (palette, target)

--- a/tests/snapshots/signature_layout/count_trigger_off.diagnostics.snap
+++ b/tests/snapshots/signature_layout/count_trigger_off.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/count_trigger_off.input.py
+---
+

--- a/tests/snapshots/signature_layout/count_trigger_off.input.py.snap
+++ b/tests/snapshots/signature_layout/count_trigger_off.input.py.snap
@@ -11,5 +11,5 @@ the disabled-count configuration.
 """
 
 
-def render(target: int, palette: str, layout: int, spread: float, verbose: bool):
-    return (target, palette, layout, spread, verbose)
+def render(layout: int, palette: str, spread: float, target: int, verbose: bool):
+    return (layout, palette, spread, target, verbose)

--- a/tests/snapshots/signature_layout/count_trigger_off.input.py.snap
+++ b/tests/snapshots/signature_layout/count_trigger_off.input.py.snap
@@ -4,10 +4,12 @@ expression: output
 input_file: tests/fixtures/signature_layout/count_trigger_off.input.py
 ---
 """
-Five-parameter signature whose inline form fits the line budget. The
-count trigger is disabled via `max-inline-params = false`.
+A five-parameter signature whose inline form fits the line budget
+stays inline when `max-inline-params = false` disables the count
+trigger entirely. Pins line-length as the sole expansion gate under
+the disabled-count configuration.
 """
 
 
-def render(a, b, c, d, e):
-    return (a, b, c, d, e)
+def render(target: int, palette: str, layout: int, spread: float, verbose: bool):
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/count_trigger_off.input.py.snap
+++ b/tests/snapshots/signature_layout/count_trigger_off.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/count_trigger_off.input.py
+---
+"""
+Five-parameter signature whose inline form fits the line budget. The
+count trigger is disabled via `max-inline-params = false`.
+"""
+
+
+def render(a, b, c, d, e):
+    return (a, b, c, d, e)

--- a/tests/snapshots/signature_layout/decorated.diagnostics.snap
+++ b/tests/snapshots/signature_layout/decorated.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/decorated.input.py
 ---
-signature-layout@126..157
+signature-layout@298..378

--- a/tests/snapshots/signature_layout/decorated.diagnostics.snap
+++ b/tests/snapshots/signature_layout/decorated.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/decorated.input.py
+---
+signature-layout@126..157

--- a/tests/snapshots/signature_layout/decorated.input.py.snap
+++ b/tests/snapshots/signature_layout/decorated.input.py.snap
@@ -4,7 +4,10 @@ expression: output
 input_file: tests/fixtures/signature_layout/decorated.input.py
 ---
 """
-A `@cache` decorator above the `def` and a four-parameter signature.
+A `@cache`-decorated function with a five-parameter signature trips
+the count trigger and expands. The decorator surface stays untouched
+because the rule's replacement range starts at `(`, leaving lines
+above the `def` keyword out of scope.
 """
 
 from functools import cache
@@ -12,9 +15,10 @@ from functools import cache
 
 @cache
 def render(
-    target,
-    palette,
-    layout,
-    spread,
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/decorated.input.py.snap
+++ b/tests/snapshots/signature_layout/decorated.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/decorated.input.py
+---
+"""
+A `@cache` decorator above the `def` and a four-parameter signature.
+"""
+
+from functools import cache
+
+
+@cache
+def render(
+    target,
+    palette,
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)

--- a/tests/snapshots/signature_layout/decorated.input.py.snap
+++ b/tests/snapshots/signature_layout/decorated.input.py.snap
@@ -15,10 +15,10 @@ from functools import cache
 
 @cache
 def render(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/snapshots/signature_layout/empty_params.diagnostics.snap
+++ b/tests/snapshots/signature_layout/empty_params.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/empty_params.input.py
+---
+

--- a/tests/snapshots/signature_layout/empty_params.input.py.snap
+++ b/tests/snapshots/signature_layout/empty_params.input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/empty_params.input.py
+---
+"""
+An empty parameter list.
+"""
+
+
+def render():
+    return 1

--- a/tests/snapshots/signature_layout/empty_params.input.py.snap
+++ b/tests/snapshots/signature_layout/empty_params.input.py.snap
@@ -4,7 +4,10 @@ expression: output
 input_file: tests/fixtures/signature_layout/empty_params.input.py
 ---
 """
-An empty parameter list.
+A zero-parameter signature trips neither threshold, leaving the def
+untouched. Pins the rule's no-op path on the degenerate input shape,
+confirming the rewrite gates close cleanly when there is nothing to
+count or measure.
 """
 
 

--- a/tests/snapshots/signature_layout/expand_on_length.diagnostics.snap
+++ b/tests/snapshots/signature_layout/expand_on_length.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/expand_on_length.input.py
+---
+signature-layout@137..223

--- a/tests/snapshots/signature_layout/expand_on_length.diagnostics.snap
+++ b/tests/snapshots/signature_layout/expand_on_length.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/expand_on_length.input.py
 ---
-signature-layout@137..223
+signature-layout@212..304

--- a/tests/snapshots/signature_layout/expand_on_length.input.py.snap
+++ b/tests/snapshots/signature_layout/expand_on_length.input.py.snap
@@ -12,7 +12,7 @@ alone, with the parameter count comfortably under the cap.
 
 def render(
     left_descriptor: LayoutLayer,
-    right_descriptor: LayoutLayer,
     palette_descriptor: PaletteSpec,
+    right_descriptor: LayoutLayer,
 ):
-    return (left_descriptor, right_descriptor, palette_descriptor)
+    return (left_descriptor, palette_descriptor, right_descriptor)

--- a/tests/snapshots/signature_layout/expand_on_length.input.py.snap
+++ b/tests/snapshots/signature_layout/expand_on_length.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/expand_on_length.input.py
+---
+"""
+Three-parameter signature whose inline form sits well past 88 columns
+even though the count threshold is satisfied.
+"""
+
+
+def render(
+    left_descriptor_for_layout,
+    right_descriptor_for_layout,
+    palette_descriptor_for_layout,
+):
+    return (left_descriptor_for_layout, right_descriptor_for_layout, palette_descriptor_for_layout)

--- a/tests/snapshots/signature_layout/expand_on_length.input.py.snap
+++ b/tests/snapshots/signature_layout/expand_on_length.input.py.snap
@@ -4,14 +4,15 @@ expression: output
 input_file: tests/fixtures/signature_layout/expand_on_length.input.py
 ---
 """
-Three-parameter signature whose inline form sits well past 88 columns
-even though the count threshold is satisfied.
+A three-parameter signature whose inline form overflows the default
+`code-line-length` of 88 columns pins the length trigger firing
+alone, with the parameter count comfortably under the cap.
 """
 
 
 def render(
-    left_descriptor_for_layout,
-    right_descriptor_for_layout,
-    palette_descriptor_for_layout,
+    left_descriptor: LayoutLayer,
+    right_descriptor: LayoutLayer,
+    palette_descriptor: PaletteSpec,
 ):
-    return (left_descriptor_for_layout, right_descriptor_for_layout, palette_descriptor_for_layout)
+    return (left_descriptor, right_descriptor, palette_descriptor)

--- a/tests/snapshots/signature_layout/idempotent.diagnostics.snap
+++ b/tests/snapshots/signature_layout/idempotent.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/idempotent.input.py
+---
+

--- a/tests/snapshots/signature_layout/idempotent.input.py.snap
+++ b/tests/snapshots/signature_layout/idempotent.input.py.snap
@@ -12,15 +12,15 @@ on inputs that match either canonical shape.
 """
 
 
-def already_inline(target: int, palette: str):
-    return (target, palette)
+def already_inline(palette: str, target: int):
+    return (palette, target)
 
 
 def already_expanded(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/snapshots/signature_layout/idempotent.input.py.snap
+++ b/tests/snapshots/signature_layout/idempotent.input.py.snap
@@ -4,19 +4,23 @@ expression: output
 input_file: tests/fixtures/signature_layout/idempotent.input.py
 ---
 """
-Two signatures already at their canonical shape. An inline form with
-two parameters and an expanded form with four.
+Two signatures already at their canonical shape stay untouched. The
+inline form with two parameters fits both thresholds, and the
+expanded form with five parameters trips the count trigger but
+already lands at the rewrite target. Pins the rule's no-op behavior
+on inputs that match either canonical shape.
 """
 
 
-def already_inline(target, palette):
+def already_inline(target: int, palette: str):
     return (target, palette)
 
 
 def already_expanded(
-    target,
-    palette,
-    layout,
-    spread,
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/idempotent.input.py.snap
+++ b/tests/snapshots/signature_layout/idempotent.input.py.snap
@@ -1,0 +1,22 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/idempotent.input.py
+---
+"""
+Two signatures already at their canonical shape. An inline form with
+two parameters and an expanded form with four.
+"""
+
+
+def already_inline(target, palette):
+    return (target, palette)
+
+
+def already_expanded(
+    target,
+    palette,
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)

--- a/tests/snapshots/signature_layout/length_trigger_custom_budget.diagnostics.snap
+++ b/tests/snapshots/signature_layout/length_trigger_custom_budget.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
 ---
-signature-layout@138..200
+signature-layout@272..331

--- a/tests/snapshots/signature_layout/length_trigger_custom_budget.diagnostics.snap
+++ b/tests/snapshots/signature_layout/length_trigger_custom_budget.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
+---
+signature-layout@138..200

--- a/tests/snapshots/signature_layout/length_trigger_custom_budget.input.py.snap
+++ b/tests/snapshots/signature_layout/length_trigger_custom_budget.input.py.snap
@@ -13,7 +13,7 @@ configured threshold rather than a hard-coded one.
 
 def render(
     left: LayoutLayer,
-    right: LayoutLayer,
     palette: PaletteSpec,
+    right: LayoutLayer,
 ):
-    return (left, right, palette)
+    return (left, palette, right)

--- a/tests/snapshots/signature_layout/length_trigger_custom_budget.input.py.snap
+++ b/tests/snapshots/signature_layout/length_trigger_custom_budget.input.py.snap
@@ -4,14 +4,16 @@ expression: output
 input_file: tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
 ---
 """
-Three-parameter signature whose inline form would sit at 71 columns,
-forcing expansion under a `code-line-length` of 50.
+A three-parameter signature whose inline form fits the default
+`code-line-length` of 88 but overflows a custom budget of 50 expands
+under the custom budget. Pins the line-length trigger consuming the
+configured threshold rather than a hard-coded one.
 """
 
 
-def fn(
-    aaaaaaaaaaaaaaaaaaa,
-    bbbbbbbbbbbbbbbbbbb,
-    cccccccccccccccccccc,
+def render(
+    left: LayoutLayer,
+    right: LayoutLayer,
+    palette: PaletteSpec,
 ):
-    return aaaaaaaaaaaaaaaaaaa
+    return (left, right, palette)

--- a/tests/snapshots/signature_layout/length_trigger_custom_budget.input.py.snap
+++ b/tests/snapshots/signature_layout/length_trigger_custom_budget.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/length_trigger_custom_budget.input.py
+---
+"""
+Three-parameter signature whose inline form would sit at 71 columns,
+forcing expansion under a `code-line-length` of 50.
+"""
+
+
+def fn(
+    aaaaaaaaaaaaaaaaaaa,
+    bbbbbbbbbbbbbbbbbbb,
+    cccccccccccccccccccc,
+):
+    return aaaaaaaaaaaaaaaaaaa

--- a/tests/snapshots/signature_layout/no_trailing_comma.diagnostics.snap
+++ b/tests/snapshots/signature_layout/no_trailing_comma.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/no_trailing_comma.input.py
+---
+signature-layout@138..138

--- a/tests/snapshots/signature_layout/no_trailing_comma.diagnostics.snap
+++ b/tests/snapshots/signature_layout/no_trailing_comma.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/no_trailing_comma.input.py
 ---
-signature-layout@138..138
+signature-layout@329..329

--- a/tests/snapshots/signature_layout/no_trailing_comma.input.py.snap
+++ b/tests/snapshots/signature_layout/no_trailing_comma.input.py.snap
@@ -12,10 +12,10 @@ it.
 
 
 def render(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/snapshots/signature_layout/no_trailing_comma.input.py.snap
+++ b/tests/snapshots/signature_layout/no_trailing_comma.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/no_trailing_comma.input.py
+---
+"""
+Multi-line signature whose last parameter carries no trailing comma.
+"""
+
+
+def render(
+    target,
+    palette,
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)

--- a/tests/snapshots/signature_layout/no_trailing_comma.input.py.snap
+++ b/tests/snapshots/signature_layout/no_trailing_comma.input.py.snap
@@ -4,14 +4,18 @@ expression: output
 input_file: tests/fixtures/signature_layout/no_trailing_comma.input.py
 ---
 """
-Multi-line signature whose last parameter carries no trailing comma.
+A multi-line signature whose last parameter lacks a trailing comma
+gets the trailing comma added in the canonical expansion. Pins the
+rewrite's trailing-comma invariant against source variants that omit
+it.
 """
 
 
 def render(
-    target,
-    palette,
-    layout,
-    spread,
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/parameter_shapes.diagnostics.snap
+++ b/tests/snapshots/signature_layout/parameter_shapes.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/parameter_shapes.input.py
+---
+signature-layout@118..160

--- a/tests/snapshots/signature_layout/parameter_shapes.diagnostics.snap
+++ b/tests/snapshots/signature_layout/parameter_shapes.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/parameter_shapes.input.py
 ---
-signature-layout@118..160
+signature-layout@320..414

--- a/tests/snapshots/signature_layout/parameter_shapes.input.py.snap
+++ b/tests/snapshots/signature_layout/parameter_shapes.input.py.snap
@@ -13,12 +13,12 @@ synthesizing a different shape.
 
 
 def render(
-    target: int,
     palette: str,
+    target: int,
     /,
     *,
     layout: tuple[int, int],
     spread: float,
     verbose: bool = False,
 ) -> tuple[int, str]:
-    return (target, palette, layout, spread, verbose)
+    return (palette, target, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/parameter_shapes.input.py.snap
+++ b/tests/snapshots/signature_layout/parameter_shapes.input.py.snap
@@ -4,17 +4,21 @@ expression: output
 input_file: tests/fixtures/signature_layout/parameter_shapes.input.py
 ---
 """
-Defaults, `/` and `*` separators, and a return-type annotation
-round-trip through the expansion.
+The expansion preserves every parameter-list shape (*defaults, the
+posonly-only `/` separator, the bare `*` separator, and a return-type
+annotation*) verbatim from source. Pins the slice machinery rendering
+each canonical separator at its source position rather than
+synthesizing a different shape.
 """
 
 
 def render(
-    target,
-    palette,
+    target: int,
+    palette: str,
     /,
     *,
-    layout,
-    spread=None,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool = False,
 ) -> tuple[int, str]:
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/parameter_shapes.input.py.snap
+++ b/tests/snapshots/signature_layout/parameter_shapes.input.py.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/parameter_shapes.input.py
+---
+"""
+Defaults, `/` and `*` separators, and a return-type annotation
+round-trip through the expansion.
+"""
+
+
+def render(
+    target,
+    palette,
+    /,
+    *,
+    layout,
+    spread=None,
+) -> tuple[int, str]:
+    return (target, palette, layout, spread)

--- a/tests/snapshots/signature_layout/return_annotation.diagnostics.snap
+++ b/tests/snapshots/signature_layout/return_annotation.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/return_annotation.input.py
 ---
-signature-layout@93..111
+signature-layout@273..291

--- a/tests/snapshots/signature_layout/return_annotation.diagnostics.snap
+++ b/tests/snapshots/signature_layout/return_annotation.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/return_annotation.input.py
+---
+signature-layout@93..111

--- a/tests/snapshots/signature_layout/return_annotation.input.py.snap
+++ b/tests/snapshots/signature_layout/return_annotation.input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/return_annotation.input.py
+---
+"""
+A single annotated parameter on its own line, with a return
+annotation.
+"""
+
+
+def render(target: int) -> int:
+    return target

--- a/tests/snapshots/signature_layout/return_annotation.input.py.snap
+++ b/tests/snapshots/signature_layout/return_annotation.input.py.snap
@@ -4,8 +4,10 @@ expression: output
 input_file: tests/fixtures/signature_layout/return_annotation.input.py
 ---
 """
-A single annotated parameter on its own line, with a return
-annotation.
+A single typed parameter in expanded shape collapses to an inline
+signature when the inline form fits under both thresholds. Pins the
+return annotation following the closing `)` on the same line as the
+inline form, rather than landing on its own line.
 """
 
 

--- a/tests/snapshots/signature_layout/trailing_def_line_comment.diagnostics.snap
+++ b/tests/snapshots/signature_layout/trailing_def_line_comment.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/trailing_def_line_comment.input.py
+---
+signature-layout@99..130

--- a/tests/snapshots/signature_layout/trailing_def_line_comment.diagnostics.snap
+++ b/tests/snapshots/signature_layout/trailing_def_line_comment.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/trailing_def_line_comment.input.py
 ---
-signature-layout@99..130
+signature-layout@271..351

--- a/tests/snapshots/signature_layout/trailing_def_line_comment.input.py.snap
+++ b/tests/snapshots/signature_layout/trailing_def_line_comment.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/trailing_def_line_comment.input.py
+---
+"""
+Four-parameter signature with a trailing comment on the `def` line
+after `:`.
+"""
+
+
+def render(
+    target,
+    palette,
+    layout,
+    spread,
+):  # entry point
+    return (target, palette, layout, spread)

--- a/tests/snapshots/signature_layout/trailing_def_line_comment.input.py.snap
+++ b/tests/snapshots/signature_layout/trailing_def_line_comment.input.py.snap
@@ -4,15 +4,18 @@ expression: output
 input_file: tests/fixtures/signature_layout/trailing_def_line_comment.input.py
 ---
 """
-Four-parameter signature with a trailing comment on the `def` line
-after `:`.
+A trailing comment on the `def` line after `:` sits outside `(...)`
+and so does not pin the signature. The rule still expands when count
+or length trips, confirming the pin check covers only comments
+strictly between the opening `(` and closing `)`.
 """
 
 
 def render(
-    target,
-    palette,
-    layout,
-    spread,
+    target: int,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):  # entry point
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/trailing_def_line_comment.input.py.snap
+++ b/tests/snapshots/signature_layout/trailing_def_line_comment.input.py.snap
@@ -12,10 +12,10 @@ strictly between the opening `(` and closing `)`.
 
 
 def render(
-    target: int,
-    palette: str,
     layout: tuple[int, int],
+    palette: str,
     spread: float,
+    target: int,
     verbose: bool,
 ):  # entry point
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/snapshots/signature_layout/type_parameters.diagnostics.snap
+++ b/tests/snapshots/signature_layout/type_parameters.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/type_parameters.input.py
+---
+signature-layout@159..202

--- a/tests/snapshots/signature_layout/type_parameters.diagnostics.snap
+++ b/tests/snapshots/signature_layout/type_parameters.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/type_parameters.input.py
 ---
-signature-layout@159..202
+signature-layout@333..381

--- a/tests/snapshots/signature_layout/type_parameters.input.py.snap
+++ b/tests/snapshots/signature_layout/type_parameters.input.py.snap
@@ -4,15 +4,19 @@ expression: output
 input_file: tests/fixtures/signature_layout/type_parameters.input.py
 ---
 """
-Generic-syntax type parameters sit between the function name and the
-opening `(`. The return annotation references the type parameter.
+A generic function with PEP 695 type parameters between the name and
+`(` expands when its parameter count trips the cap. The type
+parameter list, the parameter annotations, and the return annotation
+each survive the rewrite intact because the replacement range starts
+at `(` rather than at the function name.
 """
 
 
 def render[T](
+    alpha: T,
+    beta: T,
+    delta: T,
+    gamma: T,
     target: T,
-    palette: T,
-    layout: T,
-    spread: T,
 ) -> tuple[T, T]:
-    return (target, palette)
+    return (alpha, beta)

--- a/tests/snapshots/signature_layout/type_parameters.input.py.snap
+++ b/tests/snapshots/signature_layout/type_parameters.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/type_parameters.input.py
+---
+"""
+Generic-syntax type parameters sit between the function name and the
+opening `(`. The return annotation references the type parameter.
+"""
+
+
+def render[T](
+    target: T,
+    palette: T,
+    layout: T,
+    spread: T,
+) -> tuple[T, T]:
+    return (target, palette)

--- a/tests/snapshots/signature_layout/typed_annotations.diagnostics.snap
+++ b/tests/snapshots/signature_layout/typed_annotations.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/typed_annotations.input.py
+---
+signature-layout@394..559

--- a/tests/snapshots/signature_layout/typed_annotations.input.py.snap
+++ b/tests/snapshots/signature_layout/typed_annotations.input.py.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/typed_annotations.input.py
+---
+"""
+A signature carrying a rich variety of type annotations (*a
+`Callable` parameter, a generic `Mapping`, an `Annotated` wrapper, a
+tuple alias, and an `Optional` default*) expands to the one-per-line
+shape with each annotation's source slice preserved verbatim across
+the rewrite.
+"""
+
+from collections.abc import Callable, Mapping
+from typing import Annotated, Any, Optional
+
+
+def configure(
+    callback: Callable[[int, str], bool],
+    config: Mapping[str, Any],
+    metadata: Annotated[dict[str, int], "extra"],
+    tags: tuple[str, ...],
+    timeout: Optional[float] = None,
+) -> tuple[bool, str]:
+    return (True, "ok")

--- a/tests/snapshots/signature_layout/variadics.diagnostics.snap
+++ b/tests/snapshots/signature_layout/variadics.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/signature_layout/variadics.input.py
 ---
-signature-layout@163..216
+signature-layout@254..355

--- a/tests/snapshots/signature_layout/variadics.diagnostics.snap
+++ b/tests/snapshots/signature_layout/variadics.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/variadics.input.py
+---
+signature-layout@163..216

--- a/tests/snapshots/signature_layout/variadics.input.py.snap
+++ b/tests/snapshots/signature_layout/variadics.input.py.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/variadics.input.py
+---
+"""
+A signature that mixes positional parameters with `*args` and
+`**kwargs`. Each variadic slot counts as one parameter for the count
+trigger.
+"""
+
+
+def dispatch(
+    target,
+    palette,
+    *args,
+    layout,
+    spread=None,
+    **kwargs,
+):
+    return (target, palette, layout, spread, args, kwargs)

--- a/tests/snapshots/signature_layout/variadics.input.py.snap
+++ b/tests/snapshots/signature_layout/variadics.input.py.snap
@@ -4,18 +4,19 @@ expression: output
 input_file: tests/fixtures/signature_layout/variadics.input.py
 ---
 """
-A signature that mixes positional parameters with `*args` and
-`**kwargs`. Each variadic slot counts as one parameter for the count
-trigger.
+A signature mixing positional parameters, `*args`, kwonly parameters,
+and `**kwargs` pins each variadic's `*` or `**` prefix carrying
+through to the expanded form. Every variadic slot counts as one
+parameter for the count trigger.
 """
 
 
 def dispatch(
-    target,
-    palette,
-    *args,
-    layout,
-    spread=None,
-    **kwargs,
+    target: int,
+    palette: str,
+    *args: int,
+    layout: tuple[int, int],
+    spread: float = 0.0,
+    **kwargs: object,
 ):
     return (target, palette, layout, spread, args, kwargs)

--- a/tests/snapshots/signature_layout/variadics.input.py.snap
+++ b/tests/snapshots/signature_layout/variadics.input.py.snap
@@ -12,11 +12,11 @@ parameter for the count trigger.
 
 
 def dispatch(
-    target: int,
     palette: str,
+    target: int,
     *args: int,
     layout: tuple[int, int],
     spread: float = 0.0,
     **kwargs: object,
 ):
-    return (target, palette, layout, spread, args, kwargs)
+    return (palette, target, layout, spread, args, kwargs)

--- a/tests/snapshots/signature_layout/with_comments.diagnostics.snap
+++ b/tests/snapshots/signature_layout/with_comments.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/with_comments.input.py
+---
+

--- a/tests/snapshots/signature_layout/with_comments.input.py.snap
+++ b/tests/snapshots/signature_layout/with_comments.input.py.snap
@@ -12,21 +12,21 @@ Both own-line and trailing-line comment placements anchor.
 
 
 def own_line_pin(
-    target: int,
+    layout: tuple[int, int],
     # comment between parameters
     palette: str,
-    layout: tuple[int, int],
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)
 
 
 def trailing_line_pin(
-    target: int,
-    palette: str,  # trailing on a parameter line
     layout: tuple[int, int],
+    palette: str,  # trailing on a parameter line
     spread: float,
+    target: int,
     verbose: bool,
 ):
-    return (target, palette, layout, spread, verbose)
+    return (layout, palette, spread, target, verbose)

--- a/tests/snapshots/signature_layout/with_comments.input.py.snap
+++ b/tests/snapshots/signature_layout/with_comments.input.py.snap
@@ -4,25 +4,29 @@ expression: output
 input_file: tests/fixtures/signature_layout/with_comments.input.py
 ---
 """
-Comments between the opening `(` and closing `)` pin the existing
-shape. Both own-line and trailing-line comments anchor each parameter.
+A comment anywhere between `(` and `)` pins the existing shape,
+overriding both count and length triggers. Each pinned signature
+keeps its comment in place rather than getting rewritten around.
+Both own-line and trailing-line comment placements anchor.
 """
 
 
 def own_line_pin(
-    target,
+    target: int,
     # comment between parameters
-    palette,
-    layout,
-    spread,
+    palette: str,
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)
 
 
 def trailing_line_pin(
-    target,
-    palette,  # trailing on a parameter line
-    layout,
-    spread,
+    target: int,
+    palette: str,  # trailing on a parameter line
+    layout: tuple[int, int],
+    spread: float,
+    verbose: bool,
 ):
-    return (target, palette, layout, spread)
+    return (target, palette, layout, spread, verbose)

--- a/tests/snapshots/signature_layout/with_comments.input.py.snap
+++ b/tests/snapshots/signature_layout/with_comments.input.py.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/with_comments.input.py
+---
+"""
+Comments between the opening `(` and closing `)` pin the existing
+shape. Both own-line and trailing-line comments anchor each parameter.
+"""
+
+
+def own_line_pin(
+    target,
+    # comment between parameters
+    palette,
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)
+
+
+def trailing_line_pin(
+    target,
+    palette,  # trailing on a parameter line
+    layout,
+    spread,
+):
+    return (target, palette, layout, spread)


### PR DESCRIPTION
### 🪻 Quick Summary

Implements `signature-layout`, normalizing Python function signatures to a binary shape wherein the signature either fits on one line or expands to one parameter per line. Two thresholds gate expansion. `max-inline-params` (*default 4*) fires when the parameter count exceeds the cap, and `code-line-length` (*default 88*) fires when the inline form would overflow. Either trip expands to the one-per-line shape with the closing `)` returning to the `def`'s own indent. The reverse direction collapses a multi-line signature back to one line when both thresholds are satisfied. Comments anywhere between `(` and `)` pin the existing shape so each comment retains its parameter attachment.

---

### 🗞️ Key Changes

- Adds `src/rules/signature_layout.rs` walking every `Stmt::FunctionDef` and emitting one expand or collapse edit covering the signature from `(` through the body-opening `:`, leaving `def` / async / decorators / type parameters untouched

- Wires `signature-layout` into `register_rules!` after `match-case-align` and before `align-imports`, so the column-alignment rules downstream see a stable signature shape rather than a mid-rewrite one

- Trips expansion when `params.len() > max_inline_params` or when the inline form's last-column position would overflow `code_line_length`, and collapses a multi-line signature back to inline only when both thresholds are satisfied

- Pins the existing shape when `intersects_comment` fires on the inner-paren range derived via `TextRange::add_start` / `sub_end`, leaving every parameter-attached comment in place rather than rewriting around it

- Adds `SignatureLayoutConfig` with `enabled` and `max_inline_params: Option<NonZeroUsize>` (*default `Some(4)`*), plus a custom `untagged`-enum deserializer that accepts a positive integer or `false` and rejects `true`, `0`, and strings with a TOML error

- Defaults `max_inline_params` to `Some(4)` rather than the spec's `Some(3)`, because four-parameter signatures still read as a single declaration in practice and only past four does the inline form start to feel crowded

- Substitutes `false` for the spec's `null` as the `max-inline-params` disable sentinel, since TOML lacks a `null` literal and `false` is the closest one-token sentinel TOML's value space carries

- Walks parameter slots in source order (*posonly, args, vararg, kwonly, kwarg*) through `signature_parts`, injecting `/` after posonly and a bare `*` before kwonly when no `*args` precedes them, with a `slice_params` helper DRYing the three `.iter().map(slice)` chains

- Pins both directions of the rewrite, every parameter-list shape (*defaults, `/`, `*`, `*args`, `**kwargs`, type-annotated, return-annotated*), async and nested defs, type parameters, decorators, class methods, idempotence on canonical shapes, the comment-pinned skip, rich annotation surfaces (*`Callable`, `Mapping`, `Annotated`, `Optional`*), and the two custom-config paths through 19 fixtures under `tests/fixtures/signature_layout/`

- Adds a `composition` fixture exercising `alphabetize → signature-layout → align-colons → align-equals` together on an out-of-order typed five-parameter signature, pinning that downstream alignment and ordering rules see the canonical signature shape

---

### 🧵 Related Issues

- Closes #126