### PR TITLE
[148] Extract a `rewrite_docstrings` primitive shared across docstring rules

### DIFF
--- a/site/primitives/docstring.md
+++ b/site/primitives/docstring.md
@@ -2,7 +2,7 @@
 
 <PrimitiveLayout primitive="docstring">
 
-*Docstring* is the walker that reaches every PEP 257 docstring in a module. The first body statement of the module, each class, and each function may carry a string literal as a docstring, and the walker hands every such literal to a consumer in source order. Three rules ([[docstring-wrap]], [[multi-line-docstrings]], [[no-single-line-docstrings]]) consume the same walk, so the AST traversal lives once in *Docstring* and each rule supplies a handler that decides what to emit per docstring.
+*Docstring* is the walker that reaches every PEP 257 docstring in a module. The first body statement of the module, each class, and each function may carry a string literal as a docstring, and the walker hands every such literal to a consumer in source order. Three rules ([[docstring-wrap]], [[multi-line-docstrings]], [[no-single-line-docstrings]]) consume the same walk, so the AST traversal lives once in *Docstring* and each rule supplies a closure that decides what to emit per docstring.
 
 
 ## Public Surface
@@ -24,7 +24,17 @@ The walker recurses through nested classes and functions, so a module with deepl
 
 ## Internal Surface
 
-The receiver trait carries one required method, with `walk` provided:
+A docstring rule reaches the walker through the closure-based helper:
+
+```rust
+pub(crate) fn rewrite_docstrings<F>(source: &Source, f: F) -> Vec<Edit>
+where
+    F: FnMut(&Source, &StringLiteral, &mut Vec<Edit>),
+```
+
+`rewrite_docstrings` drives the walk across `source` and threads each discovered docstring through `f`, which receives the source, the literal, and the running edit buffer. The closure pushes whatever edits the rule needs per docstring, and the helper returns the accumulated `Vec<Edit>`.
+
+The underlying receiver trait stays in place for any future non-closure consumer:
 
 ```rust
 pub(crate) trait DocstringHandler {
@@ -34,7 +44,7 @@ pub(crate) trait DocstringHandler {
 }
 ```
 
-`handle` is the required per-docstring callback, invoked for each discovered literal in source order. `walk(source)` is the provided driver across `source`'s module body and every nested scope, and a consuming rule never overrides it.
+`handle` is the per-docstring callback invoked for each discovered literal in source order. `walk(source)` is the provided driver across `source`'s module body and every nested scope, and a consuming type never overrides it. `rewrite_docstrings` itself composes against this trait through a private collector.
 
 Two `pub(crate)` helpers reach for the docstring body:
 
@@ -53,36 +63,25 @@ Two `pub(crate)` helpers reach for the docstring body:
 
 ## Build Pattern
 
-A rule implementing `DocstringHandler` carries the accumulator state and pushes edits or diagnostics from each `handle` call. After `walk(source)` returns, the accumulator carries the full result, and the rule's `apply` method returns the `Vec<Edit>` from that accumulator. The canonical shape:
+A rule calls `rewrite_docstrings` from its `apply` method and supplies a closure that decides what to emit per docstring:
 
 ```rust
-struct MyRule<'src> {
-    source : &'src Source,
-    edits  : Vec<Edit>,
-}
-
-impl<'src> DocstringHandler for MyRule<'src> {
-    fn handle(&mut self, lit: &StringLiteral) {
-        if let Some(edit) = self.consider(lit) {
-            self.edits.push(edit);
-        }
-    }
-}
-
-impl Rule for MyRuleConfig {
+impl Rule for MyRule {
     fn apply(&self, source: &Source) -> Vec<Edit> {
-        let mut visitor = MyRule { source, edits: Vec::new() };
-        visitor.walk(source);
-        visitor.edits
+        rewrite_docstrings(source, |source, lit, edits| {
+            if let Some(edit) = consider(source, lit) {
+                edits.push(edit);
+            }
+        })
     }
 }
 ```
 
-`consider` is the rule-specific per-docstring decision, returning `Some(edit)` when the literal needs rewriting and `None` otherwise, and the accumulator pattern carries through every consuming rule without variation.
+`consider` is the rule-specific per-docstring decision, returning `Some(edit)` when the literal needs rewriting and `None` otherwise. Rule-specific configuration closes over `self` inside the closure, so a rule with line budgets, allow-patterns, or other knobs reaches them directly without needing a separate accumulator struct.
 
 ## Re-Using This Primitive
 
