### PR TITLE
[174] Unpin the Rust toolchain to restore pre-baked stable

### DIFF
--- a/.github/actions/provision-cargo/action.yml
+++ b/.github/actions/provision-cargo/action.yml
@@ -1,5 +1,5 @@
 name        : Provision the Cargo toolchain with a warm build cache
-description : Restore the rustup toolchain cache keyed off `mise.toml`, install mise tools (which provisions the Rust toolchain pinned in `mise.toml`), and restore the Swatinem Cargo cache for the given `shared-key`. The toolchain cache restores on every cell regardless of `cache`, because the pinned toolchain is not pre-baked on the runner image. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
+description : Install mise tools, which provisions the Rust toolchain pinned in `mise.toml`, and restore the Swatinem Cargo cache for the given `shared-key`. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
 
 inputs:
   cache:
@@ -16,12 +16,6 @@ runs:
   using: composite
 
   steps:
-    - name : Restore Rust toolchain
-      uses : actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-      with:
-        key  : rustup-toolchain-${{ runner.os }}-${{ hashFiles('mise.toml') }}
-        path : ~/.rustup/toolchains
-
     - name : Install mise tools
       uses : jdx/mise-action@1648a7812b9aeae629881980618f079932869151
       with:

--- a/.github/actions/provision-cargo/action.yml
+++ b/.github/actions/provision-cargo/action.yml
@@ -1,5 +1,5 @@
 name        : Provision the Cargo toolchain with a warm build cache
-description : Install mise tools, which provisions the Rust toolchain pinned in `mise.toml`, and restore the Swatinem Cargo cache for the given `shared-key`. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
+description : Restore the rustup toolchain cache keyed off `mise.toml`, install mise tools (which provisions the Rust toolchain pinned in `mise.toml`), and restore the Swatinem Cargo cache for the given `shared-key`. The toolchain cache restores on every cell regardless of `cache`, because the pinned toolchain is not pre-baked on the runner image. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
 
 inputs:
   cache:
@@ -16,6 +16,12 @@ runs:
   using: composite
 
   steps:
+    - name : Restore Rust toolchain
+      uses : actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+      with:
+        key  : rustup-toolchain-${{ runner.os }}-${{ hashFiles('mise.toml') }}
+        path : ~/.rustup/toolchains
+
     - name : Install mise tools
       uses : jdx/mise-action@1648a7812b9aeae629881980618f079932869151
       with:

--- a/mise.toml
+++ b/mise.toml
@@ -7,5 +7,5 @@ task.source_freshness_hash_contents = true
 bun     = "latest"
 maturin = "latest"
 python  = "3.14"
-rust    = { version = "1.95", profile = "default" }
+rust    = "stable"
 uv      = "latest"


### PR DESCRIPTION
### 🪻 Quick Summary

Unpins the Rust toolchain in `mise.toml` from `1.95` back to `stable`, returning CI to the runner image's pre-baked toolchain. Pinning a version the image does not pre-bake forced every job to reinstall it *(roughly 15 to 25 seconds each)*, and the reinstall through `mise-action` left mise's install marker and the rustup toolchain able to desync on a cache hit, dropping `rustfmt` and `clippy`. `stable` is pre-baked and complete, so the toolchain is always present. `Cargo.toml` keeps `rust-version = "1.95"` as the declared floor.

---

### 🗞️ Key Changes

- Reverts `mise.toml`'s `rust` to `"stable"`, so `mise install` resolves to the runner's pre-baked toolchain rather than downloading a pinned `1.95` on every job. `Cargo.toml`'s `rust-version = "1.95"` continues to declare the MSRV, and the coverage task's unconditional `rustup component add llvm-tools-preview` still supplies the one non-default component.

---

### ☕ Implementation Notes

Rationale for unpinning the toolchain rather than caching it *(the mise and `mise-action` desync that made caching impractical, the release container the pin never reached, and the MSRV tradeoff of building on stable)* lives in [this issue comment](https://github.com/Jybbs/prose/issues/174#issuecomment-4566470394).

---

### 🧵 Related Issues

- Closes #174