### PR TITLE
[130] Unify import-block handling across runs and kinds

### DIFF
--- a/site/.vitepress/lib/glossary/glossary-data.ts
+++ b/site/.vitepress/lib/glossary/glossary-data.ts
@@ -185,6 +185,12 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'A second `prose format` run against `prose`-formatted source produces no further edits. Every rule preserves this property, so re-running the formatter never thrashes the source.'
   },
 
+  'import block': {
+    aliases   : ['unified import block', 'import blocks'],
+    definition: 'An import block is the run of consecutive bare and `from` imports at the same indent, separated by at most one blank line. The primitive is shared by [[alphabetize]] (*which sorts each kind within its own contiguous slot inside the block*) and [[align-imports]] (*which right-aligns the post-keyword name at one shared column across the block*). Two or more blank lines or any non-import statement end the block.',
+    href      : '/rules/align-imports'
+  },
+
   'kebab-case': {
     definition: 'Kebab-case is the lowercase-with-hyphens naming convention *Prose* uses for every rule slug (`align-equals`, `single-use-variables`). The form is canonical across CLI flags, config tables, suppression directives, and diagnostic output.',
     href      : '/primitives/rule-id'

--- a/site/primitives/aligner.md
+++ b/site/primitives/aligner.md
@@ -31,13 +31,12 @@ The entry point `emit_group(source: &Source, members: &[Member], settings: Setti
 A consuming rule rarely hand-builds the walker from raw AST traversal, since `aligner.rs` exposes a set of `pub(crate)` helpers covering the common shapes a new alignment rule needs:
 
 1. `line_adjacent_groups(items, member_of)` partitions `items` into runs of line-adjacent siblings via `Source::is_line_adjacent`, then maps each item through `member_of`. Single-member runs drop out.
-2. `keyed_line_adjacent_groups(items, key_of, member_of)` is the same shape with a per-item key that further partitions adjacent items into sub-groups by key.
-3. `parameter_split_groups(params, qualify)` walks a `Parameters` node and splits at the first parameter that does not qualify, used by rules over annotated function signatures.
-4. `line_anchored_member(source, anchor)` builds a `Member` whose `gap` starts at `anchor` and whose `width` measures the leading display column on the line.
-5. `line_anchored_member_at_kind(source, line, kind)` finds the first token of `kind` on `line` and anchors a `Member` at its end.
-6. `range_anchored_member_single_line(source, range, anchor_of)` builds a `Member` whose `width` is the display-column width of `range`'s slice, for left-hand sides that are sub-ranges of one line.
-7. `space_padding_edit(source, range, n)` produces a `Some(Edit)` replacing `range` with `n` spaces, or `None` when the current contents already match.
-8. `is_alignment_candidate(members)` returns `true` when the group has at least two members and every member sits on a distinct line.
+2. `parameter_split_groups(params, qualify)` walks a `Parameters` node and splits at the first parameter that does not qualify, used by rules over annotated function signatures.
+3. `line_anchored_member(source, anchor)` builds a `Member` whose `gap` starts at `anchor` and whose `width` measures the leading display column on the line.
+4. `line_anchored_member_at_kind(source, line, kind)` finds the first token of `kind` on `line` and anchors a `Member` at its end.
+5. `range_anchored_member_single_line(source, range, anchor_of)` builds a `Member` whose `width` is the display-column width of `range`'s slice, for left-hand sides that are sub-ranges of one line.
+6. `space_padding_edit(source, range, n)` produces a `Some(Edit)` replacing `range` with `n` spaces, or `None` when the current contents already match.
+7. `is_alignment_candidate(members)` returns `true` when the group has at least two members and every member sits on a distinct line.
 
 ## How the Math Resolves
 

--- a/site/rules/align-imports.md
+++ b/site/rules/align-imports.md
@@ -1,7 +1,7 @@
 ---
 category : auto-fix
 family   : alignment
-caption  : "aligns the `import` and `as` keywords across consecutive import statements."
+caption  : "aligns the `import` keyword across the unified bare-and-`from` import block."
 related  : [align-colons, align-equals, alphabetize, bare-import-allowlist, blank-lines, match-case-align]
 layout   : doc
 ---
@@ -10,9 +10,9 @@ layout   : doc
 
 <RuleLayout rule="align_imports" canonical="from_imports">
 
-An import block carries two kinds of structure that the reader's eye wants to follow as columns. The module column says where a thing comes from, and the name column says what's pulled in. When the two columns float at varying widths, every line reads as a fresh sentence rather than a row in a table. `align-imports` gathers consecutive `from ... import ...` statements (*or consecutive `import ... as ...` statements*) into a shared column for the `import` (*or `as`*) keyword, leaving the module column flush left and the name column flush right.
+An import block carries two kinds of structure that the reader's eye wants to follow as columns. The module column says where a thing comes from, and the name column says what's pulled in. When the two columns float at varying widths, every line reads as a fresh sentence rather than a row in a table. `align-imports` gathers consecutive bare and `from` imports at the same indent into one unified block, right-aligning the `as` keyword in `import M as A` rows against the `import` keyword in `from M import N` rows so every post-keyword name lands at one shared column.
 
-The rule reads each block as the run of consecutive imports at the same indentation. A blank line, a comment, or a non-import statement resets the run. Pair with [[alphabetize]] to sort entries within each block before alignment, with [[blank-lines]] to separate import groups by category, and with [[bare-import-allowlist]] to canonicalize bare-versus-from before the alignment pass.
+The rule reads each block as the run of consecutive imports at the same indent, absorbing a single blank line between adjacent imports so the kind-boundary cushion `blank-lines` introduces does not split the alignment. Two or more blank lines, or a non-import statement, end the block. Comments between imports flow through without resetting. Pair with [[alphabetize]] to sort entries within each block before alignment, with [[blank-lines]] to separate import groups by category, and with [[bare-import-allowlist]] to canonicalize bare-versus-from before the alignment pass.
 
 <template #configuration>
 
@@ -30,11 +30,17 @@ A run of `from ... import ...` statements lines up on the `import` keyword, so t
 
 <template #more-examples>
 
+<Fixture rule="align_imports" case="unified_block" title="Bare Aliased and `from` Imports Share One `import` Column" />
+
+<Fixture rule="align_imports" case="unified_from_then_bare" title="The Unified Block Holds Regardless of Kind Order" />
+
 <Fixture rule="align_imports" case="aliased_imports" title="Bare Imports with Aliases Align on the `as` Keyword" />
 
-<Fixture rule="align_imports" case="breakers" title="Non-Import Statements Reset the Alignment Run" />
+<Fixture rule="align_imports" case="breakers" title="Non-Import Statements End the Block" />
 
-<Fixture rule="align_imports" case="comment_breaks" title="Comment Lines Reset the Run, like Blank Lines" />
+<Fixture rule="align_imports" case="comment_breaks" title="Comments between Imports Flow through the Block" />
+
+<Fixture rule="align_imports" case="two_blank_lines_break" title="Two Blank Lines End the Block at the First Such Gap" />
 
 <Fixture rule="align_imports" case="aliased_shift_limit_split" title="A Widest Member past `max-shift` Splits the Group" />
 

--- a/site/rules/alphabetize.md
+++ b/site/rules/alphabetize.md
@@ -10,7 +10,7 @@ layout   : doc
 
 <RuleLayout rule="alphabetize" canonical="classes">
 
-A reader who already knows the codebase carries a **mental map** of where things live. When sibling members within a class, an enum, a dataclass, or a function call sit in arrival order, every reader builds a **different map**, which slows each new reader's first read. `alphabetize` gives everyone the **same landmarks**, with classes ordered alphabetically inside a module, module-level assignment runs ordered within each dependency tier, methods ordered inside a class body (*dunders first, then properties, then private, then public*), enum members ordered, dataclass and Pydantic fields ordered (*required before optional*), function parameters with defaults ordered, keyword arguments at call sites ordered, and `from` imports ordered within each block.
+A reader who already knows the codebase carries a **mental map** of where things live. When sibling members within a class, an enum, a dataclass, or a function call sit in arrival order, every reader builds a **different map**, which slows each new reader's first read. `alphabetize` gives everyone the **same landmarks**, with classes ordered alphabetically inside a module, module-level assignment runs ordered within each dependency tier, methods ordered inside a class body (*dunders first, then properties, then private, then public*), enum members ordered, dataclass and Pydantic fields ordered (*required before optional*), function parameters with defaults ordered, keyword arguments at call sites ordered, and imports ordered within each kind's contiguous slot in the unified block.
 
 The rule fires on siblings whose order does not carry meaning. It leaves alone every surface where ordering is load-bearing (*positional-only parameters before the `/` separator, enum members with explicit integer or string values, tuple-unpacking targets bound to positional results*). Pair with [[align-imports]] to align the `import` keyword across the freshly-sorted block, with [[align-colons]] to align dataclass-field annotations after the sort, and with [[blank-lines]] for the blank-line discipline around class members.
 
@@ -18,7 +18,7 @@ The rule fires on siblings whose order does not carry meaning. It leaves alone e
 
 <RuleConfigTable />
 
-The ordering itself follows fixed per-construct conventions without per-project knobs. Method groups follow the dunders-properties-privates-publics rhythm. Pydantic fields follow required-then-optional. Imports sort alphabetically within each block.
+The ordering itself follows fixed per-construct conventions without per-project knobs. Method groups follow the dunders-properties-privates-publics rhythm. Pydantic fields follow required-then-optional. Imports sort alphabetically within each kind's contiguous slot in the unified block.
 
 </template>
 
@@ -43,6 +43,8 @@ Classes inside a module sort alphabetically, giving every reader the same first-
 <Fixture rule="alphabetize" case="from_imports" title="`from` Imports Sort Alphabetically inside Their Block" />
 
 <Fixture rule="alphabetize" case="bare_imports" title="Bare Imports Sort Alphabetically Too" />
+
+<Fixture rule="alphabetize" case="mixed_kind_block" title="Each Kind Sorts within Its Contiguous Slot in the Unified Block" />
 
 <Fixture rule="alphabetize" case="annotated_field_default" title="Field Defaults Are Preserved Across the Reorder" />
 

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -114,7 +114,7 @@ pub(crate) fn is_alignment_candidate(members: &[Member]) -> bool {
 /// run and starts a fresh one without losing the boundary statement.
 /// Walks `body` exactly once, calling the qualifier and each boundary
 /// predicate at most once per statement.
-pub(crate) fn keyed_line_adjacent_groups<'a, K, M, F>(
+fn keyed_line_adjacent_groups<'a, K, M, F>(
     source: &'a Source,
     body: &'a [Stmt],
     mut qualify: F,

--- a/src/rules/align_imports.rs
+++ b/src/rules/align_imports.rs
@@ -82,28 +82,27 @@ impl Visitor<'_> {
     /// sit in the block without contributing to or receiving
     /// alignment.
     fn qualify(&self, stmt: &Stmt) -> Option<aligner::Member> {
-        if self.walker.source.contains_line_break(stmt.range()) {
+        let source = self.walker.source;
+        if source.contains_line_break(stmt.range()) {
             return None;
         }
-        if let Some(s) = stmt.as_import_from_stmt() {
-            let member = aligner::line_anchored_member_at_kind(
-                self.walker.source,
-                s.range,
-                TokenKind::Import,
-            )?;
-            return Some(member.with_op_width("import".len()));
-        }
-        let s = stmt.as_import_stmt()?;
-        let [alias] = s.names.as_slice() else {
-            return None;
+        let (range, kind, op_width) = match stmt {
+            Stmt::Import(s) => {
+                let [alias] = s.names.as_slice() else {
+                    return None;
+                };
+                let asname = alias.asname.as_ref()?;
+                (
+                    TextRange::new(alias.name.end(), asname.start()),
+                    TokenKind::As,
+                    "as".len(),
+                )
+            }
+            Stmt::ImportFrom(s) => (s.range, TokenKind::Import, "import".len()),
+            _ => unreachable!("qualify is only called on statements inside an import block"),
         };
-        let asname = alias.asname.as_ref()?;
-        let member = aligner::line_anchored_member_at_kind(
-            self.walker.source,
-            TextRange::new(alias.name.end(), asname.start()),
-            TokenKind::As,
-        )?;
-        Some(member.with_op_width("as".len()))
+        aligner::line_anchored_member_at_kind(source, range, kind)
+            .map(|m| m.with_op_width(op_width))
     }
 }
 

--- a/src/rules/align_imports.rs
+++ b/src/rules/align_imports.rs
@@ -1,13 +1,19 @@
-//! Aligns the `import` keyword across consecutive `from M import N`
-//! statements and the `as` keyword across consecutive `import M as A`
-//! statements at the same block indentation. Group boundaries are
-//! blank lines, comments in the inter-statement gap, form changes
-//! (`from`-imports vs `import`-as), bare `import M` statements without
-//! aliases, and multi-name imports. The two forms align independently,
-//! so a stranded `import M as A` between two `from`-imports breaks the
-//! `from`-import group rather than fusing all three. Multi-line imports
-//! (parenthesized name lists, backslash continuations) skip alignment
-//! because shifting the keyword would break the continuation indent.
+//! Aligns the `import` keyword across the unified block of consecutive
+//! bare and `from`-import statements at the same indent. The block
+//! absorbs a single blank line between adjacent imports, so a bare run
+//! and a `from` run separated only by `blank_lines`'s kind-boundary
+//! gap key into one alignment group. Bare `import M as A` statements
+//! anchor on their `as` keyword and right-align it against the
+//! `import` keyword of `from` statements, so the post-keyword name
+//! starts at one shared column across the entire block. Bare imports
+//! without an alias and multi-name or multi-line imports sit in the
+//! block without participating in alignment.
+//!
+//! Block scope mirrors `alphabetize::import_block_ranges`, so the two
+//! rules see the same notion of "import block" and key on the same
+//! gap semantics.
+
+use std::ops::Range;
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::statement_visitor::{walk_body, StatementVisitor};
@@ -18,6 +24,7 @@ use ruff_text_size::{Ranged, TextRange};
 use crate::config::Config;
 use crate::primitives::aligner;
 use crate::rule::{Rule, RuleId};
+use crate::rules::alphabetize::import_block_ranges;
 use crate::source::Source;
 
 pub(crate) struct AlignImports {
@@ -46,66 +53,57 @@ impl Rule for AlignImports {
     }
 }
 
-#[derive(Eq, PartialEq)]
-enum Form {
-    As,
-    From,
-}
-
 struct Visitor<'a> {
     walker: aligner::AlignWalker<'a>,
 }
 
 impl Visitor<'_> {
-    /// Walks `body` once through `aligner::keyed_line_adjacent_groups`,
-    /// tagging each qualifying statement with its form. The keyed
-    /// grouper closes an active run whenever the form changes at an
-    /// otherwise-adjacent boundary, so a stranded `import M as A`
-    /// between two `from`-imports splits the surrounding run without
-    /// merging its neighbors and without re-walking the body.
+    /// Walks `body` once through `import_block_ranges`, collecting
+    /// alignment members for every qualifying statement in the block
+    /// and emitting one alignment group per block whose members
+    /// total at least two.
     fn process_body(&mut self, body: &[Stmt]) {
-        let groups = aligner::keyed_line_adjacent_groups(self.walker.source, body, |s| {
-            self.qualify_from(s)
-                .map(|m| (Form::From, m))
-                .or_else(|| self.qualify_import_as(s).map(|m| (Form::As, m)))
-        });
-        for members in groups {
+        for Range { start, end } in import_block_ranges(self.walker.source, body) {
+            let members: Vec<aligner::Member> = body[start..end]
+                .iter()
+                .filter_map(|s| self.qualify(s))
+                .collect();
             if members.len() >= 2 {
                 self.walker.emit_group(&members);
             }
         }
     }
 
-    /// Builds an alignment member for a `from M import N` statement,
-    /// anchored at the `import` keyword. Returns `None` for any other
-    /// statement shape and for multi-line imports whose continuation
-    /// indent would misalign if the keyword shifted.
-    fn qualify_from(&self, stmt: &Stmt) -> Option<aligner::Member> {
-        let s = stmt.as_import_from_stmt()?;
-        if self.walker.source.contains_line_break(s.range) {
+    /// Builds an alignment member for an import statement. `from M
+    /// import N` anchors at the `import` keyword with op-width 6.
+    /// `import M as A` (single-name, single-line) anchors at the `as`
+    /// keyword with op-width 2. Bare imports without an alias,
+    /// multi-name imports, and multi-line imports return `None` and
+    /// sit in the block without contributing to or receiving
+    /// alignment.
+    fn qualify(&self, stmt: &Stmt) -> Option<aligner::Member> {
+        if self.walker.source.contains_line_break(stmt.range()) {
             return None;
         }
-        aligner::line_anchored_member_at_kind(self.walker.source, s.range, TokenKind::Import)
-    }
-
-    /// Builds an alignment member for a single-name aliased import
-    /// (`import M as A`), anchored at the `as` keyword. Returns `None`
-    /// for bare imports, multi-name imports, multi-line imports, and any
-    /// other statement shape.
-    fn qualify_import_as(&self, stmt: &Stmt) -> Option<aligner::Member> {
+        if let Some(s) = stmt.as_import_from_stmt() {
+            let member = aligner::line_anchored_member_at_kind(
+                self.walker.source,
+                s.range,
+                TokenKind::Import,
+            )?;
+            return Some(member.with_op_width("import".len()));
+        }
         let s = stmt.as_import_stmt()?;
-        if self.walker.source.contains_line_break(s.range) {
-            return None;
-        }
         let [alias] = s.names.as_slice() else {
             return None;
         };
         let asname = alias.asname.as_ref()?;
-        aligner::line_anchored_member_at_kind(
+        let member = aligner::line_anchored_member_at_kind(
             self.walker.source,
             TextRange::new(alias.name.end(), asname.start()),
             TokenKind::As,
-        )
+        )?;
+        Some(member.with_op_width("as".len()))
     }
 }
 

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -240,10 +240,11 @@ impl<'src> AstVisitor<'src> for RhsAnalyzer<'src> {
 /// Builds a `Vec<Range<usize>>` of body slots that form unified import
 /// blocks. An import block is the run of consecutive `import` and
 /// `from`-import statements at the same indent, separated by at most
