### PR TITLE
[175] Carry multiple families per glossary entry with a gradient sidebar rail

### DIFF
--- a/site/.vitepress/data/glossary.data.ts
+++ b/site/.vitepress/data/glossary.data.ts
@@ -1,15 +1,13 @@
 import { defineLoader } from 'vitepress'
 
-import { glossary }                                  from '../lib/glossary/entries'
-import { getRenderer }                               from '../lib/markdown/renderer'
-import { GLOSSARY_FAMILY_META, type GlossaryFamily } from '../lib/shared/registries'
+import { glossary }            from '../lib/glossary/entries'
+import { getRenderer }         from '../lib/markdown/renderer'
+import type { GlossaryFamily } from '../lib/shared/registries'
 
 export interface RenderedGlossaryEntry {
   aliases        : readonly string[]
   definitionHtml : string
   families       : readonly GlossaryFamily[]
-  familyBadges   : readonly string[]
-  familyLabels   : readonly string[]
   href          ?: string
   initial        : string
   primaryFamily  : GlossaryFamily
@@ -34,8 +32,6 @@ export default defineLoader({
         aliases        : entry.aliases ?? [],
         definitionHtml : md.renderInline(entry.definition),
         families       : entry.families,
-        familyBadges   : entry.families.map(f => GLOSSARY_FAMILY_META[f].badge),
-        familyLabels   : entry.families.map(f => GLOSSARY_FAMILY_META[f].label),
         href           : entry.href,
         initial        : firstLetter(slug),
         primaryFamily  : entry.families[0],

--- a/site/.vitepress/data/glossary.data.ts
+++ b/site/.vitepress/data/glossary.data.ts
@@ -7,11 +7,12 @@ import { GLOSSARY_FAMILY_META, type GlossaryFamily } from '../lib/shared/registr
 export interface RenderedGlossaryEntry {
   aliases        : readonly string[]
   definitionHtml : string
-  family         : GlossaryFamily
-  familyBadge    : string
-  familyLabel    : string
+  families       : readonly GlossaryFamily[]
+  familyBadges   : readonly string[]
+  familyLabels   : readonly string[]
   href          ?: string
   initial        : string
+  primaryFamily  : GlossaryFamily
   slug           : string
 }
 
@@ -32,11 +33,12 @@ export default defineLoader({
       entries[slug] = {
         aliases        : entry.aliases ?? [],
         definitionHtml : md.renderInline(entry.definition),
-        family         : entry.family,
-        familyBadge    : GLOSSARY_FAMILY_META[entry.family].badge,
-        familyLabel    : GLOSSARY_FAMILY_META[entry.family].label,
+        families       : entry.families,
+        familyBadges   : entry.families.map(f => GLOSSARY_FAMILY_META[f].badge),
+        familyLabels   : entry.families.map(f => GLOSSARY_FAMILY_META[f].label),
         href           : entry.href,
         initial        : firstLetter(slug),
+        primaryFamily  : entry.families[0],
         slug
       }
     }

--- a/site/.vitepress/lib/glossary/entries.ts
+++ b/site/.vitepress/lib/glossary/entries.ts
@@ -3,7 +3,7 @@ import type { GlossaryFamily } from '../shared/registries'
 export interface GlossaryEntry {
   aliases   ?: readonly string[]
   definition : string
-  family     : GlossaryFamily
+  families   : readonly [GlossaryFamily, ...GlossaryFamily[]]
   href      ?: string
 }
 
@@ -13,14 +13,14 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`# fmt: off` and `# fmt: on` are block markers that preserve the exact source '
               + 'layout of code between them by disabling every rewriting rule. Inline '
               + 'comments on the same line are recognized as the marker.',
-    family    : 'formatting',
+    families  : ['formatting', 'engine'],
     href      : '/usage/suppression#block-markers'
   },
 
   '# fmt: skip': {
     definition: '`# fmt: skip` is a line-level marker that exempts the statement it sits on '
               + 'from every rewriting rule, without needing surrounding block markers.',
-    family    : 'formatting',
+    families  : ['formatting', 'engine'],
     href      : '/usage/suppression#line-markers'
   },
 
@@ -29,14 +29,14 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`# prose: ignore` is a per-line directive that suppresses specific lint '
               + 'diagnostics. The bracketed form names the rule slugs to silence, whereas the '
               + 'bare form silences every lint on that line.',
-    family    : 'formatting',
+    families  : ['lint', 'engine'],
     href      : '/usage/suppression#lint-directives'
   },
 
   '--ignore': {
     definition: '`--ignore` is a CLI flag that disables the named rules for a single '
               + 'invocation. The flag is repeatable, and pairs with `--select` to scope a run.',
-    family    : 'formatting',
+    families  : ['cli'],
     href      : '/usage/quick-start#subset-the-active-rules'
   },
 
@@ -44,14 +44,14 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`--no-cache` is a CLI flag that bypasses the user-level cache for a single '
               + 'invocation of `prose check` or `prose format`. The flag overrides the '
               + 'configured `[tool.prose.cache] enabled` value.',
-    family    : 'formatting',
+    families  : ['cli'],
     href      : '/reference/cache#no-cache'
   },
 
   '--select': {
     definition: '`--select` is a CLI flag that restricts a run to the named rules. The flag is '
               + 'repeatable, and pairs with `--ignore` to subtract from the active set.',
-    family    : 'formatting',
+    families  : ['cli'],
     href      : '/usage/quick-start#subset-the-active-rules'
   },
 
@@ -60,7 +60,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'summary to stderr at the end of each `prose check` or `prose format` run. '
               + 'The flag writes `cache: bypassed` when the cache is disabled via '
               + '`--no-cache` or `[tool.prose.cache] enabled = false`.',
-    family    : 'formatting',
+    families  : ['cli'],
     href      : '/reference/cache#hit-miss-telemetry'
   },
 
