### PR TITLE
[146] Lift duplicated engine primitives into shared modules

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -189,6 +189,18 @@ impl Config {
             )
             .unwrap_or_else(|| Ok(Self::default()))
     }
+
+    pub(crate) fn code_width(&self) -> usize {
+        self.code_line_length
+            .expect("Config::default synthesizes Some(88)")
+            .get()
+    }
+
+    pub(crate) fn docstring_width(&self) -> usize {
+        self.docstring_line_length
+            .expect("Config::default synthesizes Some(76)")
+            .get()
+    }
 }
 
 /// Failure to load a `[tool.prose]` configuration from a `pyproject.toml`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,6 +201,10 @@ impl Config {
             .expect("Config::default synthesizes Some(76)")
             .get()
     }
+
+    pub(crate) fn first_party(&self) -> Vec<String> {
+        self.imports.first_party.clone()
+    }
 }
 
 /// Failure to load a `[tool.prose]` configuration from a `pyproject.toml`.

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod docstring;
 pub(crate) mod edit;
 pub(crate) mod imports;
 pub(crate) mod orderer;
+pub(crate) mod range;
+pub(crate) mod scope;
 
 /// PEP 8 indent step in spaces, the depth one nested level adds.
 pub(crate) const INDENT_STEP: usize = 4;

--- a/src/primitives/range.rs
+++ b/src/primitives/range.rs
@@ -1,0 +1,12 @@
+//! Parenthesis-aware source ranges for expression nodes.
+
+use ruff_python_ast::token::{parenthesized_range, Tokens};
+use ruff_python_ast::{AnyNodeRef, ExprRef};
+use ruff_text_size::{Ranged, TextRange};
+
+/// Returns `expr`'s range widened to the explicit parentheses recovered
+/// against `parent`, falling back to the bare expression range when none
+/// enclose it.
+pub(crate) fn paren_aware_range(expr: ExprRef, parent: AnyNodeRef, tokens: &Tokens) -> TextRange {
+    parenthesized_range(expr, parent, tokens).unwrap_or_else(|| expr.range())
+}

--- a/src/primitives/scope.rs
+++ b/src/primitives/scope.rs
@@ -1,0 +1,8 @@
+//! The body scope a statement sits in: module, class, or function.
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum BodyScope {
+    Class,
+    Function,
+    Module,
+}

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -36,6 +36,7 @@ use crate::primitives::imports::{import_group, ImportGroup};
 use crate::primitives::orderer::{
     assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
 };
+use crate::primitives::scope::BodyScope;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
@@ -83,13 +84,6 @@ impl Rule for Alphabetize {
     fn id(&self) -> RuleId {
         Self::SLUG
     }
-}
-
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum BodyScope {
-    Class,
-    Function,
-    Module,
 }
 
 struct LeafCollector<'a> {

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -49,7 +49,7 @@ impl Alphabetize {
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
             docstring_entries: config.rules.alphabetize.docstring_entries,
-            first_party: config.imports.first_party.clone(),
+            first_party: config.first_party(),
         }
     }
 }

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -15,6 +15,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::config::Config;
 use crate::primitives::imports::import_group;
+use crate::primitives::scope::BodyScope;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
@@ -46,13 +47,6 @@ impl Rule for BlankLines {
     fn id(&self) -> RuleId {
         Self::SLUG
     }
-}
-
-#[derive(Clone, Copy)]
-enum BodyScope {
-    Class,
-    Function,
-    Module,
 }
 
 struct Walker<'a> {

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -26,7 +26,7 @@ pub(crate) struct BlankLines {
 impl BlankLines {
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
-            first_party: config.imports.first_party.clone(),
+            first_party: config.first_party(),
         }
     }
 }

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -12,14 +12,13 @@ use std::ops::Range;
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_dotted_name;
-use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::visitor::{walk_expr, Visitor};
 use ruff_python_ast::{AnyNodeRef, DictItem, Expr, ExprDict};
 use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
