### PR TITLE
[124] Extend `canonical_blanks` across the full transition matrix

### DIFF
--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -1,17 +1,8 @@
 //! Normalizes blank-line spacing between adjacent statements at module,
-//! class, and function scopes. Module-level `def` and `class` carry 2
-//! blank lines before them. Module-level bare `import` and `from` import
-//! statements carry 1 blank line at the kind boundary. A module-level
-//! statement following an `if __name__ == "__main__":` block carries 1
-//! blank line. Class-body method-after-method, field-to-method, and
-//! docstring-predecessor pairs each carry 1 blank line. A class header
-//! carries 0 blank lines before a first-member docstring and 1 blank
-//! line before any other first member. A function header carries 1
-//! blank line before its first body statement when that statement is a
-//! compound-body opener (`match`, `if`, `for`, `while`, `with`, `try`).
-//! Own-line comments between adjacent statements carry 1 blank line
-//! above the comment block and 0 blank lines between the block and the
-//! following statement.
+//! class, and function scopes. The walker pairs each statement with its
+//! predecessor and emits edits to bring the gap to the canonical count
+//! returned by `canonical_blanks`. Own-line comments between adjacent
+//! statements carry 1 blank line on each side.
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_docstring_stmt;
@@ -80,8 +71,7 @@ impl Walker<'_> {
     }
 
     /// Places exactly 1 blank line between `block_end` and
-    /// `curr_line_start`. The target gap is 2 line breaks: one to end
-    /// the block's last line and one to form the blank.
+    /// `curr_line_start`.
     fn normalize_below_block(&mut self, block_end: TextSize, curr_line_start: TextSize) {
         let target_newlines: u32 = 2;
         if lines_after(block_end, self.source.text()) == target_newlines {
@@ -95,14 +85,11 @@ impl Walker<'_> {
     }
 
     fn pair_in_scope(&mut self, header: &Stmt, body: &[Stmt], scope: BodyScope) {
-        self.pair_scope_entry(header, body, scope);
+        if let Some(first) = body.first() {
+            let prev_end = header_signature_end(self.source, first.start());
+            self.pair_with_end(header, prev_end, first, scope);
+        }
         self.pair_siblings(body, scope);
-    }
-
-    fn pair_scope_entry(&mut self, header: &Stmt, body: &[Stmt], scope: BodyScope) {
-        let Some(first) = body.first() else { return };
-        let prev_end = header_signature_end(self.source, first.start());
-        self.pair_with_end(header, prev_end, first, scope);
     }
 
     fn pair_siblings(&mut self, body: &[Stmt], scope: BodyScope) {
@@ -116,12 +103,8 @@ impl Walker<'_> {
             return;
         };
         let block = leading_block_of(self.source, prev_end, curr);
-        self.push_pair_edits(curr, canonical, block);
-    }
-
-    fn push_pair_edits(&mut self, curr: &Stmt, canonical: u32, block: Option<TextRange>) {
         let curr_line_start = self.source.text().line_start(curr.start());
-        let above_line_start = block.map_or(curr_line_start, |b| b.start());
+        let above_line_start = block.map_or(curr_line_start, TextRange::start);
         self.normalize_above(above_line_start, canonical + 1);
         if let Some(b) = block {
             self.normalize_below_block(b.end(), curr_line_start);
@@ -148,34 +131,42 @@ impl<'a> StatementVisitor<'a> for Walker<'a> {
 /// and `curr` is the first body member.
 fn canonical_blanks(prev: &Stmt, curr: &Stmt, scope: BodyScope) -> Option<u32> {
     match scope {
-        BodyScope::Class => match (prev, curr) {
-            (Stmt::ClassDef(_), _) => Some(u32::from(!is_docstring_stmt(curr))),
-            (Stmt::FunctionDef(_) | Stmt::AnnAssign(_) | Stmt::Assign(_), Stmt::FunctionDef(_)) => {
-                Some(1)
-            }
-            _ if is_docstring_stmt(prev) => Some(1),
-            _ => None,
-        },
-        BodyScope::Function => match (prev, curr) {
-            (
-                Stmt::FunctionDef(_),
-                Stmt::For(_)
-                | Stmt::If(_)
-                | Stmt::Match(_)
-                | Stmt::Try(_)
-                | Stmt::While(_)
-                | Stmt::With(_),
-            ) => Some(1),
-            _ => None,
-        },
-        BodyScope::Module => match (prev, curr) {
-            _ if is_main_guard(prev) => Some(1),
-            (Stmt::Import(_), Stmt::ImportFrom(_)) | (Stmt::ImportFrom(_), Stmt::Import(_)) => {
-                Some(1)
-            }
-            (_, Stmt::FunctionDef(_) | Stmt::ClassDef(_)) => Some(2),
-            _ => None,
-        },
+        BodyScope::Class => class_scope_blanks(prev, curr),
+        BodyScope::Function => function_scope_blanks(prev, curr),
+        BodyScope::Module => module_scope_blanks(prev, curr),
+    }
+}
+
+/// Class-scope pair dispatch. The class header pairs with its first
+/// body member, with 0 blank lines before a docstring and 1 otherwise.
+/// Class-field → method and method-after-method pairs carry 1. Any
+/// docstring-predecessor pair carries 1.
+fn class_scope_blanks(prev: &Stmt, curr: &Stmt) -> Option<u32> {
+    match (prev, curr) {
+        (Stmt::ClassDef(_), _) => Some(u32::from(!is_docstring_stmt(curr))),
+        (Stmt::FunctionDef(_) | Stmt::AnnAssign(_) | Stmt::Assign(_), Stmt::FunctionDef(_)) => {
+            Some(1)
+        }
+        _ if is_docstring_stmt(prev) => Some(1),
+        _ => None,
+    }
+}
+
+/// Function-scope pair dispatch. The function header carries 1 blank
+/// line before its first body statement when that statement is a
+/// compound-body opener.
+fn function_scope_blanks(prev: &Stmt, curr: &Stmt) -> Option<u32> {
+    match (prev, curr) {
+        (
+            Stmt::FunctionDef(_),
+            Stmt::For(_)
+            | Stmt::If(_)
+            | Stmt::Match(_)
+            | Stmt::Try(_)
+            | Stmt::While(_)
+            | Stmt::With(_),
+        ) => Some(1),
+        _ => None,
     }
 }
 
@@ -226,6 +217,19 @@ fn leading_block_of(source: &Source, prev_end: TextSize, curr: &Stmt) -> Option<
     let first = own_lines.next()?;
     let last = own_lines.next_back().unwrap_or(first);
     Some(TextRange::new(text.line_start(first.start()), last.end()))
+}
+
+/// Module-scope pair dispatch. A statement following an
+/// `if __name__ == "__main__":` block carries 1 blank line. The bare /
+/// `from` import kind boundary carries 1. A top-level `FunctionDef` or
+/// `ClassDef` carries 2 blank lines before it.
+fn module_scope_blanks(prev: &Stmt, curr: &Stmt) -> Option<u32> {
+    match (prev, curr) {
+        _ if is_main_guard(prev) => Some(1),
+        (Stmt::Import(_), Stmt::ImportFrom(_)) | (Stmt::ImportFrom(_), Stmt::Import(_)) => Some(1),
+        (_, Stmt::FunctionDef(_) | Stmt::ClassDef(_)) => Some(2),
+        _ => None,
+    }
 }
 
 /// Returns the start of the contiguous ASCII-whitespace run immediately

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -1,18 +1,23 @@
-//! Normalizes vertical spacing between adjacent statements. Module-level
-//! `def` and `class` carry 2 blank lines before them. Methods inside a
-//! class body carry 1 blank line. A class-scope predecessor that is a
-//! string-literal docstring carries 1 blank line before the next member.
-//! A module-level statement following an `if __name__ == "__main__":`
-//! block carries 1 blank line of separation. Adjacent module-level bare
-//! `import` and `from` import statements carry 1 blank line between them.
-//! Own-line comments between adjacent statements carry 1 blank line of
-//! separation from the following statement.
+//! Normalizes blank-line spacing between adjacent statements at module,
+//! class, and function scopes. Module-level `def` and `class` carry 2
+//! blank lines before them. Module-level bare `import` and `from` import
+//! statements carry 1 blank line at the kind boundary. A module-level
+//! statement following an `if __name__ == "__main__":` block carries 1
+//! blank line. Class-body method-after-method, field-to-method, and
+//! docstring-predecessor pairs each carry 1 blank line. A class header
+//! carries 0 blank lines before a first-member docstring and 1 blank
+//! line before any other first member. A function header carries 1
+//! blank line before its first body statement when that statement is a
+//! compound-body opener (`match`, `if`, `for`, `while`, `with`, `try`).
+//! Own-line comments between adjacent statements carry 1 blank line
+//! above the comment block and 0 blank lines between the block and the
+//! following statement.
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::{CmpOp, Expr, Stmt};
-use ruff_python_trivia::{lines_after, lines_before, CommentRanges};
+use ruff_python_trivia::{lines_after, lines_before, BackwardsTokenizer, CommentRanges};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -35,7 +40,7 @@ impl Rule for BlankLines {
             edits: Vec::new(),
             source,
         };
-        walker.pair_count(body, BodyScope::Module);
+        walker.pair_siblings(body, BodyScope::Module);
         walker.visit_body(body);
         walker.edits
     }