@@ -69,7 +69,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'An AST is the parsed-program tree produced by `ruff_python_parser`. *Prose* '
               + 'bundles it inside `Source` and reparses it between rules so each rule reads '
               + 'against the post-rewrite tree.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/primitives/source'
   },
 
@@ -78,7 +78,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`BindingAnalysis` is a per-`Source` table indexing every write and read of '
               + 'every name in every lexical scope. The `single-use-variables` rule consumes '
               + 'it.',
-    family    : 'engine',
+    families  : ['engine', 'lint'],
     href      : '/primitives/binding-analysis'
   },
 
@@ -87,7 +87,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'keys. The key digests the source bytes, the canonical TOML serialization of '
               + 'the active configuration, and the *Prose* version, so any meaningful change '
               + 'to any input produces a different key.',
-    family    : 'engine',
+    families  : ['engine', 'cli'],
     href      : '/reference/cache#key-shape'
   },
 
@@ -96,14 +96,14 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'A `Diagnostic` is the structured report a rule emits when it detects a '
               + 'pattern. It carries a severity, wherein `AutoFix` rewrites source under '
               + '`prose format` and `Lint` only surfaces.',
-    family    : 'engine'
+    families  : ['engine', 'lint']
   },
 
   'Pipeline': {
     aliases   : ['pipeline'],
     definition: 'The `Pipeline` orchestrates the rule loop against a `Source`, reparses '
               + 'between rules, and returns the final source plus diagnostics.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/primitives/pipeline'
   },
 
@@ -112,7 +112,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'Ruff is Astral\'s Python linter and formatter. *Prose* composes cleanly with '
               + 'it when both are in the toolchain, leaving token-level normalization to '
               + '`ruff` and layout-level legibility to *Prose*.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/integrations/ruff'
   },
 
@@ -121,14 +121,14 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'A `RuleId` is the canonical kebab-case slug identifying each registered rule '
               + 'across CLI flags, config tables, suppression directives, and diagnostic '
               + 'output.',
-    family    : 'engine',
+    families  : ['engine', 'cli'],
     href      : '/primitives/rule-id'
   },
 
   'Source': {
     definition: '`Source` is the parsed-text wrapper bundling original text, AST, token '
               + 'stream, line index, and suppression map. Every rule reads through this value.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/primitives/source'
   },
 
@@ -139,7 +139,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`SuppressionMap` is the per-`Source` index of `# fmt: off` / `# fmt: skip` / '
               + '`# yapf` / `# prose: ignore[...]` directives, consulted at the edit-emission '
               + 'boundary.',
-    family    : 'engine',
+    families  : ['engine', 'formatting', 'lint'],
     href      : '/primitives/suppression-map'
   },
 
@@ -148,7 +148,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'An alignment group is a run of consecutive members at the same indentation '
               + 'that share an alignment target. Blank lines, comment lines, and non-member '
               + 'statements reset the run, so each contiguous group resolves independently.',
-    family    : 'alignment',
+    families  : ['alignment'],
     href      : '/primitives/aligner'
   },
 
@@ -157,7 +157,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'An annotation is a `name: Type` declaration on a function parameter, return '
               + 'value, or variable. Type checkers and version-gated rules like '
               + '`legacy-union-syntax` and `unused-future-annotations` read it.',
-    family    : 'lint',
+    families  : ['lint', 'alignment'],
     href      : 'https://docs.python.org/3/glossary.html#term-annotation'
   },
 
@@ -166,7 +166,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'payload. `safe` means the rewrite preserves runtime semantics and an editor '
               + 'can apply it without prompting, whereas `unsafe` and `display` exist in the '
               + 'schema for forward compatibility.',
-    family    : 'engine',
+    families  : ['cli', 'engine'],
     href      : '/reference/output-formats#json'
   },
 
@@ -175,7 +175,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'An atomic is a simple, indivisible code element (integer, float, string, '
               + 'single name) that `collection-layout` can safely keep on one line without '
               + 'readability loss.',
-    family    : 'formatting',
+    families  : ['formatting'],
     href      : '/rules/collection-layout'
   },
 
