### PR TITLE
[147] Extract an AlignWalker primitive shared across alignment rules

### DIFF
--- a/site/.vitepress/data/primitives-composition.data.ts
+++ b/site/.vitepress/data/primitives-composition.data.ts
@@ -30,7 +30,7 @@ interface PrimitivesCompositionData {
 
 const SOURCES: readonly PrimitiveEntrySource[] = [
   {
-    consumedBy : ['align-colons', 'align-equals', 'align-imports', 'match-case-align'],
+    consumedBy : ['align-colons', 'align-comparisons', 'align-equals', 'align-imports', 'match-case-align'],
     consumes   : ['edit', 'source'],
     layer      : 'orchestration',
     slug       : 'aligner',

--- a/site/primitives/aligner.md
+++ b/site/primitives/aligner.md
@@ -2,7 +2,7 @@
 
 <PrimitiveLayout primitive="aligner">
 
-*Aligner* computes padding widths and emits the alignment edits that every alignment rule consumes. Four rules ([[align-equals]], [[align-colons]], [[align-imports]], [[match-case-align]]) share the same column-resolution math, so the math lives once in *Aligner* and each rule supplies a member list plus a knob-set rather than re-implementing the resolution from scratch.
+*Aligner* computes padding widths and emits the alignment edits that every alignment rule consumes. The shipped consumers ([[align-colons]], [[align-comparisons]], [[align-equals]], [[align-imports]], [[match-case-align]]) share the same column-resolution math, so the math lives once in *Aligner* and each rule supplies a member list plus a knob-set rather than re-implementing the resolution from scratch.
 
 
 ## Public Surface
@@ -89,7 +89,7 @@ Writing a new alignment rule comes down to wrapping an `AlignWalker` in a visito
 
 <template #related>
 
-- [[align-equals]], [[align-colons]], [[align-imports]], and [[match-case-align]] are the consumers.
+- [[align-colons]], [[align-comparisons]], [[align-equals]], [[align-imports]], and [[match-case-align]] are the consumers.
 - [[colon-targets]] constructs `Member` lists from every `:` context, consumed by [[align-colons]] and [[singleton-rule]].
 - [[edit]] is the shape `emit_group` pushes into the caller's accumulator.
 - [[orderer]] composes line-adjacency grouping differently *(by source-range block extents rather than `Member` widths)*, so a rule whose math is reorder-shaped rather than padding-shaped reaches for that primitive instead.

--- a/site/primitives/aligner.md
+++ b/site/primitives/aligner.md
@@ -22,6 +22,7 @@ The types every consumer touches:
 
 1. `Member { gap: TextRange, line_start: TextSize, op_width: usize, width: usize }` describes one row in an alignment group. `gap` is the whitespace range immediately before the aligned token, rewritten into padding. `line_start` is the offset of the source-line start, used by `is_alignment_candidate` to confirm each member sits on its own line. `op_width` is the display width of variable-width operators *(`==`, `!=`, `<=`)* opting into right-alignment. `width` is the display-column width from member start to gap start, which is what the math compares to find the target column.
 2. `Settings { max_shift, policy, strip_singleton_subgroup }` carries the rule's `[tool.prose.rules.<rule>]` knobs. `From<&AlignmentConfig>` builds the canonical settings, and `with_singleton_subgroup_strip` flips the singleton-collapse behavior on.
+3. `AlignWalker { edits: Vec<Edit>, settings: Settings, source: &'a Source }` is the carrier each rule's visitor struct wraps. `AlignWalker::new(source, settings)` builds one with an empty `edits` vector, and `AlignWalker::emit_group(&mut self, members)` pushes alignment edits for a group into `self.edits`.
 
 The entry point `emit_group(source: &Source, members: &[Member], settings: Settings, edits: &mut Vec<Edit>)` resolves the target column across `members`, falls back through `policy` *(`split` / `drop` / `skip`)* when the widest member exceeds `max_shift`, and pushes one `Edit` per row that needs padding into the caller's accumulator. A singleton group collapses its gap to one space, or to zero when `settings.strip_singleton_subgroup` is set.
 
@@ -46,34 +47,45 @@ When the widest member exceeds `max_shift`, the policy decides what happens next
 
 The `split` policy partitions the group into sub-groups of contiguous rows where the within-group widest is under `max_shift`, resolving each sub-group independently. The `drop` policy excludes the widest members from the padding calculation, leaving the group aligned to the widest non-overflow row. The `skip` policy leaves the whole group unaligned, with no edits emitted at all.
 
-Variable-width operators opt in to right-alignment by setting `op_width`, shifting each row's padding inward by `max(op_width) - row.op_width`. The hook is reserved for future comparison-alignment work *(no shipped rule consumes it at the current release)*, but the infrastructure is in place so that adding a comparison-alignment rule lands as a walker plus a knob set, not a from-scratch implementation.
+Variable-width operators opt in to right-alignment by setting `op_width`, shifting each row's padding inward by `max(op_width) - row.op_width`. [[align-comparisons]] is the shipped consumer of this hook, with the infrastructure leaving the door open for future variable-width-operator rules to land as a grouping walker plus a knob set rather than a from-scratch implementation.
 
 ## Build Pattern
 
-Each alignment rule walks the AST, collects `Vec<Member>` per group, and calls `emit_group` once per group against a shared `Vec<Edit>` accumulator. The walker shapes are rule-specific *(consecutive assignments, dict items, `import` keywords, match-arm patterns)*, because the per-rule definition of *"what counts as a group"* varies, but the math afterward is shared across every alignment rule.
+Each alignment rule wraps an `AlignWalker` in its visitor struct, walks the AST, collects `Vec<Member>` per group, and calls `walker.emit_group(&members)` once per group. The grouping shapes are rule-specific *(consecutive assignments, dict items, `import` keywords, match-arm patterns)*, because the per-rule definition of *"what counts as a group"* varies, but the math afterward is shared across every alignment rule.
 
 A rule's `apply` method takes the canonical shape:
 
 ```rust
-fn apply(&self, source: &Source) -> Vec<Edit> {
-    let settings = Settings::from(&self.config);
-    let mut edits = Vec::new();
-    for group in line_adjacent_groups(&items, |item| member_for(source, item)) {
-        if is_alignment_candidate(&group) {
-            emit_group(source, &group, settings, &mut edits);
+struct Visitor<'a> {
+    walker: AlignWalker<'a>,
+}
+
+impl Rule for MyAlignmentRule {
+    fn apply(&self, source: &Source) -> Vec<Edit> {
+        let mut visitor = Visitor {
+            walker: AlignWalker::new(source, self.settings),
+        };
+        visitor.visit_body(&source.ast().body);
+        visitor.walker.edits
+    }
+}
+
+impl Visitor<'_> {
+    fn process_body(&mut self, body: &[Stmt]) {
+        for members in line_adjacent_groups(self.walker.source, body, |s| qualify(s)) {
+            self.walker.emit_group(&members);
         }
     }
-    edits
 }
 ```
 
-`line_adjacent_groups` handles the grouping for the common contiguous-statements shape, with the per-item `member_for` constructor folding through `line_anchored_member` or `line_anchored_member_at_kind` depending on whether the gap anchors at a known offset or at a specific token. `is_alignment_candidate` keeps single-member groups from emitting trivial edits before `emit_group` is even called. `emit_group` itself pushes its per-row edits into the shared accumulator, so the rule never has to thread a returned `Vec<Edit>` per group.
+`line_adjacent_groups` handles the grouping for the common contiguous-statements shape, with the per-item qualifier folding through `line_anchored_member` or `line_anchored_member_at_kind` depending on whether the gap anchors at a known offset or at a specific token. `walker.emit_group(&members)` pushes per-row edits into `self.edits`, so the rule never has to thread a returned `Vec<Edit>` per group, and `apply` drains the accumulator from `visitor.walker.edits` at the end.
 
-When the alignment context is `:`-shaped *(dict items, class fields, annotated parameters, docstring args, match arms)*, the walker lives in [[colon-targets]] instead. A new colon-shaped rule implements `ColonEmitter`'s `handle` and `dict`/`match_arms` overrides, calls `walk(source)`, and forwards each yielded `&[Member]` slice to `emit_group`.
+When the alignment context is `:`-shaped *(dict items, class fields, annotated parameters, docstring args, match arms)*, the grouping logic lives in [[colon-targets]] instead. A new colon-shaped rule implements `ColonEmitter`'s `handle` and `dict`/`match_arms` overrides, calls `walk(source)`, and forwards each yielded `&[Member]` slice to `walker.emit_group(&members)`.
 
 ## Re-Using This Primitive
 
-Writing a new alignment rule comes down to two steps: build the walker that yields `Vec<Member>` groups, then call `emit_group` per group. The padding math, the policy fallbacks, the singleton handling, and the right-alignment hook all carry through, leaving the rule to focus on its own grouping logic.
+Writing a new alignment rule comes down to wrapping an `AlignWalker` in a visitor struct, building the grouping logic that yields `Vec<Member>` per source-line run, and calling `walker.emit_group(&members)` per group. The padding math, the policy fallbacks, the singleton handling, and the right-alignment hook all carry through, leaving the rule to focus on its own grouping logic.
 
 <template #related>
 

--- a/site/primitives/index.md
+++ b/site/primitives/index.md
@@ -22,7 +22,7 @@ Reachable from a downstream Rust consumer in `0.2.x`:
 
 1. [[binding-analysis]] · per-*Source* table indexing every write and read of every name in every lexical scope
 2. [[suppression-map]] · per-*Source* index of `# fmt: off` / `# fmt: skip` / `# yapf` / `# prose: ignore[...]` directives
-3. [[aligner]] · shared alignment math, consumed by [[align-equals]], [[align-colons]], [[align-imports]], [[align-comparisons]], [[match-case-align]]
+3. [[aligner]] · shared alignment math, consumed by [[align-colons]], [[align-comparisons]], [[align-equals]], [[align-imports]], [[match-case-align]]
 4. [[orderer]] · sibling reorder helper preserving attached comments, consumed by [[alphabetize]]
 5. [[colon-targets]] · walker that finds every `:` alignment context, consumed by [[align-colons]] and [[singleton-rule]]
 6. [[edit]] · the `Edit { range, content }` shape every rule emits and the *Pipeline* applies

--- a/site/primitives/index.md
+++ b/site/primitives/index.md
@@ -22,7 +22,7 @@ Reachable from a downstream Rust consumer in `0.2.x`:
 
 1. [[binding-analysis]] · per-*Source* table indexing every write and read of every name in every lexical scope
 2. [[suppression-map]] · per-*Source* index of `# fmt: off` / `# fmt: skip` / `# yapf` / `# prose: ignore[...]` directives
-3. [[aligner]] · shared alignment math, consumed by [[align-equals]], [[align-colons]], [[align-imports]], [[match-case-align]]
+3. [[aligner]] · shared alignment math, consumed by [[align-equals]], [[align-colons]], [[align-imports]], [[align-comparisons]], [[match-case-align]]
 4. [[orderer]] · sibling reorder helper preserving attached comments, consumed by [[alphabetize]]
 5. [[colon-targets]] · walker that finds every `:` alignment context, consumed by [[align-colons]] and [[singleton-rule]]
 6. [[edit]] · the `Edit { range, content }` shape every rule emits and the *Pipeline* applies

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -1,8 +1,8 @@
 //! Computes padding widths and emits alignment edits for rules that
-//! align a shared token across a group of lines. `emit_group` is the
-//! entry point. Per-rule knobs travel through `Settings`. Aligned
-//! rows always carry a one-space buffer between content and the
-//! aligned token.
+//! align a shared token across a group of lines. Each rule wraps an
+//! `AlignWalker` whose `emit_group` method drives the math. Per-rule
+//! knobs travel through `Settings`. Aligned rows always carry a
+//! one-space buffer between content and the aligned token.
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::token::{Token, TokenKind};
@@ -33,7 +33,6 @@ impl<'a> AlignWalker<'a> {
         }
     }
 
-    /// Emits alignment edits for `members`.
     pub(crate) fn emit_group(&mut self, members: &[Member]) {
         emit_group(self.source, members, self.settings, &mut self.edits);
     }
@@ -94,42 +93,6 @@ impl From<&AlignmentConfig> for Settings {
             policy: c.max_shift_policy,
             strip_singleton_subgroup: false,
         }
-    }
-}
-
-/// Aligns the members of a group, dispatching through `settings.policy`
-/// when the widest padding exceeds `settings.max_shift`. A singleton
-/// group collapses its gap to one space, or to zero when
-/// `settings.strip_singleton_subgroup` is set, matching the
-/// singleton-from-split treatment in `emit_split`.
-pub(crate) fn emit_group(
-    source: &Source,
-    members: &[Member],
-    settings: Settings,
-    edits: &mut Vec<Edit>,
-) {
-    let Some(first) = members.first() else {
-        return;
-    };
-    let (min_w, max_w) = members
-        .iter()
-        .fold((first.width, first.width), |(mn, mx), m| {
-            (mn.min(m.width), mx.max(m.width))
-        });
-    let max_op_w = max_op_width(members);
-    if max_w - min_w <= settings.max_shift {
-        let suffix = if members.len() == 1 && settings.strip_singleton_subgroup {
-            0
-        } else {
-            1
-        };
-        emit_with_paddings(source, members, max_w, max_op_w, suffix, edits);
-        return;
-    }
-    match settings.policy {
-        MaxAlignShiftPolicy::Drop => emit_drop(source, members, settings, edits),
-        MaxAlignShiftPolicy::Skip => {}
-        MaxAlignShiftPolicy::Split => emit_split(source, members, settings, edits),
     }
 }
 