-use crate::primitives::{edit::narrowed_replacement, INDENT_STEP};
+use crate::primitives::{edit::narrowed_replacement, range::paren_aware_range, INDENT_STEP};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
@@ -31,10 +30,7 @@ pub(crate) struct CollectionLayout {
 impl CollectionLayout {
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
-            code_line_length: config
-                .code_line_length
-                .expect("Config::default synthesizes Some(88)")
-                .get(),
+            code_line_length: config.code_width(),
             max_atomics_per_line: config
                 .rules
                 .collection_layout
@@ -311,14 +307,13 @@ impl<'a> Layouter<'a> {
     /// recovered against `parent` so precedence-bearing parens like
     /// `(-a) ** 2` survive a borrow.
     fn slice_with_parens(&self, expr: &Expr, parent: AnyNodeRef) -> &'a str {
-        let range = parenthesized_range(expr.into(), parent, self.source.tokens())
-            .unwrap_or_else(|| expr.range());
+        let range = paren_aware_range(expr.into(), parent, self.source.tokens());
         self.source.slice(range)
     }
 
     /// Appends the inline serialization of `expr` to `buf`. Recursive
     /// helper backing `inline_form`. `parent` is the immediate
-    /// enclosing AST node, used for `parenthesized_range` recovery on
+    /// enclosing AST node, used for `paren_aware_range` recovery on
     /// non-collection leaves.
     fn write_inline(&self, buf: &mut String, expr: &Expr, parent: AnyNodeRef) {
         let here = AnyNodeRef::from(expr);

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -31,15 +31,9 @@ pub(crate) struct DocstringWrap {
 
 impl DocstringWrap {
     pub(crate) fn from_config(config: &Config) -> Self {
-        let description_width = config
-            .docstring_line_length
-            .expect("Config::default synthesizes Some(76)")
-            .get();
+        let description_width = config.docstring_width();
         let section_width = match config.docstring_structured_policy {
-            DocstringStructuredPolicy::CodeLineLength => config
-                .code_line_length
-                .expect("Config::default synthesizes Some(88)")
-                .get(),
+            DocstringStructuredPolicy::CodeLineLength => config.code_width(),
             DocstringStructuredPolicy::DocstringLineLength => description_width,
         };
         Self {

--- a/src/rules/legacy_union_syntax.rs
+++ b/src/rules/legacy_union_syntax.rs
@@ -5,14 +5,13 @@
 use std::collections::HashMap;
 
 use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
-use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
 use ruff_python_ast::{AnyNodeRef, Expr, ExprSubscript, Identifier, PythonVersion, Stmt};
-use ruff_text_size::Ranged;
 
 use crate::config::Config;
 use crate::diagnostics::Diagnostic;
 use crate::primitives::binding::top_level_module;
+use crate::primitives::range::paren_aware_range;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 
@@ -91,8 +90,7 @@ impl<'a> Walker<'a> {
             .parents
             .last()
             .expect("invariant: subscript visited inside a stmt or expr");
-        let range = parenthesized_range(subscript.into(), parent, self.source.tokens())
-            .unwrap_or(subscript.range());
+        let range = paren_aware_range(subscript.into(), parent, self.source.tokens());
         self.diagnostics
             .push(Diagnostic::lint(self.rule, range, message));
     }

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -28,10 +28,7 @@ pub(crate) struct MatchCaseAlign {
 impl MatchCaseAlign {
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
-            code_line_length: config
-                .code_line_length
-                .expect("Config::default synthesizes Some(88)")
-                .get(),
+            code_line_length: config.code_width(),
             settings: aligner::Settings::from(&config.rules.match_case_align)
                 .with_singleton_subgroup_strip(),
         }

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -24,10 +24,7 @@ pub(crate) struct SignatureLayout {
 impl SignatureLayout {
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
-            code_line_length: config
-                .code_line_length
-                .expect("Config::default synthesizes Some(88)")
-                .get(),
+            code_line_length: config.code_width(),
             max_inline_params: config
                 .rules
                 .signature_layout


### PR DESCRIPTION
### 🪻 Quick Summary

Consolidates the structural patterns that multiple rules had each reimplemented locally, so every pattern now resolves to one definition rather than drifting across its copies. A `BodyScope` enum that `alphabetize` and `blank_lines` each defined locally moves to `primitives::scope`, the `parenthesized_range(...).unwrap_or(...)` span idiom that `collection_layout` and `legacy_union_syntax` both inlined becomes a `paren_aware_range` helper in `primitives::range`, and the repeated config-extraction idioms collapse into the `Config` accessors `code_width`, `docstring_width`, and `first_party`. Existing fixtures stay byte-identical throughout, because the consolidation moves code without changing what any rule emits.

---

### 🗞️ Key Changes

- Adds a shared `BodyScope` enum in `src/primitives/scope.rs`, carrying the `Eq`/`PartialEq` superset `alphabetize` needs and dropping the duplicate local definitions from `alphabetize` and `blank_lines`

- Adds a `paren_aware_range` helper in `src/primitives/range.rs` that wraps `ruff_python_ast`'s `parenthesized_range` with a bare-range fallback, shared by `collection_layout`'s `slice_with_parens` and `legacy_union_syntax`'s diagnostic span

- Adds `Config::code_width` and `Config::docstring_width` accessors that replace the repeated `.expect(...).get()` line-length-budget chains across the four rule constructors that read them

- Adds a `Config::first_party` accessor in the same shape, replacing the duplicated `imports.first_party` clone that `alphabetize` and `blank_lines` each carried

---

### 🧵 Related Issues

- Closes #146