@@ -183,7 +183,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     aliases   : ['auto-fixes', 'auto-fixing', 'Auto-Fix'],
     definition: 'Auto-fix is the rule category whose diagnostics rewrite source under `prose '
               + 'format` and surface as `Severity::AutoFix` under `prose check`.',
-    family    : 'formatting'
+    families  : ['formatting']
   },
 
   'blank line': {
@@ -193,7 +193,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'groups per the `blank-lines` rule, and binds description-shaped own-line '
               + 'comment blocks tight against the following statement while leaving '
               + 'banner-shaped blocks separated by 1 blank line below.',
-    family    : 'formatting',
+    families  : ['formatting'],
     href      : '/rules/blank-lines'
   },
 
@@ -204,14 +204,14 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`(source ++ config ++ prose_version)`, capped by the LRU eviction the '
               + '`[tool.prose.cache] max-size-mib` knob configures, bypassable per invocation '
               + 'with `--no-cache`, and clearable with `prose cache clean`.',
-    family    : 'engine',
+    families  : ['engine', 'cli'],
     href      : '/reference/cache'
   },
 
   'code-line-length': {
     definition: '`code-line-length` is the top-level config key for the line budget consumed '
               + 'by code-shaped rules. It defaults to **88**.',
-    family    : 'formatting',
+    families  : ['cli', 'formatting'],
     href      : '/reference/configuration#top-level-keys'
   },
 
@@ -223,7 +223,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`{x for ...}` literal forms that build a list, dict, or set inline. '
               + '`collection-layout` keeps them on one line when they fit, and their bound '
               + 'targets sit outside `single-use-variables`.',
-    family    : 'formatting',
+    families  : ['formatting', 'lint'],
     href      : 'https://docs.python.org/3/tutorial/datastructures.html#list-comprehensions'
   },
 
@@ -233,7 +233,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'field declarations. `alphabetize` reorders the fields (required before '
               + 'optional), `align-colons` aligns their annotation colons, and `align-equals` '
               + 'aligns their default-value `=` signs.',
-    family    : 'ordering',
+    families  : ['ordering', 'alignment'],
     href      : 'https://docs.python.org/3/library/dataclasses.html'
   },
 
@@ -243,7 +243,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'that wraps it at definition time. `alphabetize` sorts decorated functions '
               + 'together inside framework-decorator groups, and `blank-lines` keeps each '
               + 'decorator attached to its `def`.',
-    family    : 'ordering',
+    families  : ['ordering', 'formatting'],
     href      : 'https://docs.python.org/3/glossary.html#term-decorator'
   },
 
@@ -253,14 +253,14 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'in a module, class, or function. *Prose* rewraps multi-line bodies under '
               + '`docstring-wrap` and gates single-line shapes under '
               + '`no-single-line-docstrings`.',
-    family    : 'docs',
+    families  : ['docs', 'engine'],
     href      : '/primitives/docstring'
   },
 
   'docstring-line-length': {
     definition: '`docstring-line-length` is the top-level config key for the description-prose '
               + 'budget inside docstrings. It defaults to **76**.',
-    family    : 'docs',
+    families  : ['cli', 'docs'],
     href      : '/reference/configuration#top-level-keys'
   },
 
@@ -270,7 +270,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '(`__name__`, `__all__`, `__init__`). `loose-constants` treats them as runtime '
               + 'sentinels, and `alphabetize` treats them as ordering anchors that surface '
               + 'before properties and privates inside a class body.',
-    family    : 'ordering'
+    families  : ['ordering', 'lint']
   },
 
   'enum': {
@@ -278,7 +278,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'An enum is a subclass of `enum.Enum` whose body lists named constants. '
               + '`alphabetize` sorts the members, except when they carry explicit integer or '
               + 'string values that encode ordering.',
-    family    : 'ordering',
+    families  : ['ordering'],
     href      : 'https://docs.python.org/3/library/enum.html'
   },
 
@@ -288,7 +288,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'expressions inside `{}` placeholders. The `docstring` walker skips f-string '
               + 'and other concatenated forms, so only plain triple-quoted string literals '
               + 'count as docstrings.',
-    family    : 'formatting',
+    families  : ['formatting', 'docs'],
     href      : 'https://docs.python.org/3/reference/lexical_analysis.html#f-strings'
   },
 
@@ -297,7 +297,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'A fixture is an input-and-output pair that pins a rule\'s behavior. Each rule '
               + 'page renders fixtures inline as side-by-side before-and-after Python '
               + 'snippets, and the same files drive snapshot testing inside the crate.',
-    family    : 'engine'
+    families  : ['engine']
   },
 
   'forward reference': {
@@ -306,7 +306,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'later in the file. The `from __future__ import annotations` directive made '
               + 'these safe on older Python runtimes, and `unused-future-annotations` removes '
               + 'the directive when no annotation needs the forward reference.',
-    family    : 'lint',
+    families  : ['lint'],
     href      : '/rules/unused-future-annotations'
   },
 
@@ -316,7 +316,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`.gitignore` and `.ignore` files at every level of the walked tree plus the '
               + 'user\'s global gitignore, so vendored dependencies and build artifacts stay '
               + 'out of the run automatically.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/primitives/walker#ignore-semantics'
   },
 
