### PR TITLE
[150] Hang oversized dict entries at the post-colon column

### DIFF
--- a/site/rules/collection-layout.md
+++ b/site/rules/collection-layout.md
@@ -14,6 +14,8 @@ A dictionary, list, or set with five non-trivial entries on one line reads as a 
 
 The rule fires on dictionary, list, set, and tuple literals. A literal expands when any entry is non-atomic (*a function call, a nested collection, a computed expression*) or when the entry count exceeds `max-atomics-per-line`. Single-line collections of atomic literals (*ints, floats, strings, single-name identifiers*) inside the cap stay on one line. Pair with [[align-colons]] for the dict-key alignment after the expansion, with [[alphabetize]] for sibling sorting where ordering doesn't matter, and with [[strip-trailing-commas]] for the trailing-comma sweep on the multi-line form.
 
+A dict entry whose `key: value` width overflows the budget at the item-indent column breaks at `:` and hangs the value at `item_indent + INDENT_STEP`. The hang applies per-row, so a multi-item dict hangs only the rows that need it. A single-entry dict whose entry overflows enters the expand path and applies the same break. Tuples, lists, and sets stay out of the hang shape because their elements carry no `:` separator.
+
 <template #configuration>
 
 | Key | Type | Default | Meaning |
@@ -42,6 +44,8 @@ A dict literal with non-atomic entries expands to one entry per line, and the re
 <Fixture rule="collection_layout" case="matrix" title="A Matrix Literal Expands Each Row Independently" />
 
 <Fixture rule="collection_layout" case="comprehensions" title="Comprehensions Stay on One Line When They Fit" />
+
+<Fixture rule="collection_layout" case="oversized_entries" title="An Oversized Dict Entry Hangs Its Value at the Post-Colon Column" />
 
 <Fixture rule="collection_layout" case="idempotent" title="Already-Expanded Source Is Left Alone" />
 

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -2,8 +2,10 @@
 //! `Config::code_line_length` budget. Multi-line literals whose
 //! assembled inline form fits collapse back to a single line.
 //! Single-line literals whose inline form overflows expand to one
-//! entry per line. Comprehensions and any literal whose source range
-//! contains a comment are out of scope.
+//! entry per line. A dict entry whose `key: value` width overflows
+//! at the item-indent column breaks at `:` and hangs the value at
+//! `item_indent + INDENT_STEP`. Comprehensions and any literal
+//! whose source range contains a comment are out of scope.
 
 use std::borrow::Cow;
 use std::ops::Range;