@@ -304,6 +267,37 @@ fn emit_drop(source: &Source, members: &[Member], settings: Settings, edits: &mu
     }
     let max_w = kept.last().expect("kept non-empty").width;
     emit_with_paddings(source, kept, max_w, max_op_width(kept), 1, edits);
+}
+
+/// Aligns the members of a group, dispatching through `settings.policy`
+/// when the widest padding exceeds `settings.max_shift`. A singleton
+/// group collapses its gap to one space, or to zero when
+/// `settings.strip_singleton_subgroup` is set, matching the
+/// singleton-from-split treatment in `emit_split`.
+fn emit_group(source: &Source, members: &[Member], settings: Settings, edits: &mut Vec<Edit>) {
+    let Some(first) = members.first() else {
+        return;
+    };
+    let (min_w, max_w) = members
+        .iter()
+        .fold((first.width, first.width), |(mn, mx), m| {
+            (mn.min(m.width), mx.max(m.width))
+        });
+    let max_op_w = max_op_width(members);
+    if max_w - min_w <= settings.max_shift {
+        let suffix = if members.len() == 1 && settings.strip_singleton_subgroup {
+            0
+        } else {
+            1
+        };
+        emit_with_paddings(source, members, max_w, max_op_w, suffix, edits);
+        return;
+    }
+    match settings.policy {
+        MaxAlignShiftPolicy::Drop => emit_drop(source, members, settings, edits),
+        MaxAlignShiftPolicy::Skip => {}
+        MaxAlignShiftPolicy::Split => emit_split(source, members, settings, edits),
+    }
 }
 
 /// Partitions greedily into sub-groups capped at `settings.max_shift`

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -15,6 +15,30 @@ use unicode_width::UnicodeWidthStr;
 use crate::config::{AlignmentConfig, MaxAlignShiftPolicy};
 use crate::source::Source;
 