@@ -325,7 +325,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'A second `prose format` run against `prose`-formatted source produces no '
               + 'further edits. Every rule preserves this property, so re-running the '
               + 'formatter never thrashes the source.',
-    family    : 'engine'
+    families  : ['engine']
   },
 
   'kebab-case': {
@@ -333,7 +333,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'every rule slug (`align-equals`, `single-use-variables`). The form is '
               + 'canonical across CLI flags, config tables, suppression directives, and '
               + 'diagnostic output.',
-    family    : 'engine',
+    families  : ['engine', 'cli'],
     href      : '/primitives/rule-id'
   },
 
@@ -349,7 +349,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`#`, or `~`)*, with the canonical above-gap measured from the topmost '
               + 'comment either way. The orderer primitive\'s `block_range` carries the '
               + 'block with its item when reordering siblings.',
-    family    : 'formatting',
+    families  : ['formatting', 'ordering'],
     href      : '/rules/blank-lines'
   },
 
@@ -359,7 +359,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'to a given binding. Python scopes nest by module, class, and function, and '
               + '`binding-analysis` walks them once per `Source` to index every write and '
               + 'read.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/primitives/binding-analysis'
   },
 
@@ -368,7 +368,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'Lint is the rule category whose diagnostics surface as `Severity::Lint` '
               + 'without rewriting source. *Prose* always inspects them, but never modifies '
               + 'the source.',
-    family    : 'lint'
+    families  : ['lint']
   },
 
   'match': {
@@ -377,7 +377,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`case Pattern: body` arm pairs a pattern with a body, and `match-case-align` '
               + 'shares a column for the post-pattern `:` separator across consecutive '
               + 'single-expression arms.',
-    family    : 'alignment',
+    families  : ['alignment'],
     href      : '/rules/match-case-align'
   },
 
@@ -385,7 +385,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`max-shift` is the per-alignment-rule config key capping per-line padding. It '
               + 'defaults to **8**, and groups whose widest member exceeds the cap fall back '
               + 'to `max-shift-policy`.',
-    family    : 'alignment',
+    families  : ['alignment', 'cli'],
     href      : '/reference/configuration#per-rule-knobs'
   },
 
@@ -393,7 +393,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`max-shift-policy` decides how an alignment group overflowing `max-shift` '
               + 'resolves. `split` partitions the group, `drop` excludes the widest members, '
               + 'and `skip` leaves the whole group unaligned.',
-    family    : 'alignment',
+    families  : ['alignment', 'cli'],
     href      : '/reference/configuration#per-rule-knobs'
   },
 
@@ -403,7 +403,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'outside any class or function body. `loose-constants` fires only on '
               + 'module-level assignments, and `blank-lines` reserves two blanks above every '
               + 'module-level `def` and `class`.',
-    family    : 'engine'
+    families  : ['engine', 'formatting', 'lint']
   },
 
   'NDJSON': {
@@ -411,7 +411,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'NDJSON is newline-delimited JSON. `prose check --output-format json` emits '
               + 'one record per line in this shape, so editors and tooling can stream '
               + 'diagnostics without buffering the whole document.',
-    family    : 'engine',
+    families  : ['cli'],
     href      : '/reference/output-formats#json'
   },
 
@@ -421,7 +421,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'body statement of a module, class, or function when that statement is a '
               + 'single string literal expression, and the `docstring` walker matches this '
               + 'shape exactly.',
-    family    : 'docs',
+    families  : ['docs', 'engine'],
     href      : '/primitives/docstring#the-pep-257-definition'
   },
 
@@ -431,7 +431,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'None` replace `Union[X, Y]` and `Optional[T]` at the type level, and '
               + '`legacy-union-syntax` surfaces the legacy `typing` forms on projects whose '
               + '`target-version` allows the pipe form.',
-    family    : 'lint',
+    families  : ['lint'],
     href      : '/rules/legacy-union-syntax'
   },
 
@@ -441,7 +441,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'The runtime no longer evaluates annotations eagerly for typing-only code, so '
               + '`from __future__ import annotations` becomes redundant and '
               + '`unused-future-annotations` removes it on 3.14+.',
-    family    : 'lint',
+    families  : ['lint'],
     href      : '/rules/unused-future-annotations'
   },
 
@@ -451,7 +451,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'fields in the class body. `alphabetize` sorts those fields with required '
               + 'before optional, and `align-colons` aligns the annotation colons across the '
               + 'field block.',
-    family    : 'ordering',
+    families  : ['ordering', 'alignment'],
     href      : 'https://docs.pydantic.dev/'
   },
 
@@ -460,7 +460,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'Reparse names the `Source::reparse` step the `Pipeline` runs between rules. '
               + 'Each rule reads a settled AST built from the post-rewrite text, so no rule '
               + 'observes another rule\'s half-applied state.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/primitives/pipeline'
   },
 