@@ -45,7 +50,7 @@ impl Rule for BlankLines {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum BodyScope {
     Class,
     Function,
@@ -95,14 +100,29 @@ impl Walker<'_> {
         ));
     }
 
-    fn pair_count(&mut self, body: &[Stmt], scope: BodyScope) {
+    fn pair_in_scope(&mut self, header: &Stmt, body: &[Stmt], scope: BodyScope) {
+        self.pair_scope_entry(header, body, scope);
+        self.pair_siblings(body, scope);
+    }
+
+    fn pair_scope_entry(&mut self, header: &Stmt, body: &[Stmt], scope: BodyScope) {
+        let Some(first) = body.first() else { return };
+        let prev_end = header_signature_end(self.source, first.start());
+        self.pair_with_end(header, prev_end, first, scope);
+    }
+
+    fn pair_siblings(&mut self, body: &[Stmt], scope: BodyScope) {
         for (prev, curr) in body.iter().zip(body.iter().skip(1)) {
-            let Some(canonical) = canonical_blanks(prev, curr, scope) else {
-                continue;
-            };
-            let block = leading_block_of(self.source, prev.end(), curr);
-            self.push_pair_edits(curr, canonical, block);
+            self.pair_with_end(prev, prev.end(), curr, scope);
         }
+    }
+
+    fn pair_with_end(&mut self, prev: &Stmt, prev_end: TextSize, curr: &Stmt, scope: BodyScope) {
+        let Some(canonical) = canonical_blanks(prev, curr, scope) else {
+            return;
+        };
+        let block = leading_block_of(self.source, prev_end, curr);
+        self.push_pair_edits(curr, canonical, block);
     }
 
     fn push_pair_edits(&mut self, curr: &Stmt, canonical: u32, block: Option<CommentBlock>) {
@@ -118,8 +138,8 @@ impl Walker<'_> {
 impl<'a> StatementVisitor<'a> for Walker<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
-            Stmt::ClassDef(c) => self.pair_count(&c.body, BodyScope::Class),
-            Stmt::FunctionDef(f) => self.pair_count(&f.body, BodyScope::Function),
+            Stmt::ClassDef(c) => self.pair_in_scope(stmt, &c.body, BodyScope::Class),
+            Stmt::FunctionDef(f) => self.pair_in_scope(stmt, &f.body, BodyScope::Function),
             _ => {}
         }
         walk_stmt(self, stmt);
@@ -127,15 +147,33 @@ impl<'a> StatementVisitor<'a> for Walker<'a> {
 }
 
 /// Returns the canonical blank-line count for the pair `(prev, curr)`