-A new docstring rule implements `DocstringHandler::handle`, deciding per docstring what edits to emit, and calls `walk(source)` from inside `apply`. The PEP 257 detection, the nested-scope traversal, and the implicitly-concatenated skip come for free.
+A new docstring rule's `apply` body is a single `rewrite_docstrings` call carrying the per-docstring decision as a closure. The PEP 257 detection, the nested-scope traversal, and the implicitly-concatenated skip come for free. A consumer that needs richer state across the walk can implement `DocstringHandler` directly and call `walk(source)` from inside `apply`.
 
 <template #related>
 

--- a/src/primitives/docstring.rs
+++ b/src/primitives/docstring.rs
@@ -5,6 +5,7 @@
 //! literal in source order via the trait's `walk` method. Implicitly
 //! concatenated docstring expressions are skipped.
 
+use ruff_diagnostics::Edit;
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::{ExprStringLiteral, Stmt, StringFlags, StringLiteral};
 use ruff_python_trivia::{has_leading_content, leading_indentation};
@@ -69,6 +70,37 @@ impl<'a, H: DocstringHandler> StatementVisitor<'a> for Visitor<'_, H> {
 /// preserving the source's mix of tabs and spaces verbatim.
 pub(crate) fn indent_prefix<'a>(source: &'a Source, lit: &StringLiteral) -> &'a str {
     leading_indentation(source.text().line_str(lit.start()))
+}
+
+/// Walks every docstring in `source` and collects the edits produced
+/// by `f` against each. The closure receives `source`, the docstring
+/// literal, and the running edit buffer. Returns the accumulated edits.
+pub(crate) fn rewrite_docstrings<F>(source: &Source, f: F) -> Vec<Edit>
+where
+    F: FnMut(&Source, &StringLiteral, &mut Vec<Edit>),
+{
+    struct Collector<'a, F> {
+        edits: Vec<Edit>,
+        f: F,
+        source: &'a Source,
+    }
+
+    impl<F> DocstringHandler for Collector<'_, F>
+    where
+        F: FnMut(&Source, &StringLiteral, &mut Vec<Edit>),
+    {
+        fn handle(&mut self, lit: &StringLiteral) {
+            (self.f)(self.source, lit, &mut self.edits);
+        }
+    }
+
+    let mut collector = Collector {
+        edits: Vec::new(),
+        f,
+        source,
+    };
+    collector.walk(source);
+    collector.edits
 }
 
 /// Returns the body slice and source range when `lit` is triple-quoted
@@ -159,6 +191,16 @@ mod tests {
     fn returns_empty_for_module_with_no_docstrings() {
         let s = parse("x = 1\ndef f():\n    return 1\n");
         assert!(Probe::run(&s).is_empty());
+    }
+
+    #[test]
+    fn rewrite_docstrings_collects_edits_pushed_by_closure_per_docstring() {
+        let s = parse("\"\"\"M\"\"\"\ndef f():\n    \"\"\"f\"\"\"\n    pass\n");
+        let edits = rewrite_docstrings(&s, |_, lit, edits| {
+            edits.push(Edit::range_deletion(lit.range()));
+        });
+        assert_eq!(edits.len(), 2);
+        assert!(edits.windows(2).all(|w| w[0].start() < w[1].start()));
     }
 
     #[test]

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -15,12 +15,11 @@ use std::sync::LazyLock;
 
 use regex_lite::Regex;
 use ruff_diagnostics::Edit;
-use ruff_python_ast::StringLiteral;
 use ruff_python_trivia::leading_indentation;
 use textwrap::Options;
 
 use crate::config::{Config, DocstringStructuredPolicy};
-use crate::primitives::docstring::{indent_prefix, triple_quoted_body, DocstringHandler};
+use crate::primitives::docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body};
 use crate::primitives::edit::narrowed_replacement;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