@@ -470,7 +470,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '*Prose*, Ruff runs first to settle line wraps, quote normalization, '
               + 'indentation, and blank-line discipline, after which `prose format` runs '
               + 'against the settled tokens.',
-    family    : 'engine',
+    families  : ['engine'],
     href      : '/integrations/ruff'
   },
 
@@ -478,7 +478,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`ruff_python_parser` is the Astral parser crate *Prose* consumes to produce '
               + 'the AST inside each `Source`. Reparsing between rules guarantees every rule '
               + 'reads against the post-rewrite tree.',
-    family    : 'engine'
+    families  : ['engine']
   },
 
   'Severity': {
@@ -486,14 +486,14 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'Severity is a diagnostic\'s emission kind. `AutoFix` rewrites source under '
               + '`prose format` and surfaces as a pending change under `prose check`, whereas '
               + '`Lint` only reports and never rewrites.',
-    family    : 'engine'
+    families  : ['engine']
   },
 
   'singleton rule': {
     aliases   : ['singleton rules'],
     definition: 'The singleton rule drops alignment padding when a group resolves to a single '
               + 'member, so a one-key dict reads as plain code.',
-    family    : 'alignment',
+    families  : ['alignment'],
     href      : '/rules/singleton-rule'
   },
 
@@ -502,7 +502,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'Stdin mode is the CLI shape that reads a single source from standard input '
               + 'and writes to standard output. It bypasses the filesystem walker entirely, so '
               + 'editors and pipelines drive *Prose* without touching disk.',
-    family    : 'engine'
+    families  : ['cli']
   },
 
   'structured section': {
@@ -513,7 +513,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`Raises:` that reads as a code-shaped table rather than prose. '
               + '`docstring-wrap` budgets these against `code-line-length` by default, so '
               + 'argument lines align with surrounding code.',
-    family    : 'docs',
+    families  : ['docs', 'alignment'],
     href      : '/rules/docstring-wrap'
   },
 
@@ -522,7 +522,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: '`target-version` is the top-level config key naming the Python runtime the '
               + 'project ships to. Version-gated rules consume it, and leaving it unset means '
               + 'no version-dependent rewrites fire.',
-    family    : 'engine',
+    families  : ['cli', 'lint'],
     href      : '/reference/configuration#top-level-keys'
   },
 
@@ -532,7 +532,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'type checkers, used inside `if TYPE_CHECKING:` blocks to guard '
               + 'import-only-for-typing code. `loose-constants` exempts bindings declared '
               + 'inside the block.',
-    family    : 'lint',
+    families  : ['lint'],
     href      : 'https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING'
   },
 
@@ -541,7 +541,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'A `TypedDict` is a `typing.TypedDict` subclass declaring a dict\'s '
               + 'key-to-value-type contract. `alphabetize` sorts its fields the same way it '
               + 'sorts `dataclass` and Pydantic fields.',
-    family    : 'ordering',
+    families  : ['ordering', 'alignment'],
     href      : 'https://docs.python.org/3/library/typing.html#typing.TypedDict'
   },
 
@@ -550,7 +550,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'The walrus operator is Python\'s assignment expression `:=` (PEP 572). '
               + '`align-equals` treats it as a non-member, so a walrus inside a condition or '
               + 'comprehension never enters an alignment group.',
-    family    : 'alignment'
+    families  : ['alignment']
   },
 
   'workflow command': {
@@ -559,7 +559,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'file=...,line=...::message`). The `--output-format github` shape emits one '
               + 'workflow command per diagnostic, which GitHub renders as a check-run '
               + 'annotation on the PR diff.',
-    family    : 'engine',
+    families  : ['cli'],
     href      : '/reference/output-formats#github'
   }
 }

--- a/site/.vitepress/lib/shared/family-rail.ts
+++ b/site/.vitepress/lib/shared/family-rail.ts
@@ -1,0 +1,8 @@
+function familyColor(family: string | null): string {
+  return family ? `var(--prose-c-family-${family})` : 'var(--vp-c-divider)'
+}
+
+export function railPaint(families: readonly (string | null)[]): string {
+  if (families.length <= 1) return familyColor(families[0] ?? null)
+  return `linear-gradient(to bottom, ${families.map(familyColor).join(', ')})`
+}

--- a/site/.vitepress/lib/shared/registries.ts
+++ b/site/.vitepress/lib/shared/registries.ts
@@ -27,10 +27,10 @@ export const FAMILY_META: Record<RuleFamily, FamilyMeta> = {
   ordering   : { badge: '🪉', color: '#7db3e0', label: 'Ordering',   warmth: 'cool' }
 }
 