-/// one blank line. A non-import statement, a comment-only gap, or a
-/// gap spanning two or more blank lines ends the block. Singleton
-/// runs drop. Shared with `align_imports`, so the two rules see the
-/// same notion of "import block".
+/// one blank line. A non-import statement or a gap spanning two or
+/// more blank lines ends the block. Comments between adjacent imports
+/// flow through without breaking the block. Singleton runs drop.
+/// Shared with `align_imports`, so the two rules see the same notion
+/// of "import block".
 pub(crate) fn import_block_ranges(source: &Source, body: &[Stmt]) -> Vec<Range<usize>> {
     let is_import = |s: &Stmt| s.is_import_stmt() || s.is_import_from_stmt();
     chunk_runs(body, |a, b| {
@@ -620,22 +621,24 @@ fn rewrite_body<'src>(
     }
     let mut import_run_slots: Vec<usize> = Vec::new();
     for block in import_block_ranges(source, body) {
-        for sub in same_kind_sub_runs(body, block.clone(), Stmt::is_import_from_stmt) {
-            permute_in_place(&mut order, body, sub.clone(), |s| {
+        for Range { start, end } in
+            same_kind_sub_runs(body, block.clone(), Stmt::is_import_from_stmt)
+        {
+            permute_in_place(&mut order, body, start..end, |s| {
                 let i = s.as_import_from_stmt()?;
                 Some((i.level, i.module.as_deref().unwrap_or_default()))
             });
-            import_run_slots.extend(sub.start..sub.end - 1);
+            import_run_slots.extend(start..end - 1);
         }
-        for sub in same_kind_sub_runs(body, block, Stmt::is_import_stmt) {
-            permute_in_place(&mut order, body, sub.clone(), |s| {
+        for Range { start, end } in same_kind_sub_runs(body, block, Stmt::is_import_stmt) {
+            permute_in_place(&mut order, body, start..end, |s| {
                 s.as_import_stmt()?
                     .names
                     .iter()
                     .map(|a| a.name.as_str())
                     .min()
             });
-            import_run_slots.extend(sub.start..sub.end - 1);
+            import_run_slots.extend(start..end - 1);
         }
     }
     if scope == BodyScope::Module {

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -3,10 +3,15 @@
 //! class-scope `Stmt::AnnAssign` field declarations and `Stmt::Assign`
 //! runs with simple `Name` targets, function and lambda parameters
 //! with `self` / `cls` and decorators carrying positional arguments
-//! pinned, call kwargs, set literal elements, `from` and bare
-//! `import` runs plus their alias lists, `global` and `nonlocal`
-//! name lists, `del` target lists, and the string literals inside
-//! `__all__` / `__slots__`.
+//! pinned, call kwargs, set literal elements, unified import blocks
+//! plus their alias lists, `global` and `nonlocal` name lists, `del`
+//! target lists, and the string literals inside `__all__` / `__slots__`.
+//!
+//! An import block is the run of consecutive bare and `from` imports
+//! at the same indent, separated by at most one blank line. Within a
+//! block, each kind sorts in its own contiguous sub-run, leaving the
+//! relative order of the bare and `from` sub-runs as they appear in
+//! the source.
 //!
 //! Sorting flows through `primitives::orderer::reorder_text`. A
 //! recursive `Cow<'src, str>` rewriter folds inner sorts into the
@@ -25,6 +30,7 @@ use ruff_python_ast::{
     Identifier, ParameterWithDefault, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtDelete,
     StmtFunctionDef,
 };
+use ruff_python_trivia::lines_before;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
@@ -229,6 +235,20 @@ impl<'src> AstVisitor<'src> for RhsAnalyzer<'src> {
             _ => walk_expr(self, expr),
         }
     }
+}
+
+/// Builds a `Vec<Range<usize>>` of body slots that form unified import
+/// blocks. An import block is the run of consecutive `import` and
+/// `from`-import statements at the same indent, separated by at most
+/// one blank line. A non-import statement, a comment-only gap, or a
+/// gap spanning two or more blank lines ends the block. Singleton
+/// runs drop. Shared with `align_imports`, so the two rules see the
+/// same notion of "import block".
+pub(crate) fn import_block_ranges(source: &Source, body: &[Stmt]) -> Vec<Range<usize>> {
+    let is_import = |s: &Stmt| s.is_import_stmt() || s.is_import_from_stmt();
+    chunk_runs(body, |a, b| {
+        is_import(a) && is_import(b) && lines_before(b.start(), source.text()) <= 2
+    })
 }
 
 /// Returns the `StmtAnnAssign` and its target name when the target
@@ -599,22 +619,24 @@ fn rewrite_body<'src>(
         }
     }
     let mut import_run_slots: Vec<usize> = Vec::new();
-    for Range { start, end } in statement_run_ranges(body, Stmt::is_import_from_stmt) {
-        permute_in_place(&mut order, body, start..end, |s| {
-            let i = s.as_import_from_stmt()?;
-            Some((i.level, i.module.as_deref().unwrap_or_default()))
-        });
-        import_run_slots.extend(start..end - 1);
-    }
-    for Range { start, end } in statement_run_ranges(body, Stmt::is_import_stmt) {
-        permute_in_place(&mut order, body, start..end, |s| {
-            s.as_import_stmt()?
-                .names
-                .iter()
-                .map(|a| a.name.as_str())
-                .min()
-        });
-        import_run_slots.extend(start..end - 1);
+    for block in import_block_ranges(source, body) {
+        for sub in same_kind_sub_runs(body, block.clone(), Stmt::is_import_from_stmt) {
+            permute_in_place(&mut order, body, sub.clone(), |s| {
+                let i = s.as_import_from_stmt()?;
+                Some((i.level, i.module.as_deref().unwrap_or_default()))
+            });
+            import_run_slots.extend(sub.start..sub.end - 1);
+        }
+        for sub in same_kind_sub_runs(body, block, Stmt::is_import_stmt) {
+            permute_in_place(&mut order, body, sub.clone(), |s| {
+                s.as_import_stmt()?
+                    .names
+                    .iter()
+                    .map(|a| a.name.as_str())
+                    .min()
+            });
+            import_run_slots.extend(sub.start..sub.end - 1);
+        }
     }
     if scope == BodyScope::Module {
         for Range { start, end } in module_assign_run_ranges(source, body) {
@@ -768,6 +790,22 @@ fn root_name(expr: &Expr) -> Option<&str> {
     }
 }
 
+/// Returns the absolute body-slot ranges of contiguous same-kind
+/// sub-runs inside `block`, keyed by `predicate`. Singleton sub-runs
+/// drop. Used to partition a unified import block into bare-only and
+/// from-only slots, each sorted independently.
+fn same_kind_sub_runs(
+    body: &[Stmt],
+    block: Range<usize>,
+    mut predicate: impl FnMut(&Stmt) -> bool,
+) -> Vec<Range<usize>> {
+    let Range { start, end } = block;
+    chunk_runs(&body[start..end], |a, b| predicate(a) && predicate(b))
+        .into_iter()
+        .map(|r| (start + r.start)..(start + r.end))
+        .collect()
+}
+
 /// Returns the elements of a list or tuple expression. `None` for
 /// any other shape.
 fn sequence_elts(expr: &Expr) -> Option<&[Expr]> {
@@ -817,17 +855,6 @@ where
         leaf_edits,
     ));
     concat_or_borrow(&parts, source, block)
-}
-
-/// Builds a `Vec<Range<usize>>` of body slots whose statements all
-/// match `predicate`. Consecutive matching slots collapse into one
-/// run, and a non-matching statement between two matching ones breaks
-/// the run. Singleton runs drop.
-fn statement_run_ranges(
-    body: &[Stmt],
-    mut predicate: impl FnMut(&Stmt) -> bool,
-) -> Vec<Range<usize>> {
-    chunk_runs(body, |a, b| predicate(a) && predicate(b))
 }
 
 /// Assigns each binding a Kahn-style topological tier from its
@@ -934,6 +961,36 @@ mod tests {
     }
 
     #[test]
+    fn import_block_ranges_absorbs_single_blank_line() {
+        let s = parse("import a\n\nfrom m import b\n");
+        assert_eq!(import_block_ranges(&s, &s.ast().body), vec![0..2]);
+    }
+
+    #[test]
+    fn import_block_ranges_breaks_at_two_blank_lines() {
+        let s = parse("import a\nimport b\n\n\nfrom m import c\nfrom n import d\n");
+        assert_eq!(import_block_ranges(&s, &s.ast().body), vec![0..2, 2..4]);
+    }
+
+    #[test]
+    fn import_block_ranges_collapses_bare_and_from_into_one_block() {
+        let s = parse("import a\nfrom m import b\n");
+        assert_eq!(import_block_ranges(&s, &s.ast().body), vec![0..2]);
+    }
+
+    #[test]
+    fn import_block_ranges_drops_singleton() {
+        let s = parse("import a\nLOG = 1\n");
+        assert!(import_block_ranges(&s, &s.ast().body).is_empty());
+    }
+
+    #[test]
+    fn import_block_ranges_ends_at_non_import_statement() {
+        let s = parse("import a\nimport b\nLOG = 1\nfrom m import c\n");
+        assert_eq!(import_block_ranges(&s, &s.ast().body), vec![0..2]);
+    }
+
+    #[test]
     fn method_group_orders_dunder_property_private_public() {
         let src = indoc! {"
             class C:
@@ -969,6 +1026,27 @@ mod tests {
             let assign = s.ast().body[0].as_assign_stmt().expect("assign");
             assert_eq!(root_name(&assign.value), expected, "src = {src}");
         }
+    }
+
+    #[test]
+    fn same_kind_sub_runs_drops_singletons_within_block() {
+        let s = parse("import a\nfrom m import b\nimport c\n");
+        let body = &s.ast().body;
+        assert!(same_kind_sub_runs(body, 0..3, Stmt::is_import_from_stmt).is_empty());
+    }
+
+    #[test]
+    fn same_kind_sub_runs_partitions_into_absolute_index_ranges() {
+        let s = parse("import a\nimport b\nfrom m import c\nfrom n import d\n");
+        let body = &s.ast().body;
+        assert_eq!(
+            same_kind_sub_runs(body, 0..4, Stmt::is_import_stmt),
+            vec![0..2],
+        );
+        assert_eq!(
+            same_kind_sub_runs(body, 0..4, Stmt::is_import_from_stmt),
+            vec![2..4],
+        );
     }
 
     #[test]

--- a/tests/fixtures/align_imports/breakers.input.py
+++ b/tests/fixtures/align_imports/breakers.input.py
@@ -1,9 +1,9 @@
 """
-Bare `import M` statements without aliases break the surrounding
-`import`-as group, since they have no `as` keyword to align
-against. Non-import statements between imports also break the
-run. Each broken side aligns only with its own contiguous
-neighbors of the same form.
+Bare `import M` statements without aliases sit in the unified
+block without contributing a member, since they carry no `as`
+keyword to anchor on. Non-import statements between imports still
+end the block, so the from-import below the assignment lands in
+its own singleton block and drops.
 """
 
 import collections as c

--- a/tests/fixtures/align_imports/comment_breaks.input.py
+++ b/tests/fixtures/align_imports/comment_breaks.input.py
@@ -1,9 +1,9 @@
 """
-A comment between two imports (either an own-line block comment
-or a trailing comment on an import line) breaks adjacency, since
-the aligner's `is_line_adjacent` walks the inter-statement token
-gap and aborts on any comment token. Each comment-bracketed
-sub-run aligns only with its own contiguous neighbors.
+Comments between imports (block comments on their own line and
+trailing comments on an import line) leave the block intact. The
+`import_block_ranges` predicate looks only at blank-line count, so
+a comment-only line counts as zero blank lines and the block flows
+through it.
 """
 
 from collections import OrderedDict

--- a/tests/fixtures/align_imports/mixed_groups.input.py
+++ b/tests/fixtures/align_imports/mixed_groups.input.py
@@ -1,9 +1,9 @@
 """
-Multiple alignment groups separated by blank lines. Each group
-aligns at its own target column independent of its neighbors.
-A form change between `from`-imports and `import`-as statements
-also splits the run, so the second cluster of `from`-imports at
-the bottom aligns on its own and not against the top one.
+Three clusters separated by single blank lines collapse into one
+unified block under the absorption rule. The bare-with-alias
+cluster and the surrounding from-import clusters key into the
+same alignment group, so the post-keyword name lands at one
+shared column across every line.
 """
 
 from collections import OrderedDict

--- a/tests/fixtures/align_imports/multi_line_skips.input.py
+++ b/tests/fixtures/align_imports/multi_line_skips.input.py
@@ -1,10 +1,9 @@
 """
-A multi-line `from`-import (parenthesized continuation) skips
-alignment, since shifting the `import` keyword would leave its
-continuation indent visually disconnected. The skipper also acts
-as a group breaker, so the single-line neighbors above align only
-with each other and the single-line neighbors below do the same,
-without crossing the multi-line stretch.
+A multi-line `from`-import (parenthesized continuation) sits in
+the unified block without contributing a member, since shifting
+the `import` keyword would leave its continuation indent visually
+disconnected. Single-line neighbors above and below the multi-line
+stretch share the same alignment group.
 """
 
 from collections import OrderedDict

--- a/tests/fixtures/align_imports/multi_name.input.py
+++ b/tests/fixtures/align_imports/multi_name.input.py
@@ -1,8 +1,9 @@
 """
 Multi-name `import` statements (comma-separated, with or without
-aliases per name) skip alignment entirely. The rule aligns the
-unique `as` keyword in single-aliased imports, whereas multi-name
-shapes have no single anchor and so do not qualify.
+aliases per name) sit in the unified block without contributing a
+member, since they carry no single `as` anchor. The single-aliased
+neighbors flanking them align as their own pair within the same
+unified block.
 """
 
 import collections as c

--- a/tests/fixtures/align_imports/single_import.input.py
+++ b/tests/fixtures/align_imports/single_import.input.py
@@ -1,10 +1,7 @@
 """
-A single import (or any singleton group) is left untouched, since
-alignment requires at least two members per group. The lone
-`from`-import and the lone `import`-as below are each their own
-singleton.
+A genuine singleton block (just one import statement in the file)
+fails the `members.len() >= 2` gate and so emits no edit. The lone
+gap stays untouched.
 """
 
 from collections import OrderedDict
-
-import json as j

--- a/tests/fixtures/align_imports/two_blank_lines_break.input.py
+++ b/tests/fixtures/align_imports/two_blank_lines_break.input.py
@@ -1,0 +1,12 @@
+"""
+Two blank lines between import runs end the block at the first
+such gap, so the imports above and below the gap form separate
+blocks and align independently.
+"""
+
+import collections as col
+import numpy as np
+
+
+from os import path
+from typing import Any

--- a/tests/fixtures/align_imports/unified_block.input.py
+++ b/tests/fixtures/align_imports/unified_block.input.py
@@ -1,0 +1,11 @@
+"""
+Bare aliased imports followed directly by from-imports key into
+one unified block. The `as` keyword in the bares right-aligns
+against the `import` keyword in the froms, so every post-keyword
+name lands at one shared column.
+"""
+
+import os as o
+import sys as s
+from os import path
+from sys import argv

--- a/tests/fixtures/align_imports/unified_from_then_bare.input.py
+++ b/tests/fixtures/align_imports/unified_from_then_bare.input.py
@@ -1,0 +1,12 @@
+"""
+From-imports followed directly by bare aliased imports key into
+one unified block. Direction does not matter to the block
+primitive, so the `import` keyword in the froms and the `as`
+keyword in the bares still right-align at the same shared
+post-keyword column.
+"""
+
+from os import path
+from sys import argv
+import os as o
+import sys as s

--- a/tests/fixtures/alphabetize/mixed_kind_block.input.py
+++ b/tests/fixtures/alphabetize/mixed_kind_block.input.py
@@ -1,0 +1,10 @@
+"""
+A unified import block carrying bare and `from` imports sorts each
+kind within its own contiguous slot. The two slots keep their
+source-order positions until issue #137 lands the canonical order.
+"""
+
+import zlib
+import argparse
+from loguru import logger
+from collections import Counter

--- a/tests/fixtures/alphabetize/mixed_kind_block.input.py
+++ b/tests/fixtures/alphabetize/mixed_kind_block.input.py
@@ -1,7 +1,7 @@
 """
 A unified import block carrying bare and `from` imports sorts each
 kind within its own contiguous slot. The two slots keep their
-source-order positions until issue #137 lands the canonical order.
+source-order positions.
 """
 
 import zlib

--- a/tests/fixtures/composition/imports_mixed_kinds.input.py
+++ b/tests/fixtures/composition/imports_mixed_kinds.input.py
@@ -1,8 +1,10 @@
 """
 Module top with a mixed run of bare imports and from-imports, each
-kind out of alphabetical order. alphabetize sorts each kind in place,
-align_imports aligns the `as` keyword across the aliased lines, and
-blank_lines inserts one blank line at the bare-to-from boundary.
+kind out of alphabetical order. alphabetize sorts each kind in
+its own sub-run, blank_lines inserts one blank line at the
+bare-to-from boundary, and align_imports keys on the unified
+block so the post-keyword names land at one shared column across
+the whole run.
 
 Rules:
 - alphabetize

--- a/tests/snapshots/align_imports/breakers.diagnostics.snap
+++ b/tests/snapshots/align_imports/breakers.diagnostics.snap
@@ -3,5 +3,7 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/breakers.input.py
 ---
-align-imports@321..322
-align-imports@347..348
+align-imports@337..338
+align-imports@363..364
+align-imports@380..381
+align-imports@395..396

--- a/tests/snapshots/align_imports/breakers.input.py.snap
+++ b/tests/snapshots/align_imports/breakers.input.py.snap
@@ -1,22 +1,22 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/align_imports/breakers.input.py
 ---
 """
-Bare `import M` statements without aliases break the surrounding
-`import`-as group, since they have no `as` keyword to align
-against. Non-import statements between imports also break the
-run. Each broken side aligns only with its own contiguous
-neighbors of the same form.
+Bare `import M` statements without aliases sit in the unified
+block without contributing a member, since they carry no `as`
+keyword to anchor on. Non-import statements between imports still
+end the block, so the from-import below the assignment lands in
+its own singleton block and drops.
 """
 
 import collections as c
 import datetime    as dt
 import os
-import re   as r
-import json as j
+import re       as r
+import json     as j
 
-from sys import path
+from sys    import path
 LOG_LEVEL = "INFO"
 from typing import Optional

--- a/tests/snapshots/align_imports/comment_breaks.diagnostics.snap
+++ b/tests/snapshots/align_imports/comment_breaks.diagnostics.snap
@@ -3,5 +3,8 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/comment_breaks.input.py
 ---
-align-imports@365..366
-align-imports@421..422
+align-imports@330..331
+align-imports@386..387
+align-imports@411..412
+align-imports@434..435
+align-imports@495..496

--- a/tests/snapshots/align_imports/comment_breaks.input.py.snap
+++ b/tests/snapshots/align_imports/comment_breaks.input.py.snap
@@ -1,21 +1,21 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/align_imports/comment_breaks.input.py
 ---
 """
-A comment between two imports (either an own-line block comment
-or a trailing comment on an import line) breaks adjacency, since
-the aligner's `is_line_adjacent` walks the inter-statement token
-gap and aborts on any comment token. Each comment-bracketed
-sub-run aligns only with its own contiguous neighbors.
+Comments between imports (block comments on their own line and
+trailing comments on an import line) leave the block intact. The
+`import_block_ranges` predicate looks only at blank-line count, so
+a comment-only line counts as zero blank lines and the block flows
+through it.
 """
 
 from collections import OrderedDict
 from typing      import Optional
 # block comment splits the run
-from sys     import path
-from os.path import join
+from sys         import path
+from os.path     import join
 
-import re as regex  # trailing comment splits the next run
-import json as parser
+import re            as regex  # trailing comment splits the next run
+import json          as parser

--- a/tests/snapshots/align_imports/mixed_groups.diagnostics.snap
+++ b/tests/snapshots/align_imports/mixed_groups.diagnostics.snap
@@ -3,6 +3,8 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/mixed_groups.input.py
 ---
-align-imports@367..368
-align-imports@394..395
-align-imports@435..436
+align-imports@337..338
+align-imports@364..365
+align-imports@385..386
+align-imports@405..406
+align-imports@430..431

--- a/tests/snapshots/align_imports/mixed_groups.input.py.snap
+++ b/tests/snapshots/align_imports/mixed_groups.input.py.snap
@@ -1,21 +1,21 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/align_imports/mixed_groups.input.py
 ---
 """
-Multiple alignment groups separated by blank lines. Each group
-aligns at its own target column independent of its neighbors.
-A form change between `from`-imports and `import`-as statements
-also splits the run, so the second cluster of `from`-imports at
-the bottom aligns on its own and not against the top one.
+Three clusters separated by single blank lines collapse into one
+unified block under the absorption rule. The bare-with-alias
+cluster and the surrounding from-import clusters key into the
+same alignment group, so the post-keyword name lands at one
+shared column across every line.
 """
 
 from collections import OrderedDict
 from typing      import Optional
 
-import re   as regex
-import json as parser
+import re            as regex
+import json          as parser
 
-from sys     import path
-from os.path import join
+from sys         import path
+from os.path     import join

--- a/tests/snapshots/align_imports/multi_line_skips.diagnostics.snap
+++ b/tests/snapshots/align_imports/multi_line_skips.diagnostics.snap
@@ -3,5 +3,5 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/multi_line_skips.input.py
 ---
-align-imports@418..419
-align-imports@511..512
+align-imports@357..358
+align-imports@430..431

--- a/tests/snapshots/align_imports/multi_line_skips.input.py.snap
+++ b/tests/snapshots/align_imports/multi_line_skips.input.py.snap
@@ -1,15 +1,14 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/align_imports/multi_line_skips.input.py
 ---
 """
-A multi-line `from`-import (parenthesized continuation) skips
-alignment, since shifting the `import` keyword would leave its
-continuation indent visually disconnected. The skipper also acts
-as a group breaker, so the single-line neighbors above align only
-with each other and the single-line neighbors below do the same,
-without crossing the multi-line stretch.
+A multi-line `from`-import (parenthesized continuation) sits in
+the unified block without contributing a member, since shifting
+the `import` keyword would leave its continuation indent visually
+disconnected. Single-line neighbors above and below the multi-line
+stretch share the same alignment group.
 """
 
 from collections import OrderedDict
@@ -18,5 +17,5 @@ from sys import (
     path,
     platform,
 )
-from os.path import join
-from re      import sub
+from os.path     import join
+from re import sub

--- a/tests/snapshots/align_imports/multi_name.diagnostics.snap
+++ b/tests/snapshots/align_imports/multi_name.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/multi_name.input.py
 ---
-
+align-imports@375..376

--- a/tests/snapshots/align_imports/multi_name.input.py.snap
+++ b/tests/snapshots/align_imports/multi_name.input.py.snap
@@ -1,16 +1,17 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/align_imports/multi_name.input.py
 ---
 """
 Multi-name `import` statements (comma-separated, with or without
-aliases per name) skip alignment entirely. The rule aligns the
-unique `as` keyword in single-aliased imports, whereas multi-name
-shapes have no single anchor and so do not qualify.
+aliases per name) sit in the unified block without contributing a
+member, since they carry no single `as` anchor. The single-aliased
+neighbors flanking them align as their own pair within the same
+unified block.
 """
 
 import collections as c
 import os, sys
 import re as regex, json as parser
-import datetime as dt
+import datetime    as dt

--- a/tests/snapshots/align_imports/single_import.input.py.snap
+++ b/tests/snapshots/align_imports/single_import.input.py.snap
@@ -1,15 +1,12 @@
 ---
 source: tests/integration.rs
-expression: "&output"
+expression: output
 input_file: tests/fixtures/align_imports/single_import.input.py
 ---
 """
-A single import (or any singleton group) is left untouched, since
-alignment requires at least two members per group. The lone
-`from`-import and the lone `import`-as below are each their own
-singleton.
+A genuine singleton block (just one import statement in the file)
+fails the `members.len() >= 2` gate and so emits no edit. The lone
+gap stays untouched.
 """
 
 from collections import OrderedDict
-
-import json as j

--- a/tests/snapshots/align_imports/two_blank_lines_break.diagnostics.snap
+++ b/tests/snapshots/align_imports/two_blank_lines_break.diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_imports/two_blank_lines_break.input.py
+---
+align-imports@205..206
+align-imports@221..222

--- a/tests/snapshots/align_imports/two_blank_lines_break.input.py.snap
+++ b/tests/snapshots/align_imports/two_blank_lines_break.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_imports/two_blank_lines_break.input.py
+---
+"""
+Two blank lines between import runs end the block at the first
+such gap, so the imports above and below the gap form separate
+blocks and align independently.
+"""
+
+import collections as col
+import numpy       as np
+
+
+from os     import path
+from typing import Any

--- a/tests/snapshots/align_imports/unified_block.diagnostics.snap
+++ b/tests/snapshots/align_imports/unified_block.diagnostics.snap
@@ -1,0 +1,9 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_imports/unified_block.input.py
+---
+align-imports@242..243
+align-imports@258..259
+align-imports@271..272
+align-imports@292..293

--- a/tests/snapshots/align_imports/unified_block.input.py.snap
+++ b/tests/snapshots/align_imports/unified_block.input.py.snap
@@ -1,0 +1,16 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_imports/unified_block.input.py
+---
+"""
+Bare aliased imports followed directly by from-imports key into
+one unified block. The `as` keyword in the bares right-aligns
+against the `import` keyword in the froms, so every post-keyword
+name lands at one shared column.
+"""
+
+import os      as o
+import sys     as s
+from os    import path
+from sys   import argv

--- a/tests/snapshots/align_imports/unified_from_then_bare.diagnostics.snap
+++ b/tests/snapshots/align_imports/unified_from_then_bare.diagnostics.snap
@@ -1,0 +1,9 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_imports/unified_from_then_bare.input.py
+---
+align-imports@278..279
+align-imports@299..300
+align-imports@321..322
+align-imports@337..338

--- a/tests/snapshots/align_imports/unified_from_then_bare.input.py.snap
+++ b/tests/snapshots/align_imports/unified_from_then_bare.input.py.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_imports/unified_from_then_bare.input.py
+---
+"""
+From-imports followed directly by bare aliased imports key into
+one unified block. Direction does not matter to the block
+primitive, so the `import` keyword in the froms and the `as`
+keyword in the bares still right-align at the same shared
+post-keyword column.
+"""
+
+from os    import path
+from sys   import argv
+import os      as o
+import sys     as s

--- a/tests/snapshots/alphabetize/mixed_kind_block.diagnostics.snap
+++ b/tests/snapshots/alphabetize/mixed_kind_block.diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/alphabetize/mixed_kind_block.input.py
 ---
-alphabetize@212..288
+alphabetize@169..245

--- a/tests/snapshots/alphabetize/mixed_kind_block.diagnostics.snap
+++ b/tests/snapshots/alphabetize/mixed_kind_block.diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/mixed_kind_block.input.py
+---
+alphabetize@212..288

--- a/tests/snapshots/alphabetize/mixed_kind_block.input.py.snap
+++ b/tests/snapshots/alphabetize/mixed_kind_block.input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/mixed_kind_block.input.py
+---
+"""
+A unified import block carrying bare and `from` imports sorts each
+kind within its own contiguous slot. The two slots keep their
+source-order positions until issue #137 lands the canonical order.
+"""
+
+import argparse
+import zlib
+from collections import Counter
+from loguru import logger

--- a/tests/snapshots/alphabetize/mixed_kind_block.input.py.snap
+++ b/tests/snapshots/alphabetize/mixed_kind_block.input.py.snap
@@ -6,7 +6,7 @@ input_file: tests/fixtures/alphabetize/mixed_kind_block.input.py
 """
 A unified import block carrying bare and `from` imports sorts each
 kind within its own contiguous slot. The two slots keep their
-source-order positions until issue #137 lands the canonical order.
+source-order positions.
 """
 
 import argparse

--- a/tests/snapshots/composition/imports_mixed_kinds.diagnostics.snap
+++ b/tests/snapshots/composition/imports_mixed_kinds.diagnostics.snap
@@ -3,8 +3,10 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/composition/imports_mixed_kinds.input.py
 ---
-align-imports@369..370
-align-imports@391..392
-align-imports@439..440
-alphabetize@338..473
-blank-lines@398..399
+align-imports@409..410
+align-imports@429..430
+align-imports@451..452
+align-imports@476..477
+align-imports@499..500
+alphabetize@398..533
+blank-lines@458..459

--- a/tests/snapshots/composition/imports_mixed_kinds.input.py.snap
+++ b/tests/snapshots/composition/imports_mixed_kinds.input.py.snap
@@ -5,9 +5,11 @@ input_file: tests/fixtures/composition/imports_mixed_kinds.input.py
 ---
 """
 Module top with a mixed run of bare imports and from-imports, each
-kind out of alphabetical order. alphabetize sorts each kind in place,
-align_imports aligns the `as` keyword across the aliased lines, and
-blank_lines inserts one blank line at the bare-to-from boundary.
+kind out of alphabetical order. alphabetize sorts each kind in
+its own sub-run, blank_lines inserts one blank line at the
+bare-to-from boundary, and align_imports keys on the unified
+block so the post-keyword names land at one shared column across
+the whole run.
 
 Rules:
 - alphabetize
@@ -15,10 +17,10 @@ Rules:
 - blank_lines
 """
 
-import collections as col
-import numpy       as np
-import requests    as req
+import collections     as col
+import numpy           as np
+import requests        as req
 
-from collections import Counter
+from collections   import Counter
 from os     import path
 from typing import Any

--- a/tests/snapshots/thematic/module_top.diagnostics.snap
+++ b/tests/snapshots/thematic/module_top.diagnostics.snap
@@ -3,7 +3,9 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/module_top.input.py
 ---
+align-imports@400..401
 align-imports@477..478
+align-imports@506..507
 alphabetize@430..466
 bare-import-allowlist@414..416
 bare-import-allowlist@424..432

--- a/tests/snapshots/thematic/module_top.input.py.snap
+++ b/tests/snapshots/thematic/module_top.input.py.snap
@@ -13,14 +13,14 @@ definition.
 """
 
 
-import numpy as np
+import numpy         as np
 import os
 import requests
 
 from collections import Counter
 from typing      import Any
 
-import functools as ft
+import functools     as ft
 
 
 def render(text):


### PR DESCRIPTION
### 🪻 Quick Summary

Unifies the import-block primitive across `alphabetize` and `align_imports` so the two rules see the same notion of *"import block"*, in that both consume the run of consecutive bare and `from` imports at the same indent, absorbing a single blank line between adjacent imports and breaking at two or more blank lines or any non-import statement. `alphabetize` sorts each kind in its own contiguous sub-run inside the unified block, leaving the relative order of bare and `from` sub-runs as they appear in the source until #137 lands the canonical bare → from → local-package ordering. `align_imports` keys on the unified block so the `import` keyword in `from M import N` rows right-aligns against the `as` keyword in bare `import M as A` rows, landing every post-keyword name at one shared column across the block.

---

### 🗞️ Key Changes

- Adds `import_block_ranges` and `same_kind_sub_runs` helpers to `src/rules/alphabetize.rs`. The former chunks `body` into runs of consecutive `import` and `from`-import statements separated by at most one blank line via `lines_before(b.start(), source.text()) <= 2`, exported as `pub(crate)` so `align_imports` consumes the same definition. The latter partitions each block into contiguous bare-only and from-only sub-runs, used downstream to sort each kind inside its own slot.

- Rewrites `align_imports::Visitor::process_body` and `qualify` in `src/rules/align_imports.rs` to key alignment on the unified block. A `from M import N` row anchors at the `import` keyword with op-width 6, a single-name `import M as A` row anchors at the `as` keyword with op-width 2, and bare imports without an alias along with multi-name or multi-line imports sit in the block without contributing to or receiving alignment.

- Removes the `Form` enum and its `qualify_from`/`qualify_import_as` helpers from `src/rules/align_imports.rs` since the unified block primitive replaces the form-keyed grouping. With no external caller remaining, `aligner::keyed_line_adjacent_groups` narrows from `pub(crate)` to module-private, and the matching entry drops from `site/primitives/aligner.md`'s Supporting Helpers list.

- Adds 9 fixtures under `tests/fixtures/align_imports/` covering the bare-then-from shared-column case, the from-then-bare flip, the blank-line absorption, the two-blank-line break, the comment flow-through, the multi-line skip, the multi-name skip, the singleton drop, and non-import breakers. Adds `tests/fixtures/alphabetize/mixed_kind_block.input.py` and `tests/fixtures/composition/imports_mixed_kinds.input.py` exercising the alphabetize-on-unified-block path and the full-pipeline composition. Pins `import_block_ranges` and `same_kind_sub_runs` invariants in source with 7 inline tests.

- Refreshes `site/rules/align-imports.md` and `site/rules/alphabetize.md` to describe the unified-block semantic, adds five new `<Fixture>` invocations across the two rule pages, and adds an `'import block'` entry to `site/.vitepress/lib/glossary/glossary-data.ts` with aliases for *"unified import block"* and *"import blocks"*.

---

### 🧵 Related Issues

- Closes #130