### PR TITLE
[167] Extend `canonical_blanks` to module-level assignments after a top-level definition

### DIFF
--- a/site/rules/blank-lines.md
+++ b/site/rules/blank-lines.md
@@ -12,7 +12,7 @@ layout   : doc
 
 Blank lines carry rhythm. They tell the reader where one unit ends and the next begins, and a consistent rhythm across a file lets the reader skim by section without parsing each statement. `blank-lines` normalizes the discipline around module-level definitions, class members, and the `if __name__ == "__main__":` guard, so every file in the project reads with the same cadence.
 
-Module-level `def` and `class` carry two blank lines before them, methods inside a class body carry one, a module-level statement after `if __name__ == "__main__":` carries one, and adjacent bare-import and `from`-import groups carry one between them. Inside function bodies the rule leaves blank-line discipline alone, since the in-body rhythm remains a per-author choice. A description-shaped own-line comment block above a statement binds tight against the following statement, reading the comment as a description of the statement it precedes, whereas a banner-shaped block *(with any line a decorative rule of `=`, `-`, `*`, `_`, `#`, or `~`)* keeps 1 blank line below to read as a section divider. The canonical above-gap is measured from the topmost comment in the block either way. The import surface sits downstream of [[alphabetize]] (*which orders the entries first*) and [[bare-import-allowlist]] (*which decides which packages keep the bare form*), then this rule lands the blank-line separators between groups, and [[align-imports]] closes the sequence by aligning the `import` keyword.
+Module-level `def` and `class` carry two blank lines before them and two after when followed by a top-level assignment. Methods inside a class body carry one, a module-level statement after `if __name__ == "__main__":` carries one, and adjacent bare-import and `from`-import groups carry one between them. Inside function bodies the rule leaves blank-line discipline alone, since the in-body rhythm remains a per-author choice. A description-shaped own-line comment block above a statement binds tight against the following statement, reading the comment as a description of the statement it precedes, whereas a banner-shaped block *(with any line a decorative rule of `=`, `-`, `*`, `_`, `#`, or `~`)* keeps 1 blank line below to read as a section divider. The canonical above-gap is measured from the topmost comment in the block either way. The import surface sits downstream of [[alphabetize]] (*which orders the entries first*) and [[bare-import-allowlist]] (*which decides which packages keep the bare form*), then this rule lands the blank-line separators between groups, and [[align-imports]] closes the sequence by aligning the `import` keyword.
 
 <template #configuration>
 
@@ -33,6 +33,8 @@ Two blank lines precede every module-level `def` and `class`, giving the reader'
 <Fixture rule="blank_lines" case="bare_then_from_insert" title="One Blank Lands between Adjacent Bare and `from` Import Groups" />
 
 <Fixture rule="blank_lines" case="class_with_docstring" title="The First Method after a Class Docstring Tightens Up" />
+
+<Fixture rule="blank_lines" case="class_then_assignment" title="An Assignment after a Module-Level `class` Carries Two Blanks" />
 
 <Fixture rule="blank_lines" case="bare_then_from_collapse" title="Excess Blanks Collapse to the Canonical Single Blank" />
 

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -246,9 +246,9 @@ fn leading_block_of(source: &Source, prev_end: TextSize, curr: &Stmt) -> Option<
 /// Module-scope pair dispatch. A statement following an
 /// `if __name__ == "__main__":` block carries 1 blank line. The bare /
 /// `from` import kind boundary carries 1. A top-level `FunctionDef` or
