### PR TITLE
[131] Accept `-` as a stdin path alongside `--stdin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ prose format path/                          # rewrite files in place
 prose check path/                           # exit non-zero on violations
 prose format --diff path/                   # show the diff without writing
 prose check --stdin < file.py               # read from stdin
+prose format - < file.py                    # `-` reads from stdin too
 ```
 
 Subset the active rules with `--select` and `--ignore`:
@@ -309,6 +310,8 @@ CI gates compile against the [exit-code matrix](#-exit-codes) above. A non-zero 
 ### Editor
 
 Any editor that supports run-on-save (*VSCode's `runOnSave`, Vim's `autocmd BufWritePost`, JetBrains File Watchers*) can shell out to `prose format <file>`. For editors that consume structured diagnostics, `prose check --output-format json --stdin` emits one [Ruff-shaped](https://docs.astral.sh/ruff/configuration/#output-format) record per line.
+
+Both subcommands accept a `-` positional in place of `--stdin`, so `prose format - < file.py` and `prose check - < file.py` read source from stdin without naming the flag. The dash is the conventional shape for run-on-save hooks and pre-commit pipelines.
 
 ### Pre-Commit
 

--- a/site/.vitepress/lib/glossary/glossary-data.ts
+++ b/site/.vitepress/lib/glossary/glossary-data.ts
@@ -280,7 +280,7 @@ export const glossary: Record<string, GlossaryEntry> = {
   },
 
   'stdin mode': {
-    aliases   : ['--stdin', '-', 'stdin'],
+    aliases   : ['--stdin', 'stdin'],
     definition: 'Stdin mode is the CLI shape that reads a single source from standard input and writes to standard output, triggered by either the `--stdin` flag or a `-` positional path. It bypasses the filesystem walker entirely, so editors and pipelines drive *Prose* without touching disk.'
   },
 

--- a/site/.vitepress/lib/glossary/glossary-data.ts
+++ b/site/.vitepress/lib/glossary/glossary-data.ts
@@ -280,8 +280,8 @@ export const glossary: Record<string, GlossaryEntry> = {
   },
 
   'stdin mode': {
-    aliases   : ['--stdin', 'stdin'],
-    definition: 'Stdin mode is the CLI shape that reads a single source from standard input and writes to standard output. It bypasses the filesystem walker entirely, so editors and pipelines drive *Prose* without touching disk.'
+    aliases   : ['--stdin', '-', 'stdin'],
+    definition: 'Stdin mode is the CLI shape that reads a single source from standard input and writes to standard output, triggered by either the `--stdin` flag or a `-` positional path. It bypasses the filesystem walker entirely, so editors and pipelines drive *Prose* without touching disk.'
   },
 
   'structured section': {

--- a/site/integrations/editor.md
+++ b/site/integrations/editor.md
@@ -22,6 +22,8 @@ Each record carries `code`, `message`, `filename`, `location`, `end_location`, a
 
 Stdin mode reads the buffer contents the editor passes in, which is the right path for diagnostics on an unsaved buffer. Run-on-save rewriting, by contrast, operates on the file already on disk, because the rewriter writes back to that file directly. The two paths are independent, in that a project can wire one, both, or neither.
 
+Both subcommands accept a `-` positional in place of `--stdin`, so `prose format - < file.py` and `prose check - < file.py` read source from stdin without naming the flag. The dash is the conventional shape for run-on-save hooks and pre-commit pipelines.
+
 ::: tip Composes With CI Annotations
 The same JSON output drives editor squiggles and CI annotations. The [**GitHub Actions**](/integrations/github-actions) integration page covers the workflow-command and SARIF shapes that consume `--output-format json` or its `github` and `sarif` siblings.
 :::

--- a/site/primitives/walker.md
+++ b/site/primitives/walker.md
@@ -9,7 +9,7 @@
 
 *Walker* lives at `src/walker.rs` and is itself `pub(crate)`, so the function is documented here for the consumer-visible CLI behavior it shapes rather than as a directly-callable type. The downstream-visible consequence is the set of files `prose check` and `prose format` operate on, with the walk shape settled before any [[source]] construction or [[pipeline]] run.
 
-A downstream consumer in `0.2.x` reaches the walker indirectly through the CLI's path-mode arguments. The `--stdin` shape bypasses the walker entirely, because stdin mode consumes a single source from the input stream and writes to stdout.
+A downstream consumer in `0.2.x` reaches the walker indirectly through the CLI's path-mode arguments. Stdin mode bypasses the walker entirely, whether invoked through `--stdin` or the `-` positional alias, because the input stream resolves to a single source written straight to stdout.
 
 At `1.0` the discovery hooks open so a downstream can plug its own path source in front of the pipeline.
 
@@ -27,7 +27,7 @@ There is no built-in skip list. Directories like `node_modules`, `__pycache__`, 
 
 The walker accepts a slice of input paths, where the first path seeds a `WalkBuilder` and subsequent paths add to that builder's root set via `WalkBuilder::add`. Two paths under the same gitignore-controlled tree share the ignore stack, because a `.gitignore` at the common ancestor applies to both walks.
 
-An empty path list yields an empty iterator, because the CLI shape requires at least one path when not in `--stdin` mode.
+An empty path list yields an empty iterator, because the CLI shape requires at least one path outside stdin mode.
 
 ## Python File Detection
 

--- a/site/reference/cli.md
+++ b/site/reference/cli.md
@@ -21,7 +21,7 @@ Rewrites Python files to conform to the *Prose* style. Returns exit code 0 once 
 | `--stdin` | bool | off | Read source from stdin and write the rewritten source to stdout |
 | `--select` | comma-separated rule slugs | unset | Run only the listed rules, replacing the configured-enabled set |
 | `--ignore` | comma-separated rule slugs | unset | Skip the listed rules, subtracting from whichever set would otherwise have run |
-| `PATH...` | one or more paths | required when not `--stdin` | Files or directories to format |
+| `PATH...` | one or more paths, or `-` | required when not `--stdin` | Files or directories to format, or `-` to read source from stdin |
 
 Exit codes: `0` clean / rewrites applied, `3` parse error, `4` config error *(see [**Exit Codes**](/reference/exit-codes))*.
 
@@ -29,6 +29,7 @@ Exit codes: `0` clean / rewrites applied, `3` parse error, `4` config error *(se
 prose format src/
 prose format --diff src/
 prose format --stdin < module.py
+prose format - < module.py
 prose format --select align-equals,align-colons src/
 ```
 
@@ -57,7 +58,7 @@ Reports violations without modifying source. Returns the canonical [**Exit Codes
 | `--stdin` | bool | off | Read source from stdin instead of the filesystem |
 | `--select` | comma-separated rule slugs | unset | Run only the listed rules |
 | `--ignore` | comma-separated rule slugs | unset | Skip the listed rules |
-| `PATH...` | one or more paths | required when not `--stdin` | Files or directories to check |
+| `PATH...` | one or more paths, or `-` | required when not `--stdin` | Files or directories to check, or `-` to read source from stdin |
 
 Exit codes: `0` clean, `1` format diagnostics pending, `2` lint diagnostics surfaced, `3` parse error, `4` config error.
 
@@ -66,6 +67,7 @@ prose check .
 prose check --output-format github .
 prose check --output-format sarif . > prose.sarif
 prose check --stdin < module.py
+prose check - < module.py
 ```
 
 ## `prose completions`
@@ -92,7 +94,7 @@ The [**Shell Completions**](/integrations/shell-completions) integration page co
 
 ## Mutual Exclusion
 
-`--stdin` and `PATH...` are mutually exclusive on both `format` and `check`. A run that passes both fails at clap-parse time with exit code 4. `--diff` is mutually exclusive with any non-text `--output-format`, since the diff is itself the text-format presentation.
+`--stdin` and `PATH...` are mutually exclusive on both `format` and `check`. A run that passes both fails at clap-parse time with exit code 4. The `-` positional alias for stdin obeys the same restrictions, in that `prose check - --stdin` and `prose format - a.py` both fail at parse time. `--diff` is mutually exclusive with any non-text `--output-format`, since the diff is itself the text-format presentation.
 
 ## Precedence
 

--- a/site/usage/index.md
+++ b/site/usage/index.md
@@ -36,7 +36,7 @@ The invocation shapes below cover almost every run, with an additional shape for
 
 **Read source from stdin and write to stdout.** The shape an editor save reaches for, with the [**Editor**](/integrations/editor) integration covering the LSP and save-hook paths.
 
-<aside class="pq-aside"><code>prose format --stdin</code></aside>
+<aside class="pq-aside"><code>prose format -</code></aside>
 
 </div>
 

--- a/site/usage/quick-start.md
+++ b/site/usage/quick-start.md
@@ -10,12 +10,13 @@ The canonical invocation is `prose format path/to/project`, which walks the dire
 prose format path/to/project
 ```
 
-Three variants cover the surrounding cases. `prose check` is the CI shape, doing the same walk against the same rules but reporting diagnostics to stdout and gating on the exit code without touching files. `prose format --diff` is the previewing shape, emitting a unified diff to stdout in lieu of writing changes. `prose check --stdin` *(also `prose format --stdin`)* takes one file's contents on stdin and routes diagnostics or rewrites to stdout, which is the shape an editor wires into a save hook.
+Three variants cover the surrounding cases. `prose check` is the CI shape, doing the same walk against the same rules but reporting diagnostics to stdout and gating on the exit code without touching files. `prose format --diff` is the previewing shape, emitting a unified diff to stdout in lieu of writing changes. `prose check --stdin` *(also `prose format --stdin`, or the `-` positional shorthand on either subcommand)* takes one file's contents on stdin and routes diagnostics or rewrites to stdout, which is the shape an editor wires into a save hook.
 
 ```bash
 prose check path/to/project
 prose format --diff path/to/project
 prose check --stdin < file.py
+prose format - < file.py
 ```
 
 ## Which Files Get Walked

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -26,14 +26,16 @@ pub(crate) struct CheckArgs {
     #[arg(long, value_enum, default_value_t)]
     pub(crate) output_format: OutputFormat,
 
-    /// One or more files or directories to check. Omit when using `--stdin`.
+    /// Files or directories to check, or `-` to read source from
+    /// stdin. Omit when using `--stdin`.
     #[arg(conflicts_with = "stdin", value_name = "PATH")]
     pub(crate) paths: Vec<PathBuf>,
 
     #[command(flatten)]
     pub(crate) rules: RuleFilter,
 
-    /// Read source from stdin instead of the filesystem.
+    /// Read source from stdin instead of the filesystem. Equivalent
+    /// to passing `-` as the sole path.
     #[arg(long)]
     pub(crate) stdin: bool,
 }
@@ -81,14 +83,16 @@ pub(crate) struct FormatArgs {
     #[arg(long, value_enum, default_value_t)]
     pub(crate) output_format: OutputFormat,
 
-    /// One or more files or directories to format. Omit when using `--stdin`.
+    /// Files or directories to format, or `-` to read source from
+    /// stdin. Omit when using `--stdin`.
     #[arg(conflicts_with = "stdin", value_name = "PATH")]
     pub(crate) paths: Vec<PathBuf>,
 
     #[command(flatten)]
     pub(crate) rules: RuleFilter,
 
-    /// Read source from stdin instead of the filesystem.
+    /// Read source from stdin instead of the filesystem. Equivalent
+    /// to passing `-` as the sole path.
     #[arg(long)]
     pub(crate) stdin: bool,
 }
@@ -120,6 +124,28 @@ pub(crate) struct RuleFilter {
     /// configured-enabled set.
     #[arg(long, value_delimiter = ',', value_name = "RULES", value_parser = rule_id_parser())]
     pub(crate) select: Vec<RuleId>,
+}
+
+/// Resolves a `-` positional into stdin mode, surfacing a clap
+/// error when `-` appears alongside other paths.
+pub(crate) fn normalize_stdin_dash(cli: &mut Cli) -> Option<clap::Error> {
+    let (paths, stdin) = match &mut cli.command {
+        Command::Check(args) => (&mut args.paths, &mut args.stdin),
+        Command::Completions { .. } => return None,
+        Command::Format(args) => (&mut args.paths, &mut args.stdin),
+    };
+    if !paths.iter().any(|p| p.as_os_str() == "-") {
+        return None;
+    }
+    if paths.len() > 1 {
+        return Some(Cli::command().error(
+            ErrorKind::ArgumentConflict,
+            "`-` cannot appear alongside other paths",
+        ));
+    }
+    paths.clear();
+    *stdin = true;
+    None
 }
 
 /// Prints a clap parse failure and resolves the exit code.
@@ -205,6 +231,15 @@ mod tests {
     }
 
     #[test]
+    fn check_dash_routes_to_stdin() {
+        let mut cli = Cli::try_parse_from(["prose", "check", "-"]).expect("parses");
+        assert!(normalize_stdin_dash(&mut cli).is_none());
+        let args = check_command(cli);
+        assert!(args.paths.is_empty());
+        assert!(args.stdin);
+    }
+
+    #[test]
     fn check_parses_with_no_input_source() {
         let cli = Cli::try_parse_from(["prose", "check"]).expect("parses");
         let args = check_command(cli);
@@ -261,6 +296,19 @@ mod tests {
         let args = check_command(cli);
         assert!(args.paths.is_empty());
         assert!(args.stdin);
+    }
+
+    #[test]
+    fn check_rejects_dash_alongside_other_paths() {
+        let mut cli = Cli::try_parse_from(["prose", "check", "-", "a.py"]).expect("parses");
+        let err = normalize_stdin_dash(&mut cli).expect("dash + path surfaces error");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn check_rejects_dash_with_stdin_flag() {
+        let err = Cli::try_parse_from(["prose", "check", "-", "--stdin"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
     #[test]
@@ -386,6 +434,15 @@ mod tests {
     }
 
     #[test]
+    fn format_dash_routes_to_stdin() {
+        let mut cli = Cli::try_parse_from(["prose", "format", "-"]).expect("parses");
+        assert!(normalize_stdin_dash(&mut cli).is_none());
+        let args = format_command(cli);
+        assert!(args.paths.is_empty());
+        assert!(args.stdin);
+    }
+
+    #[test]
     fn format_parses_with_diff_and_paths() {
         let cli = Cli::try_parse_from(["prose", "format", "--diff", "a.py"]).expect("parses");
         let args = format_command(cli);
@@ -419,6 +476,19 @@ mod tests {
     }
 
     #[test]
+    fn format_rejects_dash_alongside_other_paths() {
+        let mut cli = Cli::try_parse_from(["prose", "format", "-", "a.py"]).expect("parses");
+        let err = normalize_stdin_dash(&mut cli).expect("dash + path surfaces error");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn format_rejects_dash_with_stdin_flag() {
+        let err = Cli::try_parse_from(["prose", "format", "-", "--stdin"]).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
     fn format_rejects_diff_with_output_format_github() {
         let cli = Cli::try_parse_from(["prose", "format", "--diff", "--output-format", "github"])
             .expect("parses");
@@ -440,5 +510,20 @@ mod tests {
     fn format_rejects_paths_with_stdin() {
         let err = Cli::try_parse_from(["prose", "format", "--stdin", "a.py"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn normalize_stdin_dash_is_noop_for_completions() {
+        let mut cli = Cli::try_parse_from(["prose", "completions", "bash"]).expect("parses");
+        assert!(normalize_stdin_dash(&mut cli).is_none());
+    }
+
+    #[test]
+    fn normalize_stdin_dash_leaves_dashless_paths_untouched() {
+        let mut cli = Cli::try_parse_from(["prose", "check", "a.py", "b/"]).expect("parses");
+        assert!(normalize_stdin_dash(&mut cli).is_none());
+        let args = check_command(cli);
+        assert_eq!(args.paths, [PathBuf::from("a.py"), PathBuf::from("b/")]);
+        assert!(!args.stdin);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,9 +3,9 @@
 //! Exposes three subcommands: `check` reports violations without
 //! modifying files, `format` rewrites in place (or prints a unified
 //! diff with `--diff`), and `completions` emits a shell-completion
-//! script. `check` and `format` accept positional paths and a
-//! `--stdin` flag for pipeline use, mutually exclusive via clap's
-//! `conflicts_with`.
+//! script. `check` and `format` accept positional paths, a `-`
+//! positional alias for stdin, and a `--stdin` flag, all mutually
+//! exclusive.
 //!
 //! Path mode parallelizes across files via `rayon`. Set
 //! `RAYON_NUM_THREADS=1` to force single-threaded execution when
@@ -28,7 +28,9 @@ mod args;
 mod exit_status;
 mod runner;
 
-use args::{report_clap_error, validate_diff_format_combination, Cli, Command};
+use args::{
+    normalize_stdin_dash, report_clap_error, validate_diff_format_combination, Cli, Command,
+};
 use exit_status::ExitStatus;
 
 pub(super) fn log_error_chain(err: &anyhow::Error) {
@@ -39,10 +41,13 @@ pub(super) fn log_error_chain(err: &anyhow::Error) {
 }
 
 pub fn run() -> ExitCode {
-    let cli = match Cli::try_parse() {
+    let mut cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(err) => return report_clap_error(err),
     };
+    if let Some(err) = normalize_stdin_dash(&mut cli) {
+        return report_clap_error(err);
+    }
     if let Some(err) = validate_diff_format_combination(&cli) {
         return report_clap_error(err);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -25,6 +25,24 @@ fn check_clean_fixture_exits_zero() {
 }
 
 #[test]
+fn check_dash_clean_exits_zero() {
+    prose()
+        .args(["check", "-"])
+        .write_stdin("x = 1\n")
+        .assert()
+        .success();
+}
+
+#[test]
+fn check_dash_unaligned_exits_format_change() {
+    prose()
+        .args(["check", "-"])
+        .write_stdin("ab = 1\nx = 2\n")
+        .assert()
+        .code(1);
+}
+
+#[test]
 fn check_stdin_clean_exits_zero() {
     prose()
         .args(["check", "--stdin"])
@@ -75,6 +93,8 @@ fn completions_bash_exits_zero() {
 fn config_errors_exit_four() {
     let cases: &[&[&str]] = &[
         &["check", "--stdin", "."],
+        &["check", "-", "--stdin"],
+        &["check", "-", "a.py"],
         &["--not-a-flag"],
         &["check", "--select", "not-a-rule", "."],
         &["format", "--diff", "--output-format", "json", "."],
@@ -82,6 +102,16 @@ fn config_errors_exit_four() {
     for args in cases {
         prose().args(*args).assert().code(4);
     }
+}
+
+#[test]
+fn format_dash_writes_rewrite_to_stdout() {
+    prose()
+        .args(["format", "-"])
+        .write_stdin("x = 1\n")
+        .assert()
+        .success()
+        .stdout("x = 1\n");
 }
 
 #[test]


### PR DESCRIPTION
### 🪻 Quick Summary

Accepts `-` as a positional path on both `prose check` and `prose format`, resolving it to the existing `--stdin` code path so editor save hooks, generated-code pipelines, and pre-commit hooks reach for the conventional `prose format -` shape rather than the longer `--stdin` flag. The dash and `--stdin` stay mutually exclusive, and the dash cannot appear alongside real paths, with both invalid pairings surfacing clap parse errors at the existing exit-code-four config-error tier.

---

### 🗞️ Key Changes

- Adds `normalize_stdin_dash` between `Cli::try_parse` and `validate_diff_format_combination` in `cli::run`, walking the parsed `Command::Check` or `Command::Format` paths vector, returning an `ArgumentConflict` clap error when `-` sits alongside another path, and otherwise clearing the dash entry and flipping the `stdin` field so the downstream runner reads stdin without further casing

- Routes the dash-and-`--stdin`-flag conflict through clap's existing `conflicts_with = "stdin"` attribute on the `paths` field, which catches the pair at parse time before `normalize_stdin_dash` runs, leaving the helper to handle only the dash-with-real-paths case

- Updates the `paths` and `--stdin` doc comments on both `CheckArgs` and `FormatArgs` to describe the dash alias, with `--stdin` noting it is equivalent to passing `-` as the sole path

- Pins behavior with 9 new inline tests covering the routing, mutual exclusion, completions no-op, and dashless-paths-untouched cases, plus 4 new end-to-end tests against the binary covering clean and unaligned routing on both subcommands and the format-rewrite-to-stdout path

- Adds `prose format -` to the README Install & Usage section next to the existing `--stdin` example, and adds a one-paragraph dash-convention note to the README Editor Integration section naming the dash as the conventional shape for run-on-save hooks and pre-commit pipelines

- Mirrors the dash convention across the docs site at `site/reference/cli.md` *(flag-table PATH rows, mutual-exclusion section, bash examples)*, `site/usage/quick-start.md` *(stdin-variant paragraph and bash line)*, `site/integrations/editor.md` *(dash-convention paragraph)*, `site/usage/index.md` *(landing-page stdin-aside)*, `site/primitives/walker.md` *(both `--stdin` and `-` named as walker-bypassing)*, and broadens the glossary's `stdin mode` entry to enumerate `--stdin` and `stdin` as aliases. The bare `-` stays out of the alias list because the glossary plugin compiles aliases into a word-boundary-anchored regex that would mis-link any standalone dash in prose to the stdin-mode chip, and a user looking up the term would not type a single dash into the search box anyway

---

### 🧵 Related Issues

- Closes #131