@@ -85,6 +87,8 @@ impl<'a> Layouter<'a> {
     /// laying out any qualifying child collections.
     fn expand(&self, expr: &Expr, indent: usize) -> String {
         let item_indent = indent + INDENT_STEP;
+        let dict_items = expr.as_dict_expr().map(|d| &d.items);
+        let parent = AnyNodeRef::from(expr);
         let GatheredItems {
             atomics,
             close,
@@ -102,9 +106,16 @@ impl<'a> Layouter<'a> {
             match segment {
                 Segment::OnePerLine(range) => {
                     for idx in range {
-                        out.push_str(&item_prefix);
-                        out.push_str(&texts[idx]);
                         let has_more = idx + 1 < total;
+                        let inline = &texts[idx];
+                        let row_overflows = !inline.contains('\n')
+                            && item_indent + inline.width() + usize::from(has_more)
+                                > self.code_line_length;
+                        let hung = dict_items.filter(|_| row_overflows).and_then(|items| {
+                            self.hang_dict_value(&items[idx], parent, item_indent)
+                        });
+                        out.push_str(&item_prefix);
+                        out.push_str(hung.as_deref().unwrap_or(inline));
                         if has_more {
                             out.push(',');
                         }
@@ -183,6 +194,25 @@ impl<'a> Layouter<'a> {
             ranges,
             texts,
         }
+    }
+
+    /// Builds the hung two-line form of a `key: value` dict entry,
+    /// breaking at `:` and emitting the value at `item_indent +
+    /// INDENT_STEP`. Returns `None` for `**value` unpacking items.
+    fn hang_dict_value(
+        &self,
+        item: &DictItem,
+        parent: AnyNodeRef,
+        item_indent: usize,
+    ) -> Option<String> {
+        let key_text = self.source.slice(item.key.as_ref()?);
+        let hang_column = item_indent + INDENT_STEP;
+        let value_text = self.serialize_expr(&item.value, parent, hang_column, hang_column);
+        let hang_prefix = " ".repeat(hang_column);
+        Some(format!(
+            "{key_text}:{newline}{hang_prefix}{value_text}",
+            newline = self.newline,
+        ))
     }
 
     /// Builds the canonical inline form of `expr`, recursively
@@ -433,12 +463,13 @@ fn is_layoutable(expr: &Expr) -> bool {
     )
 }
 
-/// True when `expr` is a multi-item `Dict`, `List`, or `Set`, the
-/// shape the expand path canonicalizes. Tuples and single-item
-/// collections collapse only, never expand.
+/// True for a `Dict`, `List`, or `Set` shape the expand path
+/// canonicalizes. Multi-item `List` and `Set` qualify. Any
+/// non-empty `Dict` qualifies. Tuples and empty collections
+/// collapse only, never expand.
 fn requires_expand(expr: &Expr) -> bool {
     match expr {
-        Expr::Dict(d) => d.len() > 1,
+        Expr::Dict(d) => !d.is_empty(),
         Expr::List(l) => l.len() > 1,
         Expr::Set(s) => s.len() > 1,
         _ => false,

--- a/tests/fixtures/collection_layout/idempotent.input.py
+++ b/tests/fixtures/collection_layout/idempotent.input.py
@@ -3,7 +3,8 @@ A canonical-inline collection and a canonical-multi-line collection
 both produce no edit. Inline canonicality holds when the literal
 already fits at its column. Multi-line canonicality holds when the
 assembled inline form overflows the budget so the rule keeps the
-expanded shape.
+expanded shape. A dict whose source already hangs an oversized
+entry's value at the post-`:` column round-trips unchanged.
 """
 
 canonical_inline = {"alpha": 1, "beta": 2, "gamma": 3}
@@ -15,4 +16,10 @@ canonical_multi_line = {
     "epsilon": 5,
     "zeta": 6,
     "eta": 7
+}
+canonical_hung_entry = {
+    "alpha": 1,
+    "beta": 2,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget":
+        "value_long_enough_to_overflow_at_item_indent"
 }

--- a/tests/fixtures/collection_layout/oversized_entries.input.py
+++ b/tests/fixtures/collection_layout/oversized_entries.input.py
@@ -1,9 +1,10 @@
 """
-A multi-item dict whose individual rows overflow the line budget at
-the item-indent column break at `:` and hang the value at
-`item_indent + INDENT_STEP`. Rows that fit at the item-indent stay
-on one line. Already-multi-line nested values pass through their
-own expansion and never trigger the hang predicate.
+A row in a multi-item dict whose `key: value` width overflows the
+line budget at the item-indent column breaks at `:` and hangs the
+value at `item_indent + INDENT_STEP`. Rows that fit at the
+item-indent stay on one line. Already-multi-line nested values
+pass through their own expansion and never trigger the hang
+predicate.
 """
 
 config = {

--- a/tests/fixtures/collection_layout/oversized_entries.input.py
+++ b/tests/fixtures/collection_layout/oversized_entries.input.py
@@ -1,0 +1,29 @@
+"""
+A multi-item dict whose individual rows overflow the line budget at
+the item-indent column break at `:` and hang the value at
+`item_indent + INDENT_STEP`. Rows that fit at the item-indent stay
+on one line. Already-multi-line nested values pass through their
+own expansion and never trigger the hang predicate.
+"""
+
+config = {
+    "alpha": 1,
+    "beta": 2,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget": "value_long_enough_to_overflow_at_item_indent"
+}
+mixed = {
+    "alpha": 1,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget": "value_long_enough_to_overflow_at_item_indent",
+    "gamma": 3
+}
+nested_value_passes_through = {
+    "alpha": 1,
+    "limits": {"burst_capacity": 1200, "concurrent_streams": 8, "queue_depth": 256, "requests_per_minute": 600},
+    "gamma": 3
+}
+multiple_hung_rows = {
+    "alpha": 1,
+    "beta": 2,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget": "value_long_enough_to_overflow_at_item_indent",
+    "z_another_extremely_long_key_pushing_past_the_budget": "another_value_long_enough_to_overflow_at_item_indent"
+}

--- a/tests/fixtures/collection_layout/single_item.input.py
+++ b/tests/fixtures/collection_layout/single_item.input.py
@@ -1,12 +1,12 @@
 """
-Single-item and empty literals keep their inline form regardless of
-line length. A multi-line single-item literal collapses to its
-canonical inline form, the spec's `SETTINGS = {"default_action":
-"noop"}` case being the most reduced. Empty literals spread across
-multiple lines collapse to their bare-bracket form. A single-entry
-dict whose entry overflows at the item-indent column breaks at `:`
-and hangs the value at `item_indent + INDENT_STEP`. Single-item
-lists and sets stay multi-line.
+Single-item literals collapse to inline when their inline form
+fits. The spec's `SETTINGS = {"default_action": "noop"}` case is
+the most reduced. Empty literals spread across multiple lines
+collapse to their bare-bracket form. A single-entry dict whose
+entry overflows at its item-indent column breaks at `:` and hangs
+the value at `item_indent + INDENT_STEP`, since any non-empty dict
+qualifies as an expand target. Single-item lists and sets fall
+outside expand-eligibility and so never enter the hang shape.
 """
 
 only_list  = [42]

--- a/tests/fixtures/collection_layout/single_item.input.py
+++ b/tests/fixtures/collection_layout/single_item.input.py
@@ -3,10 +3,10 @@ Single-item and empty literals keep their inline form regardless of
 line length. A multi-line single-item literal collapses to its
 canonical inline form, the spec's `SETTINGS = {"default_action":
 "noop"}` case being the most reduced. Empty literals spread across
-multiple lines collapse to their bare-bracket form. A multi-line
-single-item literal whose inline form overflows stays multi-line
-because the rule's expand path only canonicalizes multi-item
-collections.
+multiple lines collapse to their bare-bracket form. A single-entry
+dict whose entry overflows at the item-indent column breaks at `:`
+and hangs the value at `item_indent + INDENT_STEP`. Single-item
+lists and sets stay multi-line.
 """
 
 only_list  = [42]
@@ -23,5 +23,5 @@ collapsing_one_item_list = [
 collapsing_empty_dict = {
 }
 oversized_one_entry_dict = {
-    "extremely_long_configuration_key_for_the_settings_table": "a_descriptive_value"
+    "extremely_long_configuration_key_for_the_settings_table": "a_descriptive_value_long_enough_to_force_hang_shape"
 }

--- a/tests/fixtures/collection_layout/unpacking.input.py
+++ b/tests/fixtures/collection_layout/unpacking.input.py
@@ -8,7 +8,9 @@ a spread in the middle of a list splits its surrounding atomics into
 two independent runs that each flow on their own, and a set made
 entirely of spreads goes one entry per line. A multi-line dict with
 a `**` spread whose inline form fits collapses back to one line and
-the spread renders inline as `**value`.
+the spread renders inline as `**value`. A `**value` row whose width
+overflows the line budget at its item-indent column stays on a
+single line, since the hang shape requires a `:` separator.
 """
 
 dict_unpack = {"alpha": 1, **extra_config, "beta": 2, "gamma": 3, "delta": 4, "epsilon": 5, "zeta": 6}
@@ -17,5 +19,10 @@ set_unpack = {*alpha_set, *beta_set, *gamma_set, *delta_set, *epsilon_set, *zeta
 collapsing_dict_unpack = {
     "alpha": 1,
     **extra_config,
+    "beta": 2
+}
+overflowing_dict_unpack = {
+    "alpha": 1,
+    **absurdly_long_unpack_target_for_demonstrating_overflow_at_the_item_indent_budget_x,
     "beta": 2
 }

--- a/tests/snapshots/collection_layout/idempotent.input.py.snap
+++ b/tests/snapshots/collection_layout/idempotent.input.py.snap
@@ -8,7 +8,8 @@ A canonical-inline collection and a canonical-multi-line collection
 both produce no edit. Inline canonicality holds when the literal
 already fits at its column. Multi-line canonicality holds when the
 assembled inline form overflows the budget so the rule keeps the
-expanded shape.
+expanded shape. A dict whose source already hangs an oversized
+entry's value at the post-`:` column round-trips unchanged.
 """
 
 canonical_inline = {"alpha": 1, "beta": 2, "gamma": 3}
@@ -20,4 +21,10 @@ canonical_multi_line = {
     "epsilon": 5,
     "zeta": 6,
     "eta": 7
+}
+canonical_hung_entry = {
+    "alpha": 1,
+    "beta": 2,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget":
+        "value_long_enough_to_overflow_at_item_indent"
 }

--- a/tests/snapshots/collection_layout/oversized_entries.diagnostics.snap
+++ b/tests/snapshots/collection_layout/oversized_entries.diagnostics.snap
@@ -3,7 +3,7 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/oversized_entries.input.py
 ---
-collection-layout@427..427
-collection-layout@569..569
-collection-layout@698..793
-collection-layout@933..1041
+collection-layout@442..442
+collection-layout@584..584
+collection-layout@713..808
+collection-layout@948..1056

--- a/tests/snapshots/collection_layout/oversized_entries.diagnostics.snap
+++ b/tests/snapshots/collection_layout/oversized_entries.diagnostics.snap
@@ -1,0 +1,9 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/collection_layout/oversized_entries.input.py
+---
+collection-layout@427..427
+collection-layout@569..569
+collection-layout@698..793
+collection-layout@933..1041

--- a/tests/snapshots/collection_layout/oversized_entries.input.py.snap
+++ b/tests/snapshots/collection_layout/oversized_entries.input.py.snap
@@ -1,0 +1,43 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/collection_layout/oversized_entries.input.py
+---
+"""
+A multi-item dict whose individual rows overflow the line budget at
+the item-indent column break at `:` and hang the value at
+`item_indent + INDENT_STEP`. Rows that fit at the item-indent stay
+on one line. Already-multi-line nested values pass through their
+own expansion and never trigger the hang predicate.
+"""
+
+config = {
+    "alpha": 1,
+    "beta": 2,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget":
+        "value_long_enough_to_overflow_at_item_indent"
+}
+mixed = {
+    "alpha": 1,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget":
+        "value_long_enough_to_overflow_at_item_indent",
+    "gamma": 3
+}
+nested_value_passes_through = {
+    "alpha": 1,
+    "limits": {
+        "burst_capacity": 1200,
+        "concurrent_streams": 8,
+        "queue_depth": 256,
+        "requests_per_minute": 600
+    },
+    "gamma": 3
+}
+multiple_hung_rows = {
+    "alpha": 1,
+    "beta": 2,
+    "extremely_long_key_name_that_pushes_its_row_past_the_budget":
+        "value_long_enough_to_overflow_at_item_indent",
+    "z_another_extremely_long_key_pushing_past_the_budget":
+        "another_value_long_enough_to_overflow_at_item_indent"
+}

--- a/tests/snapshots/collection_layout/oversized_entries.input.py.snap
+++ b/tests/snapshots/collection_layout/oversized_entries.input.py.snap
@@ -4,11 +4,12 @@ expression: output
 input_file: tests/fixtures/collection_layout/oversized_entries.input.py
 ---
 """
-A multi-item dict whose individual rows overflow the line budget at
-the item-indent column break at `:` and hang the value at
-`item_indent + INDENT_STEP`. Rows that fit at the item-indent stay
-on one line. Already-multi-line nested values pass through their
-own expansion and never trigger the hang predicate.
+A row in a multi-item dict whose `key: value` width overflows the
+line budget at the item-indent column breaks at `:` and hangs the
+value at `item_indent + INDENT_STEP`. Rows that fit at the
+item-indent stay on one line. Already-multi-line nested values
+pass through their own expansion and never trigger the hang
+predicate.
 """
 
 config = {

--- a/tests/snapshots/collection_layout/single_item.diagnostics.snap
+++ b/tests/snapshots/collection_layout/single_item.diagnostics.snap
@@ -3,6 +3,7 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/single_item.input.py
 ---
-collection-layout@602..632
-collection-layout@662..670
-collection-layout@697..698
+collection-layout@628..658
+collection-layout@688..696
+collection-layout@723..724
+collection-layout@817..817

--- a/tests/snapshots/collection_layout/single_item.diagnostics.snap
+++ b/tests/snapshots/collection_layout/single_item.diagnostics.snap
@@ -3,7 +3,7 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/single_item.input.py
 ---
-collection-layout@628..658
-collection-layout@688..696
-collection-layout@723..724
-collection-layout@817..817
+collection-layout@646..676
+collection-layout@706..714
+collection-layout@741..742
+collection-layout@835..835

--- a/tests/snapshots/collection_layout/single_item.input.py.snap
+++ b/tests/snapshots/collection_layout/single_item.input.py.snap
@@ -4,14 +4,14 @@ expression: output
 input_file: tests/fixtures/collection_layout/single_item.input.py
 ---
 """
-Single-item and empty literals keep their inline form regardless of
-line length. A multi-line single-item literal collapses to its
-canonical inline form, the spec's `SETTINGS = {"default_action":
-"noop"}` case being the most reduced. Empty literals spread across
-multiple lines collapse to their bare-bracket form. A single-entry
-dict whose entry overflows at the item-indent column breaks at `:`
-and hangs the value at `item_indent + INDENT_STEP`. Single-item
-lists and sets stay multi-line.
+Single-item literals collapse to inline when their inline form
+fits. The spec's `SETTINGS = {"default_action": "noop"}` case is
+the most reduced. Empty literals spread across multiple lines
+collapse to their bare-bracket form. A single-entry dict whose
+entry overflows at its item-indent column breaks at `:` and hangs
+the value at `item_indent + INDENT_STEP`, since any non-empty dict
+qualifies as an expand target. Single-item lists and sets fall
+outside expand-eligibility and so never enter the hang shape.
 """
 
 only_list  = [42]

--- a/tests/snapshots/collection_layout/single_item.input.py.snap
+++ b/tests/snapshots/collection_layout/single_item.input.py.snap
@@ -8,10 +8,10 @@ Single-item and empty literals keep their inline form regardless of
 line length. A multi-line single-item literal collapses to its
 canonical inline form, the spec's `SETTINGS = {"default_action":
 "noop"}` case being the most reduced. Empty literals spread across
-multiple lines collapse to their bare-bracket form. A multi-line
-single-item literal whose inline form overflows stays multi-line
-because the rule's expand path only canonicalizes multi-item
-collections.
+multiple lines collapse to their bare-bracket form. A single-entry
+dict whose entry overflows at the item-indent column breaks at `:`
+and hangs the value at `item_indent + INDENT_STEP`. Single-item
+lists and sets stay multi-line.
 """
 
 only_list  = [42]
@@ -23,5 +23,6 @@ collapsing_one_entry_dict = {"default_action": "noop"}
 collapsing_one_item_list = [42]
 collapsing_empty_dict = {}
 oversized_one_entry_dict = {
-    "extremely_long_configuration_key_for_the_settings_table": "a_descriptive_value"
+    "extremely_long_configuration_key_for_the_settings_table":
+        "a_descriptive_value_long_enough_to_force_hang_shape"
 }

--- a/tests/snapshots/collection_layout/unpacking.diagnostics.snap
+++ b/tests/snapshots/collection_layout/unpacking.diagnostics.snap
@@ -3,7 +3,7 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/collection_layout/unpacking.input.py
 ---
-collection-layout@668..754
-collection-layout@771..856
-collection-layout@872..952
-collection-layout@980..1031
+collection-layout@1023..1103
+collection-layout@1131..1182
+collection-layout@819..905
+collection-layout@922..1007

--- a/tests/snapshots/collection_layout/unpacking.input.py.snap
+++ b/tests/snapshots/collection_layout/unpacking.input.py.snap
@@ -13,7 +13,9 @@ a spread in the middle of a list splits its surrounding atomics into
 two independent runs that each flow on their own, and a set made
 entirely of spreads goes one entry per line. A multi-line dict with
 a `**` spread whose inline form fits collapses back to one line and
-the spread renders inline as `**value`.
+the spread renders inline as `**value`. A `**value` row whose width
+overflows the line budget at its item-indent column stays on a
+single line, since the hang shape requires a `:` separator.
 """
 
 dict_unpack = {
@@ -41,3 +43,8 @@ set_unpack = {
     *eta_set
 }
 collapsing_dict_unpack = {"alpha": 1, **extra_config, "beta": 2}
+overflowing_dict_unpack = {
+    "alpha": 1,
+    **absurdly_long_unpack_target_for_demonstrating_overflow_at_the_item_indent_budget_x,
+    "beta": 2
+}


### PR DESCRIPTION
### 🪻 Quick Summary

Hangs a dict entry whose `key: value` width overflows the line budget at its item-indent column at `:`, emitting the value on its own line at `item_indent + INDENT_STEP` and paralleling #128's hanging-entry wrap on docstring `Args:` sections. The hang applies per row, so a multi-item dict hangs only the rows that overflow individually whereas rows that fit at the item-indent stay on one line. Single-entry dicts whose entry overflows enter the expand path under a widened `requires_expand` check, applying the same hang shape rather than leaving an over-budget line as written. Tuples, lists, and sets fall outside the hang shape because their elements carry no `:` separator to break at.

---

### 🗞️ Key Changes

- Adds `hang_dict_value` in `src/rules/collection_layout.rs` rendering the two-line `key:\n<hang>value` shape with the value at `item_indent + INDENT_STEP`, returning `None` for the `**value` unpacking variant so the OnePerLine branch falls back to the inline form

- Dispatches from `expand`'s OnePerLine branch to `hang_dict_value` when a dict row's text overflows the budget at item-indent, with the fallback emitting the inline form for non-dict collections or rows that fit

- Skips the hang when the inline row text already contains a newline, letting an already-multi-line nested value own its own expansion rather than triggering the hang predicate against a width summed across lines

- Extends `requires_expand` so any non-empty `Dict` qualifies as an expand target, replacing the prior `len() > 1` floor so a single-entry overflow takes the hang shape instead of staying as written

- Adds `tests/fixtures/collection_layout/oversized_entries.input.py` pinning the multi-item row-overflow, middle-row overflow, multi-line nested-value bypass, and multi-hung-row cases

- Extends `single_item.input.py`, `idempotent.input.py`, and `unpacking.input.py` with the single-entry overflow hang, the already-hung round-trip, and the `**value` overflow pin showing the hang predicate skips when the dict item carries no key

- Documents the hang shape on `site/rules/collection-layout.md` with an `<Fixture>` pointer to `oversized_entries`

---

### 🧵 Related Issues

- Closes #150