@@ -66,13 +65,18 @@ impl DocstringWrap {
 
 impl Rule for DocstringWrap {
     fn apply(&self, source: &Source) -> Vec<Edit> {
-        let mut rewriter = Rewriter {
-            edits: Vec::new(),
-            rule: self,
-            source,
-        };
-        rewriter.walk(source);
-        rewriter.edits
+        rewrite_docstrings(source, |source, lit, edits| {
+            let Some(body) = triple_quoted_body(source, lit).filter(|b| b.text.contains('\n'))
+            else {
+                return;
+            };
+            let indent = indent_prefix(source, lit);
+            let newline = source.newline_str();
+            let Some(rewritten) = rewrite_body(body.text, indent, newline, self) else {
+                return;
+            };
+            edits.extend(narrowed_replacement(source, body.range, rewritten));
+        })
     }
 
     fn id(&self) -> RuleId {
@@ -92,30 +96,6 @@ enum Region {
     Description,
     Section,
     SectionEntry(usize),
-}
-
-struct Rewriter<'a> {
-    edits: Vec<Edit>,
-    rule: &'a DocstringWrap,
-    source: &'a Source,
-}
-
-impl DocstringHandler for Rewriter<'_> {
-    fn handle(&mut self, lit: &StringLiteral) {
-        let Some(body) = triple_quoted_body(self.source, lit) else {
-            return;
-        };
-        if !body.text.contains('\n') {
-            return;
-        }
-        let indent = indent_prefix(self.source, lit);
-        let newline = self.source.newline_str();
-        let Some(rewritten) = rewrite_body(body.text, indent, newline, self.rule) else {
-            return;
-        };
-        self.edits
-            .extend(narrowed_replacement(self.source, body.range, rewritten));
-    }
 }
 
 struct Walker<'a> {

--- a/src/rules/multi_line_docstrings.rs
+++ b/src/rules/multi_line_docstrings.rs
@@ -6,11 +6,10 @@
 //! and pass through this rule untouched.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::StringLiteral;
 use ruff_python_trivia::has_leading_content;
 
 use crate::config::Config;
-use crate::primitives::docstring::{indent_prefix, triple_quoted_body, DocstringHandler};
+use crate::primitives::docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body};
 use crate::primitives::edit::narrowed_replacement;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
@@ -25,45 +24,26 @@ impl MultiLineDocstrings {
 
 impl Rule for MultiLineDocstrings {
     fn apply(&self, source: &Source) -> Vec<Edit> {
-        let mut rewriter = Rewriter {
-            edits: Vec::new(),
-            source,
-        };
-        rewriter.walk(source);
-        rewriter.edits
+        rewrite_docstrings(source, |source, lit, edits| {
+            let Some(body) = triple_quoted_body(source, lit).filter(|b| b.text.contains('\n'))
+            else {
+                return;
+            };
+            let leading_ok = body.text.starts_with(['\n', '\r']);
+            let trailing_ok = !has_leading_content(body.range.end(), source.text());
+            if leading_ok && trailing_ok {
+                return;
+            }
+            let pad = format!("{}{}", source.newline_str(), indent_prefix(source, lit));
+            let leading = if leading_ok { "" } else { pad.as_str() };
+            let trailing = if trailing_ok { "" } else { pad.as_str() };
+            let new_body = format!("{leading}{}{trailing}", body.text);
+            edits.extend(narrowed_replacement(source, body.range, new_body));
+        })
     }
 
     fn id(&self) -> RuleId {
         Self::SLUG
-    }
-}
-
-struct Rewriter<'a> {
-    edits: Vec<Edit>,
-    source: &'a Source,
-}
-
-impl DocstringHandler for Rewriter<'_> {
-    fn handle(&mut self, lit: &StringLiteral) {
-        let Some(body) = triple_quoted_body(self.source, lit) else {
-            return;
-        };
-        if !body.text.contains('\n') {
-            return;
-        }
-        let leading_ok = body.text.starts_with(['\n', '\r']);
-        let trailing_ok = !has_leading_content(body.range.end(), self.source.text());
-        if leading_ok && trailing_ok {
-            return;
-        }
-        let indent = indent_prefix(self.source, lit);
-        let newline = self.source.newline_str();
-        let pad = format!("{newline}{indent}");
-        let leading = if leading_ok { "" } else { pad.as_str() };
-        let trailing = if trailing_ok { "" } else { pad.as_str() };
-        let new_body = format!("{leading}{}{trailing}", body.text);
-        self.edits
-            .extend(narrowed_replacement(self.source, body.range, new_body));
     }
 }
 