-export const GLOSSARY_FAMILY_META: Record<GlossaryFamily, FamilyMeta> = {
+export const GLOSSARY_FAMILY_META: Record<GlossaryFamily, Pick<FamilyMeta, 'badge' | 'label'>> = {
   ...FAMILY_META,
-  cli    : { badge: '🪄', color: '#b4aede', label: 'CLI',    warmth: 'cool' },
-  engine : { badge: '🦉', color: '#8a80cb', label: 'Engine', warmth: 'cool' }
+  cli    : { badge: '🪄', label: 'CLI'    },
+  engine : { badge: '🦉', label: 'Engine' }
 }
 
 export const FAMILY_ORDER: readonly RuleFamily[] = [

--- a/site/.vitepress/lib/shared/registries.ts
+++ b/site/.vitepress/lib/shared/registries.ts
@@ -1,6 +1,6 @@
 export type RuleCategory   = 'auto-fix' | 'lint'
 export type RuleFamily     = 'alignment' | 'docs' | 'formatting' | 'lint' | 'ordering'
-export type GlossaryFamily = RuleFamily | 'engine'
+export type GlossaryFamily = RuleFamily | 'cli' | 'engine'
 
 interface CategoryMeta {
   badge : 'A' | 'L'
@@ -29,7 +29,8 @@ export const FAMILY_META: Record<RuleFamily, FamilyMeta> = {
 
 export const GLOSSARY_FAMILY_META: Record<GlossaryFamily, FamilyMeta> = {
   ...FAMILY_META,
-  engine: { badge: '🦉', color: '#8a80cb', label: 'Engine', warmth: 'cool' }
+  cli    : { badge: '🪄', color: '#b4aede', label: 'CLI',    warmth: 'cool' },
+  engine : { badge: '🦉', color: '#8a80cb', label: 'Engine', warmth: 'cool' }
 }
 
 export const FAMILY_ORDER: readonly RuleFamily[] = [

--- a/site/.vitepress/theme/components/glossary/GlossaryFolioIndex.vue
+++ b/site/.vitepress/theme/components/glossary/GlossaryFolioIndex.vue
@@ -2,6 +2,7 @@
 import { useData }  from 'vitepress'
 import { computed } from 'vue'
 
+import { railPaint }        from '../../../lib/shared/family-rail'
 import { useGlossaryFolio } from './use-glossary-folio'
 
 const props = defineProps<{ forceRender?: boolean }>()
@@ -40,10 +41,11 @@ const { filtered, grouped, ordered, query, selected } = useGlossaryFolio()
               type="button"
               class="glossary-folio-row"
               :class="{ 'is-active': entry.slug === selected }"
-              :data-family="entry.family"
+              :data-family="entry.primaryFamily"
+              :style="{ '--rail-paint': railPaint(entry.families) }"
               @click="selected = entry.slug"
             >
-              <span class="glossary-folio-row-dot" aria-hidden="true"></span>
+              <span class="glossary-folio-row-rail" aria-hidden="true"></span>
               <code class="glossary-folio-row-slug">{{ entry.slug }}</code>
             </button>
           </li>

--- a/site/.vitepress/theme/components/glossary/GlossaryFolioPane.vue
+++ b/site/.vitepress/theme/components/glossary/GlossaryFolioPane.vue
@@ -6,13 +6,18 @@ const { active, activeIndex, filtered, step } = useGlossaryFolio()
 </script>
 
 <template>
-  <div class="glossary-folio-stage" :data-family="active?.family">
+  <div class="glossary-folio-stage" :data-family="active?.primaryFamily">
     <article v-if="active" class="glossary-folio-pane">
       <header class="glossary-folio-head">
         <p class="glossary-folio-folio">
-          <span class="glossary-folio-chip">
-            <span class="glossary-folio-badge" aria-hidden="true">{{ active.familyBadge }}</span>
-            <span class="glossary-folio-folio-family">{{ active.familyLabel }}</span>
+          <span
+            v-for="(family, i) in active.families"
+            :key="family"
+            class="glossary-folio-chip"
+            :data-family="family"
+          >
+            <span class="glossary-folio-badge" aria-hidden="true">{{ active.familyBadges[i] }}</span>
+            <span class="glossary-folio-folio-family">{{ active.familyLabels[i] }}</span>
           </span>
           <span class="glossary-folio-folio-sep" aria-hidden="true">·</span>
           <span>{{ activeIndex < 0 ? '–' : formatFolio(activeIndex + 1) }} / {{ formatFolio(filtered.length) }}</span>

--- a/site/.vitepress/theme/components/glossary/GlossaryFolioPane.vue
+++ b/site/.vitepress/theme/components/glossary/GlossaryFolioPane.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { useGlossaryFolio } from './use-glossary-folio'
-import { formatFolio }      from '../../../lib/shared/numerals'
+import { useGlossaryFolio }   from './use-glossary-folio'
+import { formatFolio }        from '../../../lib/shared/numerals'
+import { GLOSSARY_FAMILY_META } from '../../../lib/shared/registries'
 
 const { active, activeIndex, filtered, step } = useGlossaryFolio()
 </script>
@@ -11,13 +12,13 @@ const { active, activeIndex, filtered, step } = useGlossaryFolio()
       <header class="glossary-folio-head">
         <p class="glossary-folio-folio">
           <span
-            v-for="(family, i) in active.families"
+            v-for="family in active.families"
             :key="family"
             class="glossary-folio-chip"
             :data-family="family"
           >
-            <span class="glossary-folio-badge" aria-hidden="true">{{ active.familyBadges[i] }}</span>
-            <span class="glossary-folio-folio-family">{{ active.familyLabels[i] }}</span>
+            <span class="glossary-folio-badge" aria-hidden="true">{{ GLOSSARY_FAMILY_META[family].badge }}</span>
+            <span class="glossary-folio-folio-family">{{ GLOSSARY_FAMILY_META[family].label }}</span>
           </span>
           <span class="glossary-folio-folio-sep" aria-hidden="true">·</span>
           <span>{{ activeIndex < 0 ? '–' : formatFolio(activeIndex + 1) }} / {{ formatFolio(filtered.length) }}</span>

--- a/site/.vitepress/theme/components/glossary/glossary-folio-index.css
+++ b/site/.vitepress/theme/components/glossary/glossary-folio-index.css
@@ -158,10 +158,11 @@
 
 .glossary-folio-row {
   display               : grid;
-  grid-template-columns : 8px 1fr;
+  grid-template-columns : 3px 1fr;
   align-items           : center;
-  gap                   : 8px;
+  gap                   : 10px;
   width                 : 100%;
+  min-height            : 24px;
   padding               : 3px 8px;
   border                : none;
   border-radius         : var(--prose-radius-sm);
@@ -171,11 +172,10 @@
   transition            : background var(--prose-transition);
 }
 
-.glossary-folio-row-dot {
-  width         : 6px;
-  height        : 6px;
-  border-radius : 50%;
-  background    : color-mix(in srgb, var(--family-color) 70%, transparent);
+.glossary-folio-row-rail {
+  align-self    : stretch;
+  border-radius : 2px;
+  background    : var(--rail-paint, var(--family-color));
 }
 
 .glossary-folio-row-slug {
@@ -203,8 +203,4 @@
 .glossary-folio-row.is-active .glossary-folio-row-slug {
   color       : var(--vp-c-text-1);
   font-weight : 600;
-}
-
-.glossary-folio-row.is-active .glossary-folio-row-dot {
-  background : var(--family-color);
 }

--- a/site/.vitepress/theme/components/rules/CompositionCards.vue
+++ b/site/.vitepress/theme/components/rules/CompositionCards.vue
@@ -8,6 +8,7 @@ import { data as composition }  from '../../../data/composition.data'
 import { data as fixturesData } from '../../../data/fixtures.data'
 import { data as rules }        from '../../../data/rules.data'
 import type { RenderedRule }    from '../../../data/rules.data'
+import { railPaint }            from '../../../lib/shared/family-rail'
 import type { FixtureTab }      from '../../../lib/shared/fixture-tab'
 import { formatFolio }          from '../../../lib/shared/numerals'
 
@@ -30,15 +31,6 @@ interface CardRow {
   title          : string
 }
 
-function familyColor(family: string | null): string {
-  return family ? `var(--prose-c-family-${family})` : 'var(--vp-c-divider)'
-}
-
-function railPaintFor(families: readonly (string | null)[]): string {
-  if (families.length <= 1) return familyColor(families[0] ?? null)
-  return `linear-gradient(to bottom, ${families.map(familyColor).join(', ')})`
-}
-
 const cards = computed<readonly CardRow[]>(() =>
   composition.cases.map((entry, i) => {
     const families = entry.rules.map(slug => rules.bySlug[slug]?.family ?? null)
@@ -50,7 +42,7 @@ const cards = computed<readonly CardRow[]>(() =>
       inputHtml      : fixture?.inputHtml ?? '',
       num            : formatFolio(i + 1, 3),
       outputHtml     : fixture?.outputHtml ?? '',
-      railPaint      : railPaintFor(families),
+      railPaint      : railPaint(families),
       segments       : entry.rules.map((slug, idx) => ({
         family : families[idx],
         index  : idx + 1,

--- a/site/.vitepress/theme/styles/accents.css
+++ b/site/.vitepress/theme/styles/accents.css
@@ -1,6 +1,7 @@
 [data-family="alignment"],  .fam-alignment  { --family-color: var(--prose-c-family-alignment);  }
+[data-family="cli"],        .fam-cli        { --family-color: var(--prose-c-family-cli);        }
 [data-family="docs"],       .fam-docs       { --family-color: var(--prose-c-family-docs);       }
-[data-family="engine"],     .fam-engine     { --family-color: var(--prose-c-ube);               }
+[data-family="engine"],     .fam-engine     { --family-color: var(--prose-c-family-engine);     }
 [data-family="formatting"], .fam-formatting { --family-color: var(--prose-c-family-formatting); }
 [data-family="lint"],       .fam-lint       { --family-color: var(--prose-c-family-lint);       }
 [data-family="ordering"],   .fam-ordering   { --family-color: var(--prose-c-family-ordering);   }

--- a/site/.vitepress/theme/styles/tokens.css
+++ b/site/.vitepress/theme/styles/tokens.css
@@ -22,7 +22,9 @@
   --prose-c-warning              : var(--prose-c-eureka);
 
   --prose-c-family-alignment     : var(--prose-c-eureka);
+  --prose-c-family-cli           : var(--prose-c-ube-pale);
   --prose-c-family-docs          : var(--prose-c-celadon);
+  --prose-c-family-engine        : var(--prose-c-ube);
   --prose-c-family-formatting    : var(--prose-c-heath);
   --prose-c-family-lint          : var(--prose-c-apricot);
   --prose-c-family-ordering      : var(--prose-c-chambray);


### PR DESCRIPTION
### 🪻 Quick Summary

Gives each glossary entry a hand-authored list of families rather than the single value it carried before, so a term like `binding` reads as both `engine` *(it names `BindingAnalysis`)* and `lint` *(the `single-use-variables` rule consumes it)* instead of being forced into an either/or. The sidebar repurposes the composition cards' gradient left-rail to color each entry's facets top-to-bottom, and the folio pane shows one badge chip per facet. A new `cli` facet covers the command-line surface *(flags, config keys, output shapes)*, badged 🪄 and tinted a lighter shade of `engine`'s ube.

The issue scoped this as a build-time back-index deriving each entry's families from where its slug appears across the docs pages. A probe of that approach showed it degraded the glossary, so the families stay hand-authored per entry, with the reasoning captured under Implementation Notes.

---

### 🗞️ Key Changes

- Replaces `GlossaryEntry.family` with a non-empty `families` tuple in `site/.vitepress/lib/glossary/entries.ts`, hand-authoring the facets each term genuinely spans, so 29 of the entries now carry two or more.

- Adds a `cli` facet to `GlossaryFamily` for the command-line surface, registered in `site/.vitepress/lib/shared/registries.ts` with the 🪄 badge and routed through a new `--prose-c-family-cli` token in `site/.vitepress/theme/styles/tokens.css`, alongside a `--prose-c-family-engine` token so every facet resolves through one `--prose-c-family-<facet>` naming scheme in `site/.vitepress/theme/styles/accents.css`.

- Reshapes `RenderedGlossaryEntry` in `site/.vitepress/data/glossary.data.ts` to carry `families` plus a derived `primaryFamily` *(the first authored facet, driving the single-valued `[data-family]` color hook)*, dropping the singular `family` / `familyBadge` / `familyLabel`.

- Extracts a shared `railPaint` helper into `site/.vitepress/lib/shared/family-rail.ts` and refactors `site/.vitepress/theme/components/rules/CompositionCards.vue` onto it, so one engine renders both the composition cards and the glossary sidebar.

- Replaces each glossary sidebar row's single-color dot with a gradient left-rail in `site/.vitepress/theme/components/glossary/GlossaryFolioIndex.vue` and its stylesheet, solid for one facet and a top-to-bottom gradient across facet colors for several.

- Renders one badge chip per facet in `site/.vitepress/theme/components/glossary/GlossaryFolioPane.vue`, reading each badge and label straight from `GLOSSARY_FAMILY_META` the way the rule components do, and narrows that registry to `Pick<FamilyMeta, 'badge' | 'label'>` so the loader precomputes no parallel arrays and the unread `color` / `warmth` fields fall away.

---

### ☕ Implementation Notes

#### Hand-Authored Families over Reference Derivation

Deriving each entry's families from where its slug appears across the docs pages was the spec's plan, scoping a build-time loader that scans every page, maps the containing page to a family, and fails the build on any term with zero references. A probe of that derivation against the real corpus showed it degraded the glossary, in that the most-referenced page often mismatched the term's true home *(driving the wrong primary color)*, cross-cutting terms accreted long noisy badge runs, and several legitimate terms appear in no rule or primitive page at all and so would have failed the build. Hand-authoring per entry replaced it, where each entry declares exactly the facets the term spans. `GlossaryEntry.family` became `families: readonly [GlossaryFamily, ...GlossaryFamily[]]`, a non-empty tuple so `primaryFamily` always resolves to a real facet.

#### Wider Facet Coverage and Shared Colors

Flags like `--select`, config keys like `target-version`, and output shapes like NDJSON had no facet of their own under the old rule-families-plus-`engine` vocabulary, so terms describing the command-line surface were misfiled onto whatever rule family sat closest. A `cli` facet fills that gap, badged with the project's 🪄 cli mark, and fourteen terms now carry it, alone or beside a rule family *(`max-shift` carries `[alignment, cli]`)*. Every facet resolves through one `--prose-c-family-<facet>` token, with `cli` tinted `--prose-c-ube-pale`, a lighter shade of `engine`'s ube, so a CLI term reads as a lighter sibling of the engine hue.

A single color underrepresents an entry once it spans several facets, so the sidebar borrows the composition cards' gradient rail. `familyColor` and `railPaint` moved into a shared module both surfaces consume, and a glossary row's rail renders solid for one facet and a top-to-bottom gradient across facet colors for several. The panel's `[data-family]` hook still resolves to the single `primaryFamily`, so the surrounding chrome stays single-valued while the rail and the badge-chip run carry the full facet list.

---

### 🧵 Related Issues

- Closes #175