-/// at `scope`. `None` means no case applies; the above-block gap is
-/// left alone, but a leading comment block still triggers below-gap
-/// normalization.
+/// at `scope`. `None` means no case applies and the pair is skipped,
+/// leaving any in-gap whitespace and comments untouched. For `Class`
+/// and `Function` scopes, the pair includes the scope-entry transition
+/// wherein `prev` is the enclosing `ClassDef` or `FunctionDef` itself
+/// and `curr` is the first body member.
 fn canonical_blanks(prev: &Stmt, curr: &Stmt, scope: BodyScope) -> Option<u32> {
     match scope {
-        BodyScope::Class => (is_docstring_stmt(prev)
-            || matches!((prev, curr), (Stmt::FunctionDef(_), Stmt::FunctionDef(_))))
-        .then_some(1),
-        BodyScope::Function => None,
+        BodyScope::Class => match (prev, curr) {
+            (Stmt::ClassDef(_), _) => Some(u32::from(!is_docstring_stmt(curr))),
+            (Stmt::FunctionDef(_) | Stmt::AnnAssign(_) | Stmt::Assign(_), Stmt::FunctionDef(_)) => {
+                Some(1)
+            }
+            _ if is_docstring_stmt(prev) => Some(1),
+            _ => None,
+        },
+        BodyScope::Function => match (prev, curr) {
+            (
+                Stmt::FunctionDef(_),
+                Stmt::For(_)
+                | Stmt::If(_)
+                | Stmt::Match(_)
+                | Stmt::Try(_)
+                | Stmt::While(_)
+                | Stmt::With(_),
+            ) => Some(1),
+            _ => None,
+        },
         BodyScope::Module => match (prev, curr) {
             _ if is_main_guard(prev) => Some(1),
             (Stmt::Import(_), Stmt::ImportFrom(_)) | (Stmt::ImportFrom(_), Stmt::Import(_)) => {
@@ -145,6 +183,18 @@ fn canonical_blanks(prev: &Stmt, curr: &Stmt, scope: BodyScope) -> Option<u32> {
             _ => None,
         },
     }
+}
+
+/// Returns the position immediately after the `:` that introduces a
+/// class or function body whose first statement starts at `body_start`.
+/// Scans backward from `body_start` through whitespace and comments,
+/// landing on the first non-trivia token. Falls back to `body_start`
+/// when the scan finds none.
+fn header_signature_end(source: &Source, body_start: TextSize) -> TextSize {
+    BackwardsTokenizer::up_to(body_start, source.text(), source.comment_ranges())
+        .skip_trivia()
+        .next()
+        .map_or(body_start, |t| t.end())
 }
 
 /// True when `stmt` is `if __name__ == "__main__":`.
@@ -211,6 +261,91 @@ mod tests {
             canonical_blanks(&class.body[0], &class.body[1], BodyScope::Class),
             Some(1),
         );
+    }
+
+    #[test]
+    fn canonical_blanks_class_field_to_method_returns_one() {
+        for src in [
+            "class C:\n    x: int = 1\n    def m(self): pass\n",
+            "class C:\n    x = 1\n    def m(self): pass\n",
+        ] {
+            let s = parse(src);
+            let class = s.ast().body[0].as_class_def_stmt().expect("class");
+            assert_eq!(
+                canonical_blanks(&class.body[0], &class.body[1], BodyScope::Class),
+                Some(1),
+                "src = {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_blanks_class_header_to_docstring_returns_zero() {
+        let s = parse("class C:\n    '''doc'''\n    pass\n");
+        let class = s.ast().body[0].as_class_def_stmt().expect("class");
+        assert_eq!(
+            canonical_blanks(&s.ast().body[0], &class.body[0], BodyScope::Class),
+            Some(0),
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_class_header_to_first_member_returns_one() {
+        for src in [
+            "class C:\n    def m(self): pass\n",
+            "class C:\n    @decorator\n    def m(self): pass\n",
+            "class C:\n    x: int = 1\n",
+            "class C:\n    x = 1\n",
+            "class C:\n    class Inner:\n        pass\n",
+        ] {
+            let s = parse(src);
+            let class = s.ast().body[0].as_class_def_stmt().expect("class");
+            assert_eq!(
+                canonical_blanks(&s.ast().body[0], &class.body[0], BodyScope::Class),
+                Some(1),
+                "src = {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_blanks_function_header_to_compound_body_returns_one() {
+        for src in [
+            "def f():\n    for x in y:\n        pass\n",
+            "def f():\n    if x:\n        pass\n",
+            "def f():\n    match x:\n        case _: pass\n",
+            "def f():\n    try:\n        pass\n    except Exception:\n        pass\n",
+            "def f():\n    while x:\n        pass\n",
+            "def f():\n    with x:\n        pass\n",
+            "async def f():\n    async for x in y:\n        pass\n",
+            "async def f():\n    async with x:\n        pass\n",
+        ] {
+            let s = parse(src);
+            let func = s.ast().body[0].as_function_def_stmt().expect("def");
+            assert_eq!(
+                canonical_blanks(&s.ast().body[0], &func.body[0], BodyScope::Function),
+                Some(1),
+                "src = {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_blanks_function_header_to_simple_stmt_returns_none() {
+        for src in [
+            "def f():\n    x = 1\n",
+            "def f():\n    return None\n",
+            "def f():\n    '''doc'''\n",
+            "def f():\n    def inner(): pass\n",
+        ] {
+            let s = parse(src);
+            let func = s.ast().body[0].as_function_def_stmt().expect("def");
+            assert_eq!(
+                canonical_blanks(&s.ast().body[0], &func.body[0], BodyScope::Function),
+                None,
+                "src = {src:?}",
+            );
+        }
     }
 
     #[test]
@@ -296,6 +431,46 @@ mod tests {
     }
 
     #[test]
+    fn header_signature_end_handles_multi_line_function_signature() {
+        let s = parse("def f(\n    x,\n    y,\n):\n    pass\n");
+        let func = s.ast().body[0].as_function_def_stmt().expect("def");
+        let end = header_signature_end(&s, func.body[0].start());
+        assert!(s.text()[..end.to_usize()].ends_with("):"));
+    }
+
+    #[test]
+    fn header_signature_end_points_after_colon_in_simple_class() {
+        let s = parse("class C:\n    pass\n");
+        let class = s.ast().body[0].as_class_def_stmt().expect("class");
+        let end = header_signature_end(&s, class.body[0].start());
+        assert_eq!(&s.text()[..end.to_usize()], "class C:");
+    }
+
+    #[test]
+    fn header_signature_end_points_after_colon_in_simple_function() {
+        let s = parse("def f():\n    pass\n");
+        let func = s.ast().body[0].as_function_def_stmt().expect("def");
+        let end = header_signature_end(&s, func.body[0].start());
+        assert_eq!(&s.text()[..end.to_usize()], "def f():");
+    }
+
+    #[test]
+    fn header_signature_end_skips_eol_comment_on_header_line() {
+        let s = parse("class C:  # eol\n    pass\n");
+        let class = s.ast().body[0].as_class_def_stmt().expect("class");
+        let end = header_signature_end(&s, class.body[0].start());
+        assert_eq!(&s.text()[..end.to_usize()], "class C:");
+    }
+
+    #[test]
+    fn header_signature_end_skips_own_line_comment_above_body() {
+        let s = parse("class C:\n    # comment\n    pass\n");
+        let class = s.ast().body[0].as_class_def_stmt().expect("class");
+        let end = header_signature_end(&s, class.body[0].start());
+        assert_eq!(&s.text()[..end.to_usize()], "class C:");
+    }
+
+    #[test]
     fn is_main_guard_accepts_canonical_form() {
         let s = parse(main_guard_src());
         assert!(is_main_guard(&s.ast().body[0]));
@@ -327,7 +502,7 @@ mod tests {
         let s = parse("x = 1\n# a\n# b\ndef f(): pass\n");
         let body = &s.ast().body;
         let block = leading_block_of(&s, body[0].end(), &body[1]).expect("block");
-        let comments: Vec<TextRange> = s.comment_ranges().iter().copied().collect();
+        let comments = s.comment_ranges();
         assert_eq!(
             block.top_line_start,
             s.text().line_start(comments[0].start())

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -57,12 +57,6 @@ enum BodyScope {
     Module,
 }
 
-#[derive(Clone, Copy)]
-struct CommentBlock {
-    bottom_end: TextSize,
-    top_line_start: TextSize,
-}
-
 struct Walker<'a> {
     edits: Vec<Edit>,
     source: &'a Source,
@@ -125,12 +119,12 @@ impl Walker<'_> {
         self.push_pair_edits(curr, canonical, block);
     }
 
-    fn push_pair_edits(&mut self, curr: &Stmt, canonical: u32, block: Option<CommentBlock>) {
+    fn push_pair_edits(&mut self, curr: &Stmt, canonical: u32, block: Option<TextRange>) {
         let curr_line_start = self.source.text().line_start(curr.start());
-        let above_line_start = block.map_or(curr_line_start, |b| b.top_line_start);
+        let above_line_start = block.map_or(curr_line_start, |b| b.start());
         self.normalize_above(above_line_start, canonical + 1);
         if let Some(b) = block {
-            self.normalize_below_block(b.bottom_end, curr_line_start);
+            self.normalize_below_block(b.end(), curr_line_start);
         }
     }
 }
@@ -214,14 +208,14 @@ fn is_main_guard(stmt: &Stmt) -> bool {
     ) else {
         return false;
     };
-    left.id == "__name__" && right.value == *"__main__"
+    left.id == "__name__" && right.value.to_str() == "__main__"
 }
 
 /// Returns the contiguous range of own-line comments lying between
 /// `prev_end` and `curr.start()`. `None` when no own-line comment
 /// sits in that gap. End-of-line comments on the predecessor's line
 /// are excluded.
-fn leading_block_of(source: &Source, prev_end: TextSize, curr: &Stmt) -> Option<CommentBlock> {
+fn leading_block_of(source: &Source, prev_end: TextSize, curr: &Stmt) -> Option<TextRange> {
     let text = source.text();
     let mut own_lines = source
         .comment_ranges()
@@ -231,10 +225,7 @@ fn leading_block_of(source: &Source, prev_end: TextSize, curr: &Stmt) -> Option<
         .filter(|r| CommentRanges::is_own_line(r.start(), text));
     let first = own_lines.next()?;
     let last = own_lines.next_back().unwrap_or(first);
-    Some(CommentBlock {
-        top_line_start: text.line_start(first.start()),
-        bottom_end: last.end(),
-    })
+    Some(TextRange::new(text.line_start(first.start()), last.end()))
 }
 
 /// Returns the start of the contiguous ASCII-whitespace run immediately
@@ -379,6 +370,16 @@ mod tests {
     }
 
     #[test]
+    fn canonical_blanks_module_class_after_module_stmt_returns_two() {
+        let s = parse("x = 1\nclass C: pass\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            Some(2)
+        );
+    }
+
+    #[test]
     fn canonical_blanks_module_def_after_module_stmt_returns_two() {
         let s = parse("x = 1\ndef f(): pass\n");
         let body = &s.ast().body;
@@ -503,11 +504,8 @@ mod tests {
         let body = &s.ast().body;
         let block = leading_block_of(&s, body[0].end(), &body[1]).expect("block");
         let comments = s.comment_ranges();
-        assert_eq!(
-            block.top_line_start,
-            s.text().line_start(comments[0].start())
-        );
-        assert_eq!(block.bottom_end, comments[1].end());
+        assert_eq!(block.start(), s.text().line_start(comments[0].start()));
+        assert_eq!(block.end(), comments[1].end());
     }
 
     #[test]

--- a/tests/fixtures/blank_lines/class_field_to_decorated_method.input.py
+++ b/tests/fixtures/blank_lines/class_field_to_decorated_method.input.py
@@ -1,0 +1,14 @@
+"""
+A class field directly followed by a decorated method carries 1 blank
+line of cushion. The cushion sits above the topmost decorator rather
+than between the decorator and the def, so the decorator stack reads
+as bound to the method below it.
+"""
+
+
+class Posting:
+    capacity: int = 0
+    @cached_property
+    @logged
+    def label(self):
+        return self.capacity

--- a/tests/fixtures/blank_lines/class_header_to_commented_member.input.py
+++ b/tests/fixtures/blank_lines/class_header_to_commented_member.input.py
@@ -1,0 +1,12 @@
+"""
+A class header followed by an own-line comment and then the first
+member normalizes to 1 blank line above the comment block and 1
+blank line between the comment and the member, so the comment binds
+to the member below it.
+"""
+
+
+class Posting:
+    # describes the first method
+    def m1(self):
+        return 1

--- a/tests/fixtures/blank_lines/class_header_to_docstring.input.py
+++ b/tests/fixtures/blank_lines/class_header_to_docstring.input.py
@@ -7,7 +7,9 @@ member, per the existing docstring-predecessor canonical.
 
 
 class Bound:
-    """The class docstring sits flush against the header line."""
+    """
+    The class docstring sits flush against the header line.
+    """
 
     def follow_up(self):
         return self

--- a/tests/fixtures/blank_lines/class_header_to_docstring.input.py
+++ b/tests/fixtures/blank_lines/class_header_to_docstring.input.py
@@ -1,0 +1,13 @@
+"""
+A class header that introduces a docstring carries 0 blank lines
+between the header and the docstring, binding the docstring to its
+signature. The docstring then carries 1 blank line before the next
+member, per the existing docstring-predecessor canonical.
+"""
+
+
+class Bound:
+    """The class docstring sits flush against the header line."""
+
+    def follow_up(self):
+        return self

--- a/tests/fixtures/blank_lines/class_header_to_first_member.input.py
+++ b/tests/fixtures/blank_lines/class_header_to_first_member.input.py
@@ -1,0 +1,32 @@
+"""
+A class header carries 1 blank line of separation before its first
+non-docstring member. The cushion applies whether the first member is
+a method, a decorated method, an annotated field, an unannotated
+assignment, or a nested class. When the first member is a decorated
+method, the cushion sits above the topmost decorator.
+"""
+
+
+class WithMethod:
+    def alpha(self):
+        return self
+
+
+class WithDecoratedMethod:
+    @classmethod
+    def builder(cls):
+        return cls()
+
+
+class WithAnnotatedField:
+    capacity: int = 0
+
+
+class WithBareField:
+    label = "unset"
+
+
+class WithNestedClass:
+    class Inner:
+        def m(self):
+            return self

--- a/tests/fixtures/blank_lines/decorated_class_with_docstring.input.py
+++ b/tests/fixtures/blank_lines/decorated_class_with_docstring.input.py
@@ -1,0 +1,21 @@
+"""
+A class carrying a decorator stack with a first-member docstring binds
+the docstring tight against `class Posting:` (0 blank lines) with the
+top-level 2-blank cushion measured above the topmost decorator. The
+docstring then cushions the next member by 1 blank line per the
+existing docstring-predecessor canonical, and the field block cushions
+the following method by 1 blank line per the new class-field → method
+arm.
+"""
+
+@final
+@dataclass
+class Posting:
+
+    """
+    Hold a single posting's normalized fields.
+    """
+    company: str
+    title: str
+    def summary(self):
+        return f"{self.title} at {self.company}"

--- a/tests/fixtures/blank_lines/function_header_to_compound_body.input.py
+++ b/tests/fixtures/blank_lines/function_header_to_compound_body.input.py
@@ -1,0 +1,51 @@
+"""
+A function header carries 1 blank line of separation before its first
+body statement when that statement is a compound-body opener. The
+cushion applies uniformly to `match`, `if`, `for`, `while`, `with`,
+and `try` openers. Async function bodies that open with `async for` or
+`async with` get the same cushion since `async` collapses into the
+sync variant in the AST.
+"""
+
+
+def with_match(value):
+    match value:
+        case _:
+            return value
+
+
+def with_if(value):
+    if value:
+        return value
+
+
+def with_for(items):
+    for item in items:
+        yield item
+
+
+def with_while(condition):
+    while condition:
+        condition = False
+
+
+def with_with(handle):
+    with handle:
+        return None
+
+
+def with_try(action):
+    try:
+        action()
+    except Exception:
+        pass
+
+
+async def with_async_for(items):
+    async for item in items:
+        yield item
+
+
+async def with_async_with(handle):
+    async with handle:
+        return None

--- a/tests/fixtures/blank_lines/idempotent.input.py
+++ b/tests/fixtures/blank_lines/idempotent.input.py
@@ -1,7 +1,10 @@
 """
 A module that already carries canonical blank-line spacing round-trips
-unchanged. Two-blank gaps around module-level defs and a one-blank gap
-between methods both satisfy the rule.
+unchanged. The fixture covers each canonical pair the rule emits: a
+two-blank gap around module-level defs, a one-blank gap between methods,
+a one-blank cushion between class header and first non-docstring member,
+a zero-blank gap between class header and a first-member docstring, and
+a one-blank gap between a function header and a compound-body opener.
 """
 
 
@@ -10,6 +13,8 @@ def alpha():
 
 
 class Posting:
+    '''Class docstring binds to the class header with no blank line.'''
+
     def first(self):
         return 1
 
@@ -17,5 +22,16 @@ class Posting:
         return 2
 
 
-def beta():
-    return 2
+class Sized:
+
+    capacity: int = 0
+
+    def grow(self):
+        self.capacity += 1
+
+
+def beta(value):
+
+    match value:
+        case _:
+            return value

--- a/tests/fixtures/blank_lines/idempotent.input.py
+++ b/tests/fixtures/blank_lines/idempotent.input.py
@@ -13,7 +13,9 @@ def alpha():
 
 
 class Posting:
-    '''Class docstring binds to the class header with no blank line.'''
+    """
+    Class docstring binds to the class header with no blank line.
+    """
 
     def first(self):
         return 1

--- a/tests/fixtures/composition/method_with_try.config.toml
+++ b/tests/fixtures/composition/method_with_try.config.toml
@@ -1,0 +1,2 @@
+[harness]
+rules = ["alphabetize", "blank-lines"]

--- a/tests/fixtures/composition/method_with_try.input.py
+++ b/tests/fixtures/composition/method_with_try.input.py
@@ -1,0 +1,22 @@
+"""
+Class with methods out of alphabetical order, one of which opens its
+body with a `try`/`except` block. Blank lines between methods are
+missing.
+
+Rules:
+- alphabetize
+- blank_lines
+"""
+
+
+class Validator:
+    def validate_zeta(self, value):
+        return value > 0
+    def validate_alpha(self, value):
+        try:
+            int(value)
+        except ValueError:
+            return False
+        return True
+    def validate_beta(self, value):
+        return isinstance(value, str)

--- a/tests/snapshots/blank_lines/class_field_to_decorated_method.diagnostics.snap
+++ b/tests/snapshots/blank_lines/class_field_to_decorated_method.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/class_field_to_decorated_method.input.py
+---
+blank-lines@265..266
+blank-lines@287..288

--- a/tests/snapshots/blank_lines/class_field_to_decorated_method.input.py.snap
+++ b/tests/snapshots/blank_lines/class_field_to_decorated_method.input.py.snap
@@ -1,0 +1,21 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/class_field_to_decorated_method.input.py
+---
+"""
+A class field directly followed by a decorated method carries 1 blank
+line of cushion. The cushion sits above the topmost decorator rather
+than between the decorator and the def, so the decorator stack reads
+as bound to the method below it.
+"""
+
+
+class Posting:
+
+    capacity: int = 0
+
+    @cached_property
+    @logged
+    def label(self):
+        return self.capacity

--- a/tests/snapshots/blank_lines/class_header_to_commented_member.diagnostics.snap
+++ b/tests/snapshots/blank_lines/class_header_to_commented_member.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/class_header_to_commented_member.input.py
+---
+blank-lines@246..247
+blank-lines@279..280

--- a/tests/snapshots/blank_lines/class_header_to_commented_member.input.py.snap
+++ b/tests/snapshots/blank_lines/class_header_to_commented_member.input.py.snap
@@ -1,0 +1,19 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/class_header_to_commented_member.input.py
+---
+"""
+A class header followed by an own-line comment and then the first
+member normalizes to 1 blank line above the comment block and 1
+blank line between the comment and the member, so the comment binds
+to the member below it.
+"""
+
+
+class Posting:
+
+    # describes the first method
+
+    def m1(self):
+        return 1

--- a/tests/snapshots/blank_lines/class_header_to_docstring.diagnostics.snap
+++ b/tests/snapshots/blank_lines/class_header_to_docstring.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/class_header_to_docstring.input.py
+---
+

--- a/tests/snapshots/blank_lines/class_header_to_docstring.input.py.snap
+++ b/tests/snapshots/blank_lines/class_header_to_docstring.input.py.snap
@@ -1,0 +1,18 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/class_header_to_docstring.input.py
+---
+"""
+A class header that introduces a docstring carries 0 blank lines
+between the header and the docstring, binding the docstring to its
+signature. The docstring then carries 1 blank line before the next
+member, per the existing docstring-predecessor canonical.
+"""
+
+
+class Bound:
+    """The class docstring sits flush against the header line."""
+
+    def follow_up(self):
+        return self

--- a/tests/snapshots/blank_lines/class_header_to_docstring.input.py.snap
+++ b/tests/snapshots/blank_lines/class_header_to_docstring.input.py.snap
@@ -12,7 +12,9 @@ member, per the existing docstring-predecessor canonical.
 
 
 class Bound:
-    """The class docstring sits flush against the header line."""
+    """
+    The class docstring sits flush against the header line.
+    """
 
     def follow_up(self):
         return self

--- a/tests/snapshots/blank_lines/class_header_to_first_member.diagnostics.snap
+++ b/tests/snapshots/blank_lines/class_header_to_first_member.diagnostics.snap
@@ -1,0 +1,11 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/class_header_to_first_member.input.py
+---
+blank-lines@351..352
+blank-lines@421..422
+blank-lines@509..510
+blank-lines@554..555
+blank-lines@599..600
+blank-lines@616..617

--- a/tests/snapshots/blank_lines/class_header_to_first_member.input.py.snap
+++ b/tests/snapshots/blank_lines/class_header_to_first_member.input.py.snap
@@ -1,0 +1,43 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/class_header_to_first_member.input.py
+---
+"""
+A class header carries 1 blank line of separation before its first
+non-docstring member. The cushion applies whether the first member is
+a method, a decorated method, an annotated field, an unannotated
+assignment, or a nested class. When the first member is a decorated
+method, the cushion sits above the topmost decorator.
+"""
+
+
+class WithMethod:
+
+    def alpha(self):
+        return self
+
+
+class WithDecoratedMethod:
+
+    @classmethod
+    def builder(cls):
+        return cls()
+
+
+class WithAnnotatedField:
+
+    capacity: int = 0
+
+
+class WithBareField:
+
+    label = "unset"
+
+
+class WithNestedClass:
+
+    class Inner:
+
+        def m(self):
+            return self

--- a/tests/snapshots/blank_lines/decorated_class_with_docstring.diagnostics.snap
+++ b/tests/snapshots/blank_lines/decorated_class_with_docstring.diagnostics.snap
@@ -1,0 +1,9 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/decorated_class_with_docstring.input.py
+---
+blank-lines@428..430
+blank-lines@462..464
+blank-lines@526..527
+blank-lines@558..559

--- a/tests/snapshots/blank_lines/decorated_class_with_docstring.input.py.snap
+++ b/tests/snapshots/blank_lines/decorated_class_with_docstring.input.py.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/decorated_class_with_docstring.input.py
+---
+"""
+A class carrying a decorator stack with a first-member docstring binds
+the docstring tight against `class Posting:` (0 blank lines) with the
+top-level 2-blank cushion measured above the topmost decorator. The
+docstring then cushions the next member by 1 blank line per the
+existing docstring-predecessor canonical, and the field block cushions
+the following method by 1 blank line per the new class-field → method
+arm.
+"""
+
+
+@final
+@dataclass
+class Posting:
+    """
+    Hold a single posting's normalized fields.
+    """
+
+    company: str
+    title: str
+
+    def summary(self):
+        return f"{self.title} at {self.company}"

--- a/tests/snapshots/blank_lines/decorated_method.diagnostics.snap
+++ b/tests/snapshots/blank_lines/decorated_method.diagnostics.snap
@@ -3,4 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/blank_lines/decorated_method.input.py
 ---
+blank-lines@206..207
 blank-lines@244..248

--- a/tests/snapshots/blank_lines/decorated_method.input.py.snap
+++ b/tests/snapshots/blank_lines/decorated_method.input.py.snap
@@ -11,6 +11,7 @@ canonical of 1 blank line above the decorator line.
 
 
 class Posting:
+
     def first(self):
         return 1
 

--- a/tests/snapshots/blank_lines/field_then_method.diagnostics.snap
+++ b/tests/snapshots/blank_lines/field_then_method.diagnostics.snap
@@ -3,4 +3,6 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/blank_lines/field_then_method.input.py
 ---
+blank-lines@219..220
+blank-lines@258..262
 blank-lines@296..300

--- a/tests/snapshots/blank_lines/field_then_method.input.py.snap
+++ b/tests/snapshots/blank_lines/field_then_method.input.py.snap
@@ -11,10 +11,9 @@ so only the inter-method gap normalizes to 1 blank line.
 
 
 class Posting:
+
     field: int = 1
     name: str = "x"
-
-
 
     def m1(self):
         return 1

--- a/tests/snapshots/blank_lines/function_header_to_compound_body.diagnostics.snap
+++ b/tests/snapshots/blank_lines/function_header_to_compound_body.diagnostics.snap
@@ -1,0 +1,13 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/function_header_to_compound_body.input.py
+---
+blank-lines@399..400
+blank-lines@479..480
+blank-lines@537..538
+blank-lines@608..609
+blank-lines@680..681
+blank-lines@741..742
+blank-lines@837..838
+blank-lines@922..923

--- a/tests/snapshots/blank_lines/function_header_to_compound_body.input.py.snap
+++ b/tests/snapshots/blank_lines/function_header_to_compound_body.input.py.snap
@@ -1,0 +1,64 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/function_header_to_compound_body.input.py
+---
+"""
+A function header carries 1 blank line of separation before its first
+body statement when that statement is a compound-body opener. The
+cushion applies uniformly to `match`, `if`, `for`, `while`, `with`,
+and `try` openers. Async function bodies that open with `async for` or
+`async with` get the same cushion since `async` collapses into the
+sync variant in the AST.
+"""
+
+
+def with_match(value):
+
+    match value:
+        case _:
+            return value
+
+
+def with_if(value):
+
+    if value:
+        return value
+
+
+def with_for(items):
+
+    for item in items:
+        yield item
+
+
+def with_while(condition):
+
+    while condition:
+        condition = False
+
+
+def with_with(handle):
+
+    with handle:
+        return None
+
+
+def with_try(action):
+
+    try:
+        action()
+    except Exception:
+        pass
+
+
+async def with_async_for(items):
+
+    async for item in items:
+        yield item
+
+
+async def with_async_with(handle):
+
+    async with handle:
+        return None

--- a/tests/snapshots/blank_lines/idempotent.input.py.snap
+++ b/tests/snapshots/blank_lines/idempotent.input.py.snap
@@ -18,7 +18,9 @@ def alpha():
 
 
 class Posting:
-    '''Class docstring binds to the class header with no blank line.'''
+    """
+    Class docstring binds to the class header with no blank line.
+    """
 
     def first(self):
         return 1

--- a/tests/snapshots/blank_lines/idempotent.input.py.snap
+++ b/tests/snapshots/blank_lines/idempotent.input.py.snap
@@ -5,8 +5,11 @@ input_file: tests/fixtures/blank_lines/idempotent.input.py
 ---
 """
 A module that already carries canonical blank-line spacing round-trips
-unchanged. Two-blank gaps around module-level defs and a one-blank gap
-between methods both satisfy the rule.
+unchanged. The fixture covers each canonical pair the rule emits: a
+two-blank gap around module-level defs, a one-blank gap between methods,
+a one-blank cushion between class header and first non-docstring member,
+a zero-blank gap between class header and a first-member docstring, and
+a one-blank gap between a function header and a compound-body opener.
 """
 
 
@@ -15,6 +18,8 @@ def alpha():
 
 
 class Posting:
+    '''Class docstring binds to the class header with no blank line.'''
+
     def first(self):
         return 1
 
@@ -22,5 +27,16 @@ class Posting:
         return 2
 
 
-def beta():
-    return 2
+class Sized:
+
+    capacity: int = 0
+
+    def grow(self):
+        self.capacity += 1
+
+
+def beta(value):
+
+    match value:
+        case _:
+            return value

--- a/tests/snapshots/blank_lines/methods_in_class.diagnostics.snap
+++ b/tests/snapshots/blank_lines/methods_in_class.diagnostics.snap
@@ -3,4 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/blank_lines/methods_in_class.input.py
 ---
+blank-lines@148..149
 blank-lines@186..190

--- a/tests/snapshots/blank_lines/methods_in_class.input.py.snap
+++ b/tests/snapshots/blank_lines/methods_in_class.input.py.snap
@@ -10,6 +10,7 @@ them, collapsing extra blanks and expanding missing ones.
 
 
 class Posting:
+
     def first(self):
         return 1
 

--- a/tests/snapshots/blank_lines/methods_with_comment.diagnostics.snap
+++ b/tests/snapshots/blank_lines/methods_with_comment.diagnostics.snap
@@ -3,5 +3,6 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/blank_lines/methods_with_comment.input.py
 ---
+blank-lines@174..175
 blank-lines@212..216
 blank-lines@249..250

--- a/tests/snapshots/blank_lines/methods_with_comment.input.py.snap
+++ b/tests/snapshots/blank_lines/methods_with_comment.input.py.snap
@@ -11,6 +11,7 @@ and the method.
 
 
 class Posting:
+
     def first(self):
         return 1
 

--- a/tests/snapshots/blank_lines/nested_class.diagnostics.snap
+++ b/tests/snapshots/blank_lines/nested_class.diagnostics.snap
@@ -3,4 +3,6 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/blank_lines/nested_class.input.py
 ---
+blank-lines@116..117
+blank-lines@133..134
 blank-lines@179..183

--- a/tests/snapshots/blank_lines/nested_class.input.py.snap
+++ b/tests/snapshots/blank_lines/nested_class.input.py.snap
@@ -10,7 +10,9 @@ blank line between siblings.
 
 
 class Outer:
+
     class Inner:
+
         def alpha(self):
             return 1
 

--- a/tests/snapshots/blank_lines/top_level_class_then_def.diagnostics.snap
+++ b/tests/snapshots/blank_lines/top_level_class_then_def.diagnostics.snap
@@ -3,4 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/blank_lines/top_level_class_then_def.input.py
 ---
+blank-lines@146..147
 blank-lines@162..163

--- a/tests/snapshots/blank_lines/top_level_class_then_def.input.py.snap
+++ b/tests/snapshots/blank_lines/top_level_class_then_def.input.py.snap
@@ -10,6 +10,7 @@ between them, regardless of the source's actual count.
 
 
 class Posting:
+
     title = "x"
 
 

--- a/tests/snapshots/composition/blank_lines_between_classes.diagnostics.snap
+++ b/tests/snapshots/composition/blank_lines_between_classes.diagnostics.snap
@@ -5,5 +5,8 @@ input_file: tests/fixtures/composition/blank_lines_between_classes.input.py
 ---
 alphabetize@287..336
 blank-lines@280..281
+blank-lines@293..294
 blank-lines@302..303
+blank-lines@315..316
 blank-lines@324..325
+blank-lines@337..338

--- a/tests/snapshots/composition/blank_lines_between_classes.input.py.snap
+++ b/tests/snapshots/composition/blank_lines_between_classes.input.py.snap
@@ -16,12 +16,15 @@ Rules:
 
 
 class Alpha:
+
     pass
 
 
 class Mango:
+
     pass
 
 
 class Zebra:
+
     pass

--- a/tests/snapshots/composition/class_constructor_and_methods.diagnostics.snap
+++ b/tests/snapshots/composition/class_constructor_and_methods.diagnostics.snap
@@ -3,9 +3,10 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/composition/class_constructor_and_methods.input.py
 ---
-align-equals@312..313
-align-equals@340..341
+align-equals@313..314
+align-equals@341..342
 alphabetize@386..520
+blank-lines@258..259
 blank-lines@377..378
 blank-lines@426..427
 blank-lines@475..476

--- a/tests/snapshots/composition/class_constructor_and_methods.input.py.snap
+++ b/tests/snapshots/composition/class_constructor_and_methods.input.py.snap
@@ -16,6 +16,7 @@ Rules:
 
 
 class Service:
+
     def __init__(self, host, port):
         self.host     = host
         self.port_id  = port

--- a/tests/snapshots/composition/docstrings_in_class.diagnostics.snap
+++ b/tests/snapshots/composition/docstrings_in_class.diagnostics.snap
@@ -4,6 +4,7 @@ expression: render(&diagnostics)
 input_file: tests/fixtures/composition/docstrings_in_class.input.py
 ---
 alphabetize@433..687
+blank-lines@424..425
 blank-lines@555..556
 blank-lines@648..649
 multi-line-docstrings@457..517

--- a/tests/snapshots/composition/docstrings_in_class.input.py.snap
+++ b/tests/snapshots/composition/docstrings_in_class.input.py.snap
@@ -19,6 +19,7 @@ Rules:
 
 
 class Service:
+
     def alpha(self):
         """
         The alpha entry point.

--- a/tests/snapshots/composition/method_assignments_aligned.diagnostics.snap
+++ b/tests/snapshots/composition/method_assignments_aligned.diagnostics.snap
@@ -3,8 +3,9 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/composition/method_assignments_aligned.input.py
 ---
-align-equals@255..256
-align-equals@385..386
-align-equals@428..429
+align-equals@256..257
+align-equals@386..387
+align-equals@429..430
 alphabetize@226..472
+blank-lines@217..218
 blank-lines@350..351

--- a/tests/snapshots/composition/method_assignments_aligned.input.py.snap
+++ b/tests/snapshots/composition/method_assignments_aligned.input.py.snap
@@ -16,6 +16,7 @@ Rules:
 
 
 class Builder:
+
     def configure(self):
         host    = "localhost"
         port_id = 8080

--- a/tests/snapshots/composition/method_with_match.diagnostics.snap
+++ b/tests/snapshots/composition/method_with_match.diagnostics.snap
@@ -4,11 +4,13 @@ expression: render(&diagnostics)
 input_file: tests/fixtures/composition/method_with_match.input.py
 ---
 alphabetize@266..573
+blank-lines@250..251
+blank-lines@285..286
 blank-lines@455..456
 blank-lines@514..515
-match-case-align@325..325
-match-case-align@326..343
-match-case-align@374..374
-match-case-align@375..392
-match-case-align@423..423
-match-case-align@424..441
+match-case-align@327..327
+match-case-align@328..345
+match-case-align@376..376
+match-case-align@377..394
+match-case-align@425..425
+match-case-align@426..443

--- a/tests/snapshots/composition/method_with_match.input.py.snap
+++ b/tests/snapshots/composition/method_with_match.input.py.snap
@@ -16,7 +16,9 @@ Rules:
 
 
 class Dispatcher:
+
     def handle_alpha(self, value):
+
         match value:
             case 1 : return "one"
             case 2 : return "two"

--- a/tests/snapshots/composition/method_with_try.diagnostics.snap
+++ b/tests/snapshots/composition/method_with_try.diagnostics.snap
@@ -1,0 +1,10 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/composition/method_with_try.input.py
+---
+alphabetize@224..486
+blank-lines@206..207
+blank-lines@243..244
+blank-lines@351..352
+blank-lines@425..426

--- a/tests/snapshots/composition/method_with_try.input.py.snap
+++ b/tests/snapshots/composition/method_with_try.input.py.snap
@@ -1,0 +1,31 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/composition/method_with_try.input.py
+---
+"""
+Class with methods out of alphabetical order, one of which opens its
+body with a `try`/`except` block. Blank lines between methods are
+missing.
+
+Rules:
+- alphabetize
+- blank_lines
+"""
+
+
+class Validator:
+
+    def validate_alpha(self, value):
+
+        try:
+            int(value)
+        except ValueError:
+            return False
+        return True
+
+    def validate_beta(self, value):
+        return isinstance(value, str)
+
+    def validate_zeta(self, value):
+        return value > 0

--- a/tests/snapshots/composition/multiline_docstring_methods.diagnostics.snap
+++ b/tests/snapshots/composition/multiline_docstring_methods.diagnostics.snap
@@ -3,9 +3,10 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/composition/multiline_docstring_methods.input.py
 ---
+blank-lines@241..242
 blank-lines@389..390
-docstring-wrap@309..317
-docstring-wrap@462..470
+docstring-wrap@310..318
+docstring-wrap@463..471
 docstring-wrap@69..137
 multi-line-docstrings@276..340
 multi-line-docstrings@408..474

--- a/tests/snapshots/composition/multiline_docstring_methods.input.py.snap
+++ b/tests/snapshots/composition/multiline_docstring_methods.input.py.snap
@@ -15,6 +15,7 @@ Rules:
 
 
 class Service:
+
     def primary(self):
         """
         The primary entry point. Returns the configured default.

--- a/tests/snapshots/composition/oneline_docstring_methods.diagnostics.snap
+++ b/tests/snapshots/composition/oneline_docstring_methods.diagnostics.snap
@@ -4,6 +4,7 @@ expression: render(&diagnostics)
 input_file: tests/fixtures/composition/oneline_docstring_methods.input.py
 ---
 blank-lines@178..183
+blank-lines@197..198
 blank-lines@294..295
 no-single-line-docstrings@232..256
 no-single-line-docstrings@313..339

--- a/tests/snapshots/composition/oneline_docstring_methods.input.py.snap
+++ b/tests/snapshots/composition/oneline_docstring_methods.input.py.snap
@@ -15,6 +15,7 @@ Rules:
 
 
 class Service:
+
     def primary(self):
         """
         The primary entry point.

--- a/tests/snapshots/composition/wide_class.diagnostics.snap
+++ b/tests/snapshots/composition/wide_class.diagnostics.snap
@@ -3,11 +3,13 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/composition/wide_class.input.py
 ---
-align-colons@227..227
-align-colons@262..262
-align-colons@283..283
-align-equals@240..241
-align-equals@276..277
+align-colons@228..228
+align-colons@263..263
+align-colons@284..284
+align-equals@241..242
+align-equals@277..278
 alphabetize@223..450
+blank-lines@218..219
+blank-lines@297..298
 blank-lines@341..342
 blank-lines@395..396

--- a/tests/snapshots/composition/wide_class.input.py.snap
+++ b/tests/snapshots/composition/wide_class.input.py.snap
@@ -16,9 +16,11 @@ Rules:
 
 
 class Service:
+
     host        : str   = "localhost"
     retry_count : int   = 3
     timeout     : float = 30.0
+
     def _cleanup(self):
         return None
 

--- a/tests/snapshots/thematic/class_essentials.diagnostics.snap
+++ b/tests/snapshots/thematic/class_essentials.diagnostics.snap
@@ -3,15 +3,16 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/class_essentials.input.py
 ---
-align-colons@491..491
-align-colons@520..520
-align-colons@541..541
-align-colons@564..564
-align-equals@501..502
-align-equals@531..532
-align-equals@588..589
+align-colons@492..492
+align-colons@521..521
+align-colons@542..542
+align-colons@565..565
+align-equals@502..503
+align-equals@532..533
+align-equals@589..590
 align-imports@424..425
 alphabetize@386..850
 bare-import-allowlist@444..446
 bare-import-allowlist@454..457
+blank-lines@474..475
 docstring-wrap@73..368

--- a/tests/snapshots/thematic/class_essentials.input.py.snap
+++ b/tests/snapshots/thematic/class_essentials.input.py.snap
@@ -20,6 +20,7 @@ import sys
 
 
 class Posting:
+
     company     : str   = "TBD"
     description : str   = ""
     salary      : float = 0.0

--- a/tests/snapshots/thematic/dataclass_definition.diagnostics.snap
+++ b/tests/snapshots/thematic/dataclass_definition.diagnostics.snap
@@ -3,15 +3,17 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/dataclass_definition.input.py
 ---
-align-colons@476..476
-align-colons@505..505
-align-colons@529..529
-align-colons@555..555
-align-colons@578..578
-align-equals@486..487
-align-equals@516..517
-align-equals@543..544
-align-equals@600..601
+align-colons@477..477
+align-colons@506..506
+align-colons@530..530
+align-colons@556..556
+align-colons@579..579
+align-equals@487..488
+align-equals@517..518
+align-equals@544..545
+align-equals@601..602
 alphabetize@469..595
+blank-lines@464..465
+blank-lines@596..597
 docstring-wrap@69..378
 no-single-line-docstrings@631..661

--- a/tests/snapshots/thematic/dataclass_definition.input.py.snap
+++ b/tests/snapshots/thematic/dataclass_definition.input.py.snap
@@ -17,11 +17,13 @@ from dataclasses import dataclass
 
 @dataclass
 class JobPosting:
+
     company     : str   = "TBD"
     description : str   = ""
     posted_on   : str   = ""
     salary_band : float = 0.0
     title       : str   = "Untitled"
+
     def summary(self):
         """
         Return a short summary string.

--- a/tests/snapshots/thematic/match_dispatch.diagnostics.snap
+++ b/tests/snapshots/thematic/match_dispatch.diagnostics.snap
@@ -1,17 +1,17 @@
 ---
 source: tests/diagnostics.rs
-assertion_line: 39
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/match_dispatch.input.py
 ---
 alphabetize@521..760
 blank-lines@438..440
+blank-lines@460..461
 docstring-wrap@67..393
-loose-constants@829..872
-match-case-align@506..507
-match-case-align@599..600
-match-case-align@692..693
-match-case-align@777..783
-singleton-rule@862..863
+loose-constants@830..873
+match-case-align@507..508
+match-case-align@600..601
+match-case-align@693..694
+match-case-align@778..784
+singleton-rule@863..864
 strip-trailing-commas@840..841
 strip-trailing-commas@887..888

--- a/tests/snapshots/thematic/match_dispatch.input.py.snap
+++ b/tests/snapshots/thematic/match_dispatch.input.py.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration.rs
-assertion_line: 28
 expression: output
 input_file: tests/fixtures/thematic/match_dispatch.input.py
 ---
@@ -15,6 +14,7 @@ padding. The full pipeline running twice produces no further change.
 
 
 def dispatch(event):
+
     match event.kind:
         case "create":
             return Counter(action="create", source=event.src, timestamp=event.ts)

--- a/tests/snapshots/thematic/nested_classes.diagnostics.snap
+++ b/tests/snapshots/thematic/nested_classes.diagnostics.snap
@@ -3,16 +3,20 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/nested_classes.input.py
 ---
-align-colons@337..337
-align-colons@361..361
-align-colons@381..381
-align-colons@429..429
-align-colons@459..459
-align-colons@480..480
-align-equals@343..344
-align-equals@370..371
-align-equals@480..481
-align-equals@507..508
+align-colons@338..338
+align-colons@362..362
+align-colons@382..382
+align-colons@431..431
+align-colons@461..461
+align-colons@482..482
+align-equals@344..345
+align-equals@371..372
+align-equals@482..483
+align-equals@509..510
 alphabetize@326..707
+blank-lines@321..322
+blank-lines@415..416
+blank-lines@490..491
+blank-lines@564..565
 blank-lines@632..633
 docstring-wrap@68..294

--- a/tests/snapshots/thematic/nested_classes.input.py.snap
+++ b/tests/snapshots/thematic/nested_classes.input.py.snap
@@ -13,16 +13,20 @@ methods.
 
 
 class Order:
+
     customer_id : str   = ""
     placed_on   : str   = ""
     total       : float = 0.0
 
     class LineItem:
+
         price    : float = 0.0
         quantity : int   = 1
         sku      : str   = ""
+
         def subtotal(self):
             return self.price * self.quantity
+
     def __repr__(self):
         return f"Order({self.customer_id})"
 

--- a/tests/snapshots/thematic/service_class.diagnostics.snap
+++ b/tests/snapshots/thematic/service_class.diagnostics.snap
@@ -3,12 +3,14 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/service_class.input.py
 ---
-align-colons@414..414
-align-colons@443..443
-align-colons@466..466
-align-equals@420..421
-align-equals@454..455
+align-colons@415..415
+align-colons@444..444
+align-colons@467..467
+align-equals@421..422
+align-equals@455..456
 alphabetize@402..732
+blank-lines@397..398
+blank-lines@480..481
 blank-lines@546..547
 blank-lines@604..605
 blank-lines@672..673

--- a/tests/snapshots/thematic/service_class.input.py.snap
+++ b/tests/snapshots/thematic/service_class.input.py.snap
@@ -13,9 +13,11 @@ columns, and normalizes the blank-line spacing between members.
 
 
 class CacheService:
+
     backend_name : str   = "memory"
     capacity     : int   = 128
     timeout      : float = 30.0
+
     @property
     def size(self):
         return len(self._store)


### PR DESCRIPTION
### 🪻 Quick Summary

Extends `canonical_blanks` in `src/rules/blank_lines.rs` from the `0.2.0` baseline (*method-after-method and docstring-predecessor pairs at class scope, plus the bare-to-`from` import-kind boundary from #98*) to the full pair-decision matrix the rule has an opinion on. The new arms cover class-header → first-member (*0 blank lines for a docstring, 1 otherwise, with the cushion sitting above the topmost decorator when one is present*), class-field → method, and function-header → compound-body opener (*`match`, `if`, `for`, `while`, `with`, `try`*). The walker pairs each `ClassDef` and `FunctionDef` with its first body member through a new `pair_in_scope` orchestrator, anchored by a new `header_signature_end` helper that uses `BackwardsTokenizer::up_to` to land just past the header `:`.

---

### 🗞️ Key Changes

- Adds class-header → first-member arms in `canonical_blanks`, returning 0 blank lines for a docstring curr and 1 for any other first member (*`def`, decorator-stacked `def`, `ClassDef`, `AnnAssign`, `Assign`*). The decorator-stack cushion sits above the topmost decorator because ruff's `Stmt::FunctionDef.range()` already starts at the decorator-list head rather than the `def` keyword, so no manual offset is needed

- Adds class-field → method arm in the same `BodyScope::Class` block, returning 1 blank line between `AnnAssign`/`Assign` and a following `FunctionDef`. The arm fires regardless of whether the method carries a decorator stack, because decorations live on `FunctionDef.decorator_list` rather than as a separate `Stmt` variant

- Adds function-header → compound-body arm in `BodyScope::Function`, covering `match`/`if`/`for`/`while`/`with`/`try` openers. The async variants go through `Stmt::For` and `Stmt::With` via the `is_async` field rather than as separate `Stmt::AsyncFor` / `Stmt::AsyncWith` variants, so a single arm covers both

- Introduces `pair_in_scope` on the walker so it calls `pair_scope_entry` followed by `pair_siblings`, paired with a new `header_signature_end` helper that uses `BackwardsTokenizer::up_to(...).skip_trivia()` to anchor the scope-entry pair's `prev_end` immediately past the header `:`, skipping trailing whitespace, end-of-line comments on the header line, and own-line comments between header and body

- Replaces the hand-rolled `CommentBlock` newtype (*two `TextSize` fields, structurally identical to a range*) with `ruff_text_size::TextRange` already in scope, threading `Option<TextRange>` through `leading_block_of` and `push_pair_edits` and dropping the struct definition entirely

- Aligns the `is_main_guard` literal check with ruff's `.value.to_str() == "..."` idiom (*used four times across `ruff_linter`*) over the `*"__main__"` deref form, which worked through `StringLiteralValue: PartialEq<str>` but read as unusual at the call site

- Covers every new dispatch arm and five `header_signature_end` shapes (*simple class, simple function, multi-line function signature, EOL comment on header line, own-line comment above body*) with inline tests, plus pins the `Stmt::ClassDef` branch of the module-scope `(_, FunctionDef|ClassDef)` arm with a dedicated dispatch test

- Adds five fixtures for the new transitions (*`class_header_to_docstring`, `class_header_to_first_member`, `class_header_to_commented_member`, `class_field_to_decorated_method`, `function_header_to_compound_body`*) and rewrites `idempotent` against the new canonical, regenerating 13 snapshots across `tests/snapshots/composition/` (*8 cases*) and `tests/snapshots/thematic/` (*5 cases*) for the new cushions

---

### 🧵 Related Issues

- Closes #124