--- a/src/rules/no_single_line_docstrings.rs
+++ b/src/rules/no_single_line_docstrings.rs
@@ -7,11 +7,10 @@
 //! here on every already-multi-line docstring.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::StringLiteral;
 use ruff_python_trivia::PythonWhitespace;
 
 use crate::config::Config;
-use crate::primitives::docstring::{indent_prefix, triple_quoted_body, DocstringHandler};
+use crate::primitives::docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body};
 use crate::primitives::edit::narrowed_replacement;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
@@ -26,41 +25,24 @@ impl NoSingleLineDocstrings {
 
 impl Rule for NoSingleLineDocstrings {
     fn apply(&self, source: &Source) -> Vec<Edit> {
-        let mut rewriter = Rewriter {
-            edits: Vec::new(),
-            source,
-        };
-        rewriter.walk(source);
-        rewriter.edits
+        rewrite_docstrings(source, |source, lit, edits| {
+            let Some(body) = triple_quoted_body(source, lit).filter(|b| !b.text.contains('\n'))
+            else {
+                return;
+            };
+            let trimmed = body.text.trim_whitespace();
+            if trimmed.is_empty() {
+                return;
+            }
+            let indent = indent_prefix(source, lit);
+            let newline = source.newline_str();
+            let candidate = format!("{newline}{indent}{trimmed}{newline}{indent}");
+            edits.extend(narrowed_replacement(source, body.range, candidate));
+        })
     }
 
     fn id(&self) -> RuleId {
         Self::SLUG
-    }
-}
-
-struct Rewriter<'a> {
-    edits: Vec<Edit>,
-    source: &'a Source,
-}
-
-impl DocstringHandler for Rewriter<'_> {
-    fn handle(&mut self, lit: &StringLiteral) {
-        let Some(body) = triple_quoted_body(self.source, lit) else {
-            return;
-        };
-        if body.text.contains('\n') {
-            return;
-        }
-        let trimmed = body.text.trim_whitespace();
-        if trimmed.is_empty() {
-            return;
-        }
-        let indent = indent_prefix(self.source, lit);
-        let newline = self.source.newline_str();
-        let candidate = format!("{newline}{indent}{trimmed}{newline}{indent}");
-        self.edits
-            .extend(narrowed_replacement(self.source, body.range, candidate));
     }
 }
 


### PR DESCRIPTION
### 🪻 Quick Summary

Extracts the docstring walker's collector shell into a closure-driven `rewrite_docstrings<F>(source, f) -> Vec<Edit>` helper at `src/primitives/docstring.rs`, retiring the three private `Rewriter<'a>` structs the docstring rules each carried. Two of those structs were byte-identical and the third added a `rule: &'a Self` field so `docstring_wrap`'s closure body could reach `description_width` and `section_width`, all three of which collapse against the helper because rule-specific configuration closes over `self` rather than living on a per-rule struct. The `DocstringHandler` trait stays in place for the in-file test probe and any future non-closure consumer.

---

### 🗞️ Key Changes

- Adds `pub(crate) fn rewrite_docstrings<F>(source: &Source, f: F) -> Vec<Edit>` where `F: FnMut(&Source, &StringLiteral, &mut Vec<Edit>)`, driving a private `Collector<'a, F>` that implements `DocstringHandler` to walk every docstring in source order and accumulate the edits `f` pushes per literal.

- Migrates `docstring_wrap`, `multi_line_docstrings`, and `no_single_line_docstrings` to compose against the helper, deleting each rule's `Rewriter<'a>` struct and `impl DocstringHandler` block, with each `Rule::apply` body collapsing to a single `rewrite_docstrings(source, |source, lit, edits| { ... })` call.

- Adds an inline test `rewrite_docstrings_collects_edits_pushed_by_closure_per_docstring` pinning the closure's `(source, lit, edits)` threading and the source-order invariant across nested scopes through a module-plus-nested-function fixture.

- Reshapes `site/primitives/docstring.md` to lead the Internal Surface, Build Pattern, and Re-Using sections with the closure helper, keeping the trait surface documented for any future implementor that needs richer cross-walk state than a closure capture carries.

- Holds snapshots byte-identical against the existing fixtures under `tests/fixtures/docstring_wrap/`, `tests/fixtures/multi_line_docstrings/`, and `tests/fixtures/no_single_line_docstrings/`, with `mise ci` and `mise run press` both green.

---

### 🧵 Related Issues

- Closes #148