-/// `ClassDef` carries 2 blank lines before it. A top-level `Assign` or
-/// `AnnAssign` carries 2 blank lines before it when its predecessor is
-/// a `FunctionDef` or `ClassDef`.
+/// `ClassDef` carries 2 blank lines before it. An `Assign` or
+/// `AnnAssign` following a top-level `FunctionDef` or `ClassDef`
+/// carries 2.
 fn module_scope_blanks(prev: &Stmt, curr: &Stmt) -> Option<u32> {
     match (prev, curr) {
         _ if is_main_guard(prev) => Some(1),
@@ -401,43 +401,21 @@ mod tests {
     }
 
     #[test]
-    fn canonical_blanks_module_ann_assign_after_module_class_returns_two() {
-        let s = parse("class C: pass\nPORT: int = 8080\n");
-        let body = &s.ast().body;
-        assert_eq!(
-            canonical_blanks(&body[0], &body[1], BodyScope::Module),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn canonical_blanks_module_ann_assign_after_module_def_returns_two() {
-        let s = parse("def f(): pass\nPORT: int = 8080\n");
-        let body = &s.ast().body;
-        assert_eq!(
-            canonical_blanks(&body[0], &body[1], BodyScope::Module),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn canonical_blanks_module_assign_after_module_class_returns_two() {
-        let s = parse("class C: pass\nPORT = 8080\n");
-        let body = &s.ast().body;
-        assert_eq!(
-            canonical_blanks(&body[0], &body[1], BodyScope::Module),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn canonical_blanks_module_assign_after_module_def_returns_two() {
-        let s = parse("def f(): pass\nPORT = 8080\n");
-        let body = &s.ast().body;
-        assert_eq!(
-            canonical_blanks(&body[0], &body[1], BodyScope::Module),
-            Some(2)
-        );
+    fn canonical_blanks_module_assignment_after_def_or_class_returns_two() {
+        for src in [
+            "class C: pass\nPORT = 8080\n",
+            "class C: pass\nPORT: int = 8080\n",
+            "def f(): pass\nPORT = 8080\n",
+            "def f(): pass\nPORT: int = 8080\n",
+        ] {
+            let s = parse(src);
+            let body = &s.ast().body;
+            assert_eq!(
+                canonical_blanks(&body[0], &body[1], BodyScope::Module),
+                Some(2),
+                "src = {src:?}",
+            );
+        }
     }
 
     #[test]

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -246,12 +246,15 @@ fn leading_block_of(source: &Source, prev_end: TextSize, curr: &Stmt) -> Option<
 /// Module-scope pair dispatch. A statement following an
 /// `if __name__ == "__main__":` block carries 1 blank line. The bare /
 /// `from` import kind boundary carries 1. A top-level `FunctionDef` or
-/// `ClassDef` carries 2 blank lines before it.
+/// `ClassDef` carries 2 blank lines before it. A top-level `Assign` or
+/// `AnnAssign` carries 2 blank lines before it when its predecessor is
+/// a `FunctionDef` or `ClassDef`.
 fn module_scope_blanks(prev: &Stmt, curr: &Stmt) -> Option<u32> {
     match (prev, curr) {
         _ if is_main_guard(prev) => Some(1),
         (Stmt::Import(_), Stmt::ImportFrom(_)) | (Stmt::ImportFrom(_), Stmt::Import(_)) => Some(1),
         (_, Stmt::FunctionDef(_) | Stmt::ClassDef(_)) => Some(2),
+        (Stmt::FunctionDef(_) | Stmt::ClassDef(_), Stmt::Assign(_) | Stmt::AnnAssign(_)) => Some(2),
         _ => None,
     }
 }
@@ -394,6 +397,46 @@ mod tests {
         assert_eq!(
             canonical_blanks(&body[0], &body[1], BodyScope::Module),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_module_ann_assign_after_module_class_returns_two() {
+        let s = parse("class C: pass\nPORT: int = 8080\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_module_ann_assign_after_module_def_returns_two() {
+        let s = parse("def f(): pass\nPORT: int = 8080\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_module_assign_after_module_class_returns_two() {
+        let s = parse("class C: pass\nPORT = 8080\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn canonical_blanks_module_assign_after_module_def_returns_two() {
+        let s = parse("def f(): pass\nPORT = 8080\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            canonical_blanks(&body[0], &body[1], BodyScope::Module),
+            Some(2)
         );
     }
 

--- a/tests/fixtures/blank_lines/assignment_run_unchanged.input.py
+++ b/tests/fixtures/blank_lines/assignment_run_unchanged.input.py
@@ -1,0 +1,9 @@
+"""
+A run of module-level assignments leaves each adjacency at the
+source's actual count, because the module-scope dispatch returns
+`None` for assignment-after-assignment pairs.
+"""
+
+PORT = 8080
+HOST = "localhost"
+TIMEOUT: float = 30.0

--- a/tests/fixtures/blank_lines/class_then_assignment.input.py
+++ b/tests/fixtures/blank_lines/class_then_assignment.input.py
@@ -1,0 +1,9 @@
+"""
+A module-level class followed by an assignment normalizes to 2 blank
+lines between them, regardless of the source's actual count.
+"""
+
+
+class Posting:
+    title = "x"
+PORT = 8080

--- a/tests/fixtures/blank_lines/def_then_assignment.input.py
+++ b/tests/fixtures/blank_lines/def_then_assignment.input.py
@@ -1,0 +1,9 @@
+"""
+A module-level def followed by an annotated assignment normalizes to 2
+blank lines between them, regardless of the source's actual count.
+"""
+
+
+def configure():
+    return None
+TIMEOUT: float = 30.0

--- a/tests/snapshots/blank_lines/assignment_run_unchanged.diagnostics.snap
+++ b/tests/snapshots/blank_lines/assignment_run_unchanged.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/assignment_run_unchanged.input.py
+---
+

--- a/tests/snapshots/blank_lines/assignment_run_unchanged.input.py.snap
+++ b/tests/snapshots/blank_lines/assignment_run_unchanged.input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/assignment_run_unchanged.input.py
+---
+"""
+A run of module-level assignments leaves each adjacency at the
+source's actual count, because the module-scope dispatch returns
+`None` for assignment-after-assignment pairs.
+"""
+
+PORT = 8080
+HOST = "localhost"
+TIMEOUT: float = 30.0

--- a/tests/snapshots/blank_lines/class_then_assignment.diagnostics.snap
+++ b/tests/snapshots/blank_lines/class_then_assignment.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/class_then_assignment.input.py
+---
+blank-lines@154..155
+blank-lines@170..171

--- a/tests/snapshots/blank_lines/class_then_assignment.input.py.snap
+++ b/tests/snapshots/blank_lines/class_then_assignment.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/class_then_assignment.input.py
+---
+"""
+A module-level class followed by an assignment normalizes to 2 blank
+lines between them, regardless of the source's actual count.
+"""
+
+
+class Posting:
+
+    title = "x"
+
+
+PORT = 8080

--- a/tests/snapshots/blank_lines/def_then_assignment.diagnostics.snap
+++ b/tests/snapshots/blank_lines/def_then_assignment.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/blank_lines/def_then_assignment.input.py
+---
+blank-lines@180..181

--- a/tests/snapshots/blank_lines/def_then_assignment.input.py.snap
+++ b/tests/snapshots/blank_lines/def_then_assignment.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/blank_lines/def_then_assignment.input.py
+---
+"""
+A module-level def followed by an annotated assignment normalizes to 2
+blank lines between them, regardless of the source's actual count.
+"""
+
+
+def configure():
+    return None
+
+
+TIMEOUT: float = 30.0


### PR DESCRIPTION
### 🪻 Quick Summary

Extends `canonical_blanks` in `src/rules/blank_lines.rs` with a `(Stmt::FunctionDef(_) | Stmt::ClassDef(_), Stmt::Assign(_) | Stmt::AnnAssign(_)) => Some(2)` arm at module scope, mirroring the existing `(_, Stmt::FunctionDef(_) | Stmt::ClassDef(_))` arm in reverse. A class or `def` followed by `PORT = 8080` or `TIMEOUT: float = 30.0` now normalizes to two blank lines between them, regardless of the source's actual count. Every other module-scope adjacency stays at `None`, including assignment-after-assignment, leaving that case to the existing `loose-constants` lint.

---

### 🗞️ Key Changes

- Extends `module_scope_blanks` in `src/rules/blank_lines.rs` with the def-or-class → `Assign`/`AnnAssign` arm and its doc-comment enumeration, mirroring the existing `_, FunctionDef | ClassDef` arm so a top-level class or `def` followed by a bare or annotated module-level assignment normalizes to two blank lines.

- Adds three fixtures under `tests/fixtures/blank_lines/`. `class_then_assignment` pins the class → `Assign` case, `def_then_assignment` pins the `def` → `AnnAssign` case, and `assignment_run_unchanged` pins the negative case wherein a run of module-level assignments leaves each adjacency at the source's actual count because the dispatch returns `None` for assignment-after-assignment pairs.

- Pins helper-level coverage with `canonical_blanks_module_assignment_after_def_or_class_returns_two`, a parameterized inline test walking all four `(class/def, Assign/AnnAssign)` combinations through the dispatch and asserting `Some(2)` for each. The `for src in [..]` shape matches `canonical_blanks_function_header_to_compound_body_returns_one`'s pattern for similar arm coverage.

- Surfaces the new canonical case on `site/rules/blank-lines.md` through a sentence extension on the overview paragraph plus a `<Fixture rule="blank_lines" case="class_then_assignment" />` invocation in the more-examples panel.

---

### 🧵 Related Issues

- Closes #167