+/// Bundles the `edits` accumulator, `settings`, and borrowed `source`
+/// shared by every alignment-rule visitor.
+pub(crate) struct AlignWalker<'a> {
+    pub edits: Vec<Edit>,
+    pub settings: Settings,
+    pub source: &'a Source,
+}
+
+impl<'a> AlignWalker<'a> {
+    /// Builds a walker with an empty `edits` accumulator.
+    pub(crate) fn new(source: &'a Source, settings: Settings) -> Self {
+        Self {
+            edits: Vec::new(),
+            settings,
+            source,
+        }
+    }
+
+    /// Emits alignment edits for `members`.
+    pub(crate) fn emit_group(&mut self, members: &[Member]) {
+        emit_group(self.source, members, self.settings, &mut self.edits);
+    }
+}
+
 /// One row in an alignment group.
 ///
 /// `width` is the display-column width of the row's left-hand-side

--- a/src/rules/align_colons.rs
+++ b/src/rules/align_colons.rs
@@ -30,12 +30,10 @@ impl AlignColons {
 impl Rule for AlignColons {
     fn apply(&self, source: &Source) -> Vec<Edit> {
         let mut emitter = Emitter {
-            edits: Vec::new(),
-            settings: self.settings,
-            source,
+            walker: aligner::AlignWalker::new(source, self.settings),
         };
         emitter.walk(source);
-        emitter.edits
+        emitter.walker.edits
     }
 
     fn id(&self) -> RuleId {
@@ -44,21 +42,19 @@ impl Rule for AlignColons {
 }
 
 struct Emitter<'a> {
-    edits: Vec<Edit>,
-    settings: aligner::Settings,
-    source: &'a Source,
+    walker: aligner::AlignWalker<'a>,
 }
 
 impl ColonEmitter for Emitter<'_> {
     fn dict(&mut self, d: &ExprDict, members: &[aligner::Member]) {
-        if !self.source.intersects_comment(d) {
+        if !self.walker.source.intersects_comment(d) {
             self.handle(members);
         }
     }
 
     fn handle(&mut self, members: &[aligner::Member]) {
         if aligner::is_alignment_candidate(members) {
-            aligner::emit_group(self.source, members, self.settings, &mut self.edits);
+            self.walker.emit_group(members);
         }
     }
 

--- a/src/rules/align_comparisons.rs
+++ b/src/rules/align_comparisons.rs
@@ -8,9 +8,9 @@
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::visitor::{walk_expr, Visitor};
+use ruff_python_ast::visitor::{walk_expr, Visitor as AstVisitor};
 use ruff_python_ast::{CmpOp, Expr, ExprBoolOp};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::config::Config;
 use crate::primitives::aligner;
@@ -31,13 +31,11 @@ impl AlignComparisons {
 
 impl Rule for AlignComparisons {
     fn apply(&self, source: &Source) -> Vec<Edit> {
-        let mut walker = Walker {
-            edits: Vec::new(),
-            settings: self.settings,
-            source,
+        let mut visitor = Visitor {
+            walker: aligner::AlignWalker::new(source, self.settings),
         };
-        walker.visit_body(&source.ast().body);
-        walker.edits
+        visitor.visit_body(&source.ast().body);
+        visitor.walker.edits
     }
 
     fn id(&self) -> RuleId {
@@ -45,24 +43,13 @@ impl Rule for AlignComparisons {
     }
 }
 
-struct Walker<'a> {
-    edits: Vec<Edit>,
-    settings: aligner::Settings,
-    source: &'a Source,
+struct Visitor<'a> {
+    walker: aligner::AlignWalker<'a>,
 }
 
-impl Walker<'_> {
-    /// Returns `true` when `prev_end` and `next_start` sit on directly
-    /// consecutive source lines. Directive comments (`# fmt: off`,
-    /// `# prose: skip[...]`) are handled by the pipeline's
-    /// `SuppressionMap` filter on emitted edits, so the rule itself
-    /// stays comment-agnostic.
-    fn is_operand_line_adjacent(&self, prev_end: TextSize, next_start: TextSize) -> bool {
-        self.source.line_index(next_start) == self.source.line_index(prev_end).saturating_add(1)
-    }
-
+impl Visitor<'_> {
     fn process_bool_op(&mut self, bool_op: &ExprBoolOp) {
-        if !self.source.contains_line_break(bool_op) {
+        if !self.walker.source.contains_line_break(bool_op) {
             return;
         }
         let mut groups: Vec<Vec<aligner::Member>> = Vec::new();
@@ -73,8 +60,9 @@ impl Walker<'_> {
                 continue;
             };
             let extends = active.is_some_and(|prev| {
-                !self.source.contains_line_break(prev)
-                    && self.is_operand_line_adjacent(prev.end(), operand.start())
+                !self.walker.source.contains_line_break(prev)
+                    && self.walker.source.line_index(operand.start())
+                        == self.walker.source.line_index(prev.end()).saturating_add(1)
             });
             if extends {
                 groups
@@ -88,7 +76,7 @@ impl Walker<'_> {
         }
         for group in &groups {
             if aligner::is_alignment_candidate(group) {
-                aligner::emit_group(self.source, group, self.settings, &mut self.edits);
+                self.walker.emit_group(group);
             }
         }
     }
@@ -98,7 +86,7 @@ impl Walker<'_> {
         let op = *compare.ops.first()?;
         let comparator = compare.comparators.first()?;
         let member = aligner::line_anchored_member_at_kind(
-            self.source,
+            self.walker.source,
             TextRange::new(compare.left.end(), comparator.start()),
             cmp_op_anchor_token_kind(op),
         )?;
@@ -106,7 +94,7 @@ impl Walker<'_> {
     }
 }
 
-impl<'a> Visitor<'a> for Walker<'a> {
+impl<'a> AstVisitor<'a> for Visitor<'a> {
     fn visit_expr(&mut self, expr: &'a Expr) {
         if let Expr::BoolOp(bool_op) = expr {
             self.process_bool_op(bool_op);

--- a/src/rules/align_equals.rs
+++ b/src/rules/align_equals.rs
@@ -35,12 +35,10 @@ impl AlignEquals {
 impl Rule for AlignEquals {
     fn apply(&self, source: &Source) -> Vec<Edit> {
         let mut visitor = Visitor {
-            edits: Vec::new(),
-            settings: self.settings,
-            source,
+            walker: aligner::AlignWalker::new(source, self.settings),
         };
         visitor.visit_body(&source.ast().body);
-        visitor.edits
+        visitor.walker.edits
     }
 
     fn id(&self) -> RuleId {
@@ -49,9 +47,7 @@ impl Rule for AlignEquals {
 }
 
 struct Visitor<'a> {
-    edits: Vec<Edit>,
-    settings: aligner::Settings,
-    source: &'a Source,
+    walker: aligner::AlignWalker<'a>,
 }
 
 impl Visitor<'_> {
@@ -59,7 +55,7 @@ impl Visitor<'_> {
     /// the search range running from `target.end()` to `value_start`.
     fn equal_member(&self, target: TextRange, value_start: TextSize) -> Option<aligner::Member> {
         aligner::range_anchored_member_single_line(
-            self.source,
+            self.walker.source,
             target,
             TextRange::new(target.end(), value_start),
             |t| t.kind() == TokenKind::Equal,
@@ -68,8 +64,9 @@ impl Visitor<'_> {
     }
 
     fn process_body(&mut self, body: &[Stmt]) {
-        for members in aligner::line_adjacent_groups(self.source, body, |s| self.qualify(s)) {
-            aligner::emit_group(self.source, &members, self.settings, &mut self.edits);
+        for members in aligner::line_adjacent_groups(self.walker.source, body, |s| self.qualify(s))
+        {
+            self.walker.emit_group(&members);
         }
     }
 
@@ -79,7 +76,7 @@ impl Visitor<'_> {
     fn process_parameters(&mut self, params: &Parameters) {
         for members in aligner::parameter_split_groups(params, |p| self.qualify_parameter(p)) {
             if aligner::is_alignment_candidate(&members) {
-                aligner::emit_group(self.source, &members, self.settings, &mut self.edits);
+                self.walker.emit_group(&members);
             }
         }
     }
@@ -109,7 +106,7 @@ impl Visitor<'_> {
             Stmt::AugAssign(a) => {
                 let target_range = a.target.range();
                 aligner::range_anchored_member_single_line(
-                    self.source,
+                    self.walker.source,
                     target_range,
                     TextRange::new(target_range.end(), a.value.start()),
                     |t| t.kind().as_augmented_assign_operator().is_some(),

--- a/src/rules/align_imports.rs
+++ b/src/rules/align_imports.rs
@@ -35,12 +35,10 @@ impl AlignImports {
 impl Rule for AlignImports {
     fn apply(&self, source: &Source) -> Vec<Edit> {
         let mut visitor = Visitor {
-            edits: Vec::new(),
-            settings: self.settings,
-            source,
+            walker: aligner::AlignWalker::new(source, self.settings),
         };
         visitor.visit_body(&source.ast().body);
-        visitor.edits
+        visitor.walker.edits
     }
 
     fn id(&self) -> RuleId {
@@ -55,22 +53,10 @@ enum Form {
 }
 
 struct Visitor<'a> {
-    edits: Vec<Edit>,
-    settings: aligner::Settings,
-    source: &'a Source,
+    walker: aligner::AlignWalker<'a>,
 }
 
 impl Visitor<'_> {
-    /// Emits alignment edits for a qualifying group. Singleton groups
-    /// pass through untouched, since the rule has nothing to align
-    /// against on a single-row group.
-    fn emit(&mut self, members: &[aligner::Member]) {
-        if members.len() < 2 {
-            return;
-        }
-        aligner::emit_group(self.source, members, self.settings, &mut self.edits);
-    }
-
     /// Walks `body` once through `aligner::keyed_line_adjacent_groups`,
     /// tagging each qualifying statement with its form. The keyed
     /// grouper closes an active run whenever the form changes at an
@@ -78,13 +64,15 @@ impl Visitor<'_> {
     /// between two `from`-imports splits the surrounding run without
     /// merging its neighbors and without re-walking the body.
     fn process_body(&mut self, body: &[Stmt]) {
-        let groups = aligner::keyed_line_adjacent_groups(self.source, body, |s| {
+        let groups = aligner::keyed_line_adjacent_groups(self.walker.source, body, |s| {
             self.qualify_from(s)
                 .map(|m| (Form::From, m))
                 .or_else(|| self.qualify_import_as(s).map(|m| (Form::As, m)))
         });
         for members in groups {
-            self.emit(&members);
+            if members.len() >= 2 {
+                self.walker.emit_group(&members);
+            }
         }
     }
 
@@ -94,10 +82,10 @@ impl Visitor<'_> {
     /// indent would misalign if the keyword shifted.
     fn qualify_from(&self, stmt: &Stmt) -> Option<aligner::Member> {
         let s = stmt.as_import_from_stmt()?;
-        if self.source.contains_line_break(s.range) {
+        if self.walker.source.contains_line_break(s.range) {
             return None;
         }
-        aligner::line_anchored_member_at_kind(self.source, s.range, TokenKind::Import)
+        aligner::line_anchored_member_at_kind(self.walker.source, s.range, TokenKind::Import)
     }
 
     /// Builds an alignment member for a single-name aliased import
@@ -106,7 +94,7 @@ impl Visitor<'_> {
     /// other statement shape.
     fn qualify_import_as(&self, stmt: &Stmt) -> Option<aligner::Member> {
         let s = stmt.as_import_stmt()?;
-        if self.source.contains_line_break(s.range) {
+        if self.walker.source.contains_line_break(s.range) {
             return None;
         }
         let [alias] = s.names.as_slice() else {
@@ -114,7 +102,7 @@ impl Visitor<'_> {
         };
         let asname = alias.asname.as_ref()?;
         aligner::line_anchored_member_at_kind(
-            self.source,
+            self.walker.source,
             TextRange::new(alias.name.end(), asname.start()),
             TokenKind::As,
         )

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -42,12 +42,10 @@ impl Rule for MatchCaseAlign {
     fn apply(&self, source: &Source) -> Vec<Edit> {
         let mut visitor = Visitor {
             code_line_length: self.code_line_length,
-            edits: Vec::new(),
-            settings: self.settings,
-            source,
+            walker: aligner::AlignWalker::new(source, self.settings),
         };
         visitor.visit_body(&source.ast().body);
-        visitor.edits
+        visitor.walker.edits
     }
 
     fn id(&self) -> RuleId {
@@ -67,20 +65,18 @@ enum CaseOutcome {
 
 struct Visitor<'a> {
     code_line_length: usize,
-    edits: Vec<Edit>,
-    settings: aligner::Settings,
-    source: &'a Source,
+    walker: aligner::AlignWalker<'a>,
 }
 
 impl Visitor<'_> {
     /// Emits alignment and collapse edits for a sub-group and drains it.
     fn flush_subgroup(&mut self, group: &mut Vec<(aligner::Member, TextRange)>) {
         let (members, ranges): (Vec<aligner::Member>, Vec<TextRange>) = group.drain(..).unzip();
-        aligner::emit_group(self.source, &members, self.settings, &mut self.edits);
-        self.edits.extend(
+        self.walker.emit_group(&members);
+        self.walker.edits.extend(
             ranges
                 .into_iter()
-                .filter_map(|r| aligner::space_padding_edit(self.source, r, 1)),
+                .filter_map(|r| aligner::space_padding_edit(self.walker.source, r, 1)),
         );
     }
 
@@ -88,11 +84,15 @@ impl Visitor<'_> {
     /// a line break, otherwise `Split` carrying an edit that pushes
     /// the body onto the next source line.
     fn over_budget_outcome(&self, case: &MatchCase, collapse_range: TextRange) -> CaseOutcome {
-        if self.source.contains_line_break(collapse_range) {
+        if self.walker.source.contains_line_break(collapse_range) {
             return CaseOutcome::Disqualify;
         }
-        let body_indent = self.source.line_indent_width(case.start()) + INDENT_STEP;
-        let replacement = format!("{}{}", self.source.newline_str(), " ".repeat(body_indent));
+        let body_indent = self.walker.source.line_indent_width(case.start()) + INDENT_STEP;
+        let replacement = format!(
+            "{}{}",
+            self.walker.source.newline_str(),
+            " ".repeat(body_indent),
+        );
         CaseOutcome::Split(Edit::range_replacement(replacement, collapse_range))
     }
 
@@ -105,11 +105,13 @@ impl Visitor<'_> {
             .as_deref()
             .map_or(case.pattern.end(), Ranged::end);
         let lhs_width = self
+            .walker
             .source
             .slice(TextRange::new(case.start(), pre_colon_end))
             .width();
-        let body_width = self.source.slice(body_first.range()).width();
-        self.source.column_of(case.start()) + lhs_width + 3 + body_width > self.code_line_length
+        let body_width = self.walker.source.slice(body_first.range()).width();
+        self.walker.source.column_of(case.start()) + lhs_width + 3 + body_width
+            > self.code_line_length
     }
 
     /// Emits collapse-and-align edits for one match by walking each
@@ -122,7 +124,7 @@ impl Visitor<'_> {
                 CaseOutcome::Disqualify => self.flush_subgroup(&mut current),
                 CaseOutcome::Split(edit) => {
                     self.flush_subgroup(&mut current);
-                    self.edits.push(edit);
+                    self.walker.edits.push(edit);
                 }
             }
         }
@@ -131,22 +133,22 @@ impl Visitor<'_> {
 
     /// Classifies one arm into the matching `CaseOutcome` variant.
     /// Disqualifies on multi-statement, compound, or multi-line
-    /// bodies and on a comment in the `:`-to-body gap; defers to
+    /// bodies and on a comment in the `:`-to-body gap, deferring to
     /// `over_budget_outcome` when the arm would overflow the
     /// line-length budget collapsed.
     fn qualify_case(&self, case: &MatchCase) -> CaseOutcome {
         let [body_first] = case.body.as_slice() else {
             return CaseOutcome::Disqualify;
         };
-        if is_compound_statement(body_first) || self.source.contains_line_break(body_first) {
+        if is_compound_statement(body_first) || self.walker.source.contains_line_break(body_first) {
             return CaseOutcome::Disqualify;
         }
-        let Some(member) = colon_targets::match_case(self.source, case) else {
+        let Some(member) = colon_targets::match_case(self.walker.source, case) else {
             return CaseOutcome::Disqualify;
         };
         let collapse_range =
             TextRange::new(member.gap.end() + TextSize::from(1u32), body_first.start());
-        if self.source.intersects_comment(collapse_range) {
+        if self.walker.source.intersects_comment(collapse_range) {
             return CaseOutcome::Disqualify;
         }
         if self.overflows_budget(case, body_first) {


### PR DESCRIPTION
### 🪻 Quick Summary

Extracts the visitor shell shared by every alignment rule into an `aligner::AlignWalker<'a>` primitive carrying `edits`, `settings`, and a borrowed `source`. Each rule *(`align_colons`, `align_comparisons`, `align_equals`, `align_imports`, and `match_case_align`)* now wraps an `AlignWalker` and calls `walker.emit_group(&members)` rather than the verbose four-argument free function, with `match_case_align` keeping its `code_line_length` knob as a sibling field rather than complicating the walker for a single consumer.

---

### 🗞️ Key Changes

- Adds `aligner::AlignWalker<'a>` at `src/primitives/aligner.rs` carrying `edits: Vec<Edit>`, `settings: Settings`, and a borrowed `source: &'a Source`, plus `AlignWalker::new(source, settings)` initializing `edits` to an empty `Vec` and a `pub(crate) fn emit_group(&mut self, members: &[Member])` convenience method that pushes alignment edits into `self.edits` rather than threading a returned `Vec<Edit>` per group

- Migrates `align_equals`, `align_imports`, `match_case_align`, and `align_comparisons` to compose against `AlignWalker` via named-field embedding, with each rule's `apply` method collapsing to a three-line construct-visit-return. `match_case_align`'s `code_line_length` knob stays as a sibling field alongside the embedded walker rather than complicating `AlignWalker` with a generic extras slot for one consumer

- Extends the migration to `align_colons` during the polish round, since its `Emitter` struct already carried the same `edits` / `settings` / `source` shell shape the spec enumerated for the other four rules. That move privatizes the free `aligner::emit_group` function, leaving `AlignWalker::emit_group` as the sole entry point beyond the in-file tests

- Refreshes `site/primitives/aligner.md` to document the `AlignWalker` shape in the Internal Surface section and update the Build Pattern example, plus folds `align-comparisons` into the consumer surfaces in `site/primitives/index.md` and the `<PrimitivesComposition>` data loader since #140 had left those out

- Keeps snapshots byte-identical against the existing fixtures under every migrated rule's directory, with `mise ci` and `mise run press` both green

---

### 🧵 Related Issues

- Closes #147