### PR TITLE
[185] Add an interactive run-summary explorer to the CLI reference page

### DIFF
--- a/site/.vitepress/theme/components/reference/RunSummary.vue
+++ b/site/.vitepress/theme/components/reference/RunSummary.vue
@@ -1,28 +1,25 @@
 <script setup lang="ts">
-interface SummaryLine {
-  anchor : string
-  text   : string
-  tint   : 'apricot' | 'celadon'
-}
+import type { RenderedLine } from './run-summary'
 
-const lines: readonly SummaryLine[] = [
-  { anchor: '🪻', text: 'All clean.',                    tint: 'celadon' },
-  { anchor: '☕', text: '5 diagnostics in 2 files.',     tint: 'apricot' },
-  { anchor: '🗞️', text: 'Reformatted 4 files.',          tint: 'apricot' },
-  { anchor: '🗞️', text: '3 files would be reformatted.', tint: 'apricot' }
-]
+defineProps<{ line: RenderedLine }>()
 </script>
 
 <template>
   <div class="run-summary">
-    <div class="run-summary-bar" aria-hidden="true">
-      <span v-for="n in 3" :key="n" class="run-summary-dot" />
-      <span class="run-summary-title">prose</span>
+    <div class="run-summary-bar">
+      <span v-for="n in 3" :key="n" class="run-summary-dot" aria-hidden="true" />
+      <span class="run-summary-title" aria-hidden="true">prose</span>
+      <slot name="bar" />
     </div>
     <div class="run-summary-body">
-      <div v-for="line in lines" :key="line.text" class="run-summary-line">
-        <span class="run-summary-anchor" aria-hidden="true">{{ line.anchor }}</span>
-        <span class="run-summary-msg" :data-tint="line.tint">{{ line.text }}</span>
+      <div class="run-summary-line">
+        <span
+          v-if="line.anchor"
+          class="run-summary-anchor"
+          :data-ube="line.anchorUbe || undefined"
+          aria-hidden="true"
+        >{{ line.anchor }}</span>
+        <span class="run-summary-msg" :data-tint="line.countTint || undefined">{{ line.text }}</span>
       </div>
     </div>
   </div>

--- a/site/.vitepress/theme/components/reference/RunSummaryExplorer.vue
+++ b/site/.vitepress/theme/components/reference/RunSummaryExplorer.vue
@@ -27,15 +27,13 @@ const outcomeOpts = computed<SelectOption[]>(() => OUTCOMES.map(o => ({
 })))
 
 const quietOpts = computed<SelectOption[]>(() => QUIET_OPTIONS.map(q => ({
-  id      : q.id,
-  mono    : q.mono,
-  preview : resolveSelection(outcomeId.value, q.id, streamId.value)
+  ...q,
+  preview: resolveSelection(outcomeId.value, q.id, streamId.value)
 })))
 
 const streamOpts = computed<SelectOption[]>(() => STREAM_OPTIONS.map(s => ({
-  id      : s.id,
-  mono    : s.mono,
-  preview : resolveSelection(outcomeId.value, quietId.value, s.id)
+  ...s,
+  preview: resolveSelection(outcomeId.value, quietId.value, s.id)
 })))
 </script>
 

--- a/site/.vitepress/theme/components/reference/RunSummaryExplorer.vue
+++ b/site/.vitepress/theme/components/reference/RunSummaryExplorer.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+import RunSummary       from './RunSummary.vue'
+import RunSummarySelect from './RunSummarySelect.vue'
+
+import {
+  glossFor,
+  OUTCOMES,
+  QUIET_OPTIONS,
+  resolveSelection,
+  type SelectOption,
+  STREAM_OPTIONS
+} from './run-summary'
+
+const outcomeId = ref('clean')
+const quietId   = ref('full')
+const streamId  = ref('tty')
+
+const line  = computed(() => resolveSelection(outcomeId.value, quietId.value, streamId.value))
+const gloss = computed(() => glossFor(outcomeId.value, quietId.value, streamId.value))
+
+const outcomeOpts = computed<SelectOption[]>(() => OUTCOMES.map(o => ({
+  id      : o.key,
+  mono    : o.args,
+  preview : resolveSelection(o.key, quietId.value, streamId.value)
+})))
+
+const quietOpts = computed<SelectOption[]>(() => QUIET_OPTIONS.map(q => ({
+  id      : q.id,
+  mono    : q.mono,
+  preview : resolveSelection(outcomeId.value, q.id, streamId.value)
+})))
+
+const streamOpts = computed<SelectOption[]>(() => STREAM_OPTIONS.map(s => ({
+  id      : s.id,
+  mono    : s.mono,
+  preview : resolveSelection(outcomeId.value, quietId.value, s.id)
+})))
+</script>
+
+<template>
+  <div class="run-summary-explorer">
+    <span class="kicker run-summary-explorer-kicker">Build A Run</span>
+    <div class="run-summary-cmd">
+      <span class="run-summary-cmd-prompt" aria-hidden="true">$ prose</span>
+      <RunSummarySelect v-model="outcomeId" :options="outcomeOpts" aria-label="Run command" />
+      <span class="run-summary-cmd-path" aria-hidden="true">.</span>
+      <RunSummarySelect v-model="quietId" :options="quietOpts" aria-label="Verbosity" />
+      <RunSummarySelect v-model="streamId" :options="streamOpts" aria-label="Output stream" />
+    </div>
+    <RunSummary :line="line">
+      <template #bar>
+        <span class="run-summary-caption">{{ gloss }}</span>
+      </template>
+    </RunSummary>
+  </div>
+</template>

--- a/site/.vitepress/theme/components/reference/RunSummarySelect.vue
+++ b/site/.vitepress/theme/components/reference/RunSummarySelect.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { SelectOption } from './run-summary'
+
+const props = defineProps<{
+  ariaLabel  : string
+  modelValue : string
+  options    : readonly SelectOption[]
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const selected = computed(() =>
+  props.options.find(o => o.id === props.modelValue) ?? props.options[0]
+)
+
+function choose(option: SelectOption): void {
+  emit('update:modelValue', option.id)
+}
+</script>
+
+<template>
+  <VDropdown theme="run-summary-select" class="run-summary-select">
+    <button
+      type="button"
+      class="run-summary-select-trigger"
+      :aria-label="ariaLabel"
+      aria-haspopup="listbox"
+    >
+      <span class="run-summary-select-value">{{ selected.mono }}</span>
+      <span class="run-summary-select-caret" aria-hidden="true">▾</span>
+    </button>
+    <template #popper>
+      <ul class="run-summary-opts" role="listbox" :aria-label="ariaLabel">
+        <li
+          v-for="o in options"
+          :key="o.id"
+          role="option"
+          :aria-selected="o.id === modelValue"
+        >
+          <button
+            v-close-popper
+            type="button"
+            class="run-summary-opt"
+            :class="{ 'is-active': o.id === modelValue }"
+            @click="choose(o)"
+          >
+            <span class="run-summary-opt-mono">{{ o.mono }}</span>
+            <span v-if="o.preview" class="run-summary-opt-eg">
+              <span
+                v-if="o.preview.anchor"
+                class="run-summary-opt-eg-anchor"
+                aria-hidden="true"
+              >{{ o.preview.anchor }}</span>
+              <span class="run-summary-opt-eg-text" :data-tint="o.preview.countTint || undefined">
+                {{ o.preview.text }}
+              </span>
+            </span>
+          </button>
+        </li>
+      </ul>
+    </template>
+  </VDropdown>
+</template>

--- a/site/.vitepress/theme/components/reference/RunSummarySelect.vue
+++ b/site/.vitepress/theme/components/reference/RunSummarySelect.vue
@@ -4,20 +4,15 @@ import { computed } from 'vue'
 import type { SelectOption } from './run-summary'
 
 const props = defineProps<{
-  ariaLabel  : string
-  modelValue : string
-  options    : readonly SelectOption[]
+  ariaLabel : string
+  options   : readonly SelectOption[]
 }>()
 
-const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+const model = defineModel<string>({ required: true })
 
 const selected = computed(() =>
-  props.options.find(o => o.id === props.modelValue) ?? props.options[0]
+  props.options.find(o => o.id === model.value) ?? props.options[0]
 )
-
-function choose(option: SelectOption): void {
-  emit('update:modelValue', option.id)
-}
 </script>
 
 <template>
@@ -28,7 +23,7 @@ function choose(option: SelectOption): void {
       :aria-label="ariaLabel"
       aria-haspopup="listbox"
     >
-      <span class="run-summary-select-value">{{ selected.mono }}</span>
+      <span>{{ selected.mono }}</span>
       <span class="run-summary-select-caret" aria-hidden="true">▾</span>
     </button>
     <template #popper>
@@ -37,14 +32,14 @@ function choose(option: SelectOption): void {
           v-for="o in options"
           :key="o.id"
           role="option"
-          :aria-selected="o.id === modelValue"
+          :aria-selected="o.id === model"
         >
           <button
             v-close-popper
             type="button"
             class="run-summary-opt"
-            :class="{ 'is-active': o.id === modelValue }"
-            @click="choose(o)"
+            :class="{ 'is-active': o.id === model }"
+            @click="model = o.id"
           >
             <span class="run-summary-opt-mono">{{ o.mono }}</span>
             <span v-if="o.preview" class="run-summary-opt-eg">

--- a/site/.vitepress/theme/components/reference/run-summary.css
+++ b/site/.vitepress/theme/components/reference/run-summary.css
@@ -1,11 +1,10 @@
 .run-summary {
-  margin        : 20px 0;
   border        : 1px solid var(--vp-c-divider);
   border-radius : var(--prose-radius);
   background    : var(--vp-code-block-bg);
   overflow      : hidden;
   font-family   : var(--vp-font-family-mono);
-  font-size     : var(--prose-text-xs);
+  font-size     : var(--prose-text-md);
 }
 
 .run-summary-bar {
@@ -28,16 +27,29 @@
 .run-summary-title {
   margin-inline-start : 6px;
   color               : var(--vp-c-text-3);
-  font-size           : var(--prose-label-size);
+  font-size           : var(--prose-text-xs);
   letter-spacing      : 0.05em;
 }
 
+.run-summary-caption {
+  min-width            : 0;
+  margin-inline-start  : 10px;
+  padding-inline-start : 10px;
+  border-inline-start  : 1px solid var(--vp-c-divider);
+  color                : var(--vp-c-text-3);
+  font-family          : var(--vp-font-family-base);
+  font-size            : var(--prose-text-md);
+  font-style           : italic;
+  line-height          : 1.4;
+  white-space          : nowrap;
+  overflow             : hidden;
+  text-overflow        : ellipsis;
+}
+
 .run-summary-body {
-  display        : flex;
-  flex-direction : column;
-  gap            : 7px;
-  padding        : 18px 22px;
-  line-height    : 1.5;
+  padding     : 18px 22px;
+  line-height : 1.5;
+  min-height  : 1.5em;
 }
 
 .run-summary-line {
@@ -51,5 +63,143 @@
   text-align : center;
 }
 
-.run-summary-msg[data-tint="apricot"] { color: var(--prose-c-apricot); }
-.run-summary-msg[data-tint="celadon"] { color: var(--prose-c-celadon); }
+.run-summary-anchor[data-ube]          { color: var(--prose-c-ube);     }
+.run-summary-msg[data-tint="apricot"]  { color: var(--prose-c-apricot); }
+.run-summary-msg[data-tint="celadon"]  { color: var(--prose-c-celadon); }
+
+.run-summary-explorer {
+  display        : flex;
+  flex-direction : column;
+  gap            : 12px;
+  margin         : 20px 0;
+}
+
+.run-summary-explorer-kicker {
+  color : var(--vp-c-text-3);
+}
+
+.run-summary-cmd {
+  display       : flex;
+  flex-wrap     : wrap;
+  align-items   : baseline;
+  gap           : 0.5em;
+  padding       : 13px 17px;
+  border        : 1px solid var(--vp-c-divider);
+  border-radius : var(--prose-radius);
+  background    : var(--vp-code-block-bg);
+  font-family   : var(--vp-font-family-mono);
+  font-size     : var(--prose-text-md);
+  line-height   : 1.6;
+}
+
+.run-summary-cmd-prompt {
+  color       : var(--vp-c-text-2);
+  white-space : nowrap;
+  user-select : none;
+}
+
+.run-summary-cmd-path {
+  color       : var(--vp-c-text-3);
+  user-select : none;
+}
+
+.run-summary-select {
+  display : inline-block;
+}
+
+.run-summary-select-trigger {
+  display     : inline-flex;
+  align-items : baseline;
+  gap         : 0.2em;
+  padding     : 0 2px;
+  border      : 0;
+  background  : transparent;
+  color       : var(--prose-c-ube-deep);
+  font-family : var(--vp-font-family-mono);
+  font-size   : inherit;
+  cursor      : pointer;
+  box-shadow  : inset 0 -1px 0 color-mix(in srgb, var(--prose-c-ube) 38%, transparent);
+  transition  : color var(--prose-transition), box-shadow var(--prose-transition);
+}
+
+.run-summary-select-trigger:hover {
+  color      : var(--prose-c-ube);
+  box-shadow : inset 0 -1px 0 var(--prose-c-ube);
+}
+
+.run-summary-select-trigger:focus-visible {
+  outline        : 1px solid var(--prose-c-ube);
+  outline-offset : 2px;
+}
+
+.run-summary-select-caret {
+  font-size : 0.7em;
+  color     : var(--prose-c-ube-mid);
+}
+
+.v-popper--theme-run-summary-select .v-popper__inner {
+  padding       : 4px;
+  border        : 1px solid var(--vp-c-divider);
+  border-radius : var(--prose-radius);
+  background    : var(--vp-c-bg);
+  box-shadow    : var(--prose-shadow-tooltip);
+}
+
+.v-popper--theme-run-summary-select .v-popper__arrow-container {
+  display : none;
+}
+
+.run-summary-opts {
+  min-width  : max-content;
+  margin     : 0;
+  padding    : 0;
+  list-style : none;
+}
+
+.run-summary-opt {
+  display        : flex;
+  flex-direction : column;
+  gap            : 3px;
+  width          : 100%;
+  padding        : 7px 11px;
+  border         : 0;
+  border-radius  : var(--prose-radius-sm);
+  background     : transparent;
+  text-align     : start;
+  cursor         : pointer;
+  transition     : background var(--prose-transition);
+}
+
+.run-summary-opt:hover {
+  background : var(--vp-c-bg-soft);
+}
+
+.run-summary-opt.is-active {
+  background : color-mix(in srgb, var(--prose-c-ube) 12%, transparent);
+}
+
+.run-summary-opt-mono {
+  font-family : var(--vp-font-family-mono);
+  font-size   : var(--prose-text-sm);
+  color       : var(--vp-c-text-1);
+}
+
+.run-summary-opt.is-active .run-summary-opt-mono {
+  color : var(--prose-c-ube-deep);
+}
+
+.run-summary-opt-eg {
+  display     : inline-flex;
+  align-items : baseline;
+  gap         : 0.5em;
+  font-family : var(--vp-font-family-mono);
+  font-size   : var(--prose-text-sm);
+}
+
+.run-summary-opt-eg-anchor {
+  flex : 0 0 auto;
+}
+
+.run-summary-opt-eg-text                  { color: var(--vp-c-text-2);     }
+.run-summary-opt-eg-text[data-tint="apricot"] { color: var(--prose-c-apricot); }
+.run-summary-opt-eg-text[data-tint="celadon"] { color: var(--prose-c-celadon); }

--- a/site/.vitepress/theme/components/reference/run-summary.ts
+++ b/site/.vitepress/theme/components/reference/run-summary.ts
@@ -1,9 +1,16 @@
 type CountTint  = 'apricot' | 'celadon'
 type OutcomeKey = 'check' | 'clean' | 'diff' | 'format'
 
+interface AxisOption {
+  gloss : string
+  id    : string
+  mono  : string
+}
+
 interface Outcome {
   anchor : string
   args   : string
+  gloss  : string
   key    : OutcomeKey
   text   : string
   tint   : CountTint
@@ -23,40 +30,22 @@ export interface SelectOption {
 }
 
 export const OUTCOMES: readonly Outcome[] = [
-  { anchor: '🪻', args: 'check',         key: 'clean',  text: 'All clean.',                    tint: 'celadon' },
-  { anchor: '🔖', args: 'check',         key: 'check',  text: '5 diagnostics in 2 files.',     tint: 'apricot' },
-  { anchor: '🗞️', args: 'format',        key: 'format', text: 'Reformatted 4 files.',          tint: 'apricot' },
-  { anchor: '🗞️', args: 'format --diff', key: 'diff',   text: '3 files would be reformatted.', tint: 'apricot' }
+  { anchor: '🪻', args: 'check',         gloss: 'A clean run',       key: 'clean',  text: 'All clean.',                    tint: 'celadon' },
+  { anchor: '🔖', args: 'check',         gloss: 'Violations found',  key: 'check',  text: '5 diagnostics in 2 files.',     tint: 'apricot' },
+  { anchor: '🗞️', args: 'format',        gloss: 'Files reformatted', key: 'format', text: 'Reformatted 4 files.',          tint: 'apricot' },
+  { anchor: '🗞️', args: 'format --diff', gloss: 'A diff preview',    key: 'diff',   text: '3 files would be reformatted.', tint: 'apricot' }
 ]
 
-export const QUIET_OPTIONS: readonly SelectOption[] = [
-  { id: 'full',  mono: 'default' },
-  { id: 'quiet', mono: '--quiet' }
+export const QUIET_OPTIONS: readonly AxisOption[] = [
+  { gloss: 'full output', id: 'full',  mono: 'default' },
+  { gloss: 'quiet',       id: 'quiet', mono: '--quiet' }
 ]
 
-export const STREAM_OPTIONS: readonly SelectOption[] = [
-  { id: 'tty',     mono: 'interactive tty' },
-  { id: 'pipe',    mono: '| cat'           },
-  { id: 'nocolor', mono: '--color never'   }
+export const STREAM_OPTIONS: readonly AxisOption[] = [
+  { gloss: 'on a tty', id: 'tty',     mono: 'interactive tty' },
+  { gloss: 'piped',    id: 'pipe',    mono: '| cat'           },
+  { gloss: 'no color', id: 'nocolor', mono: '--color never'   }
 ]
-
-const OUTCOME_GLOSS: Record<string, string> = {
-  check  : 'Violations found',
-  clean  : 'A clean run',
-  diff   : 'A diff preview',
-  format : 'Files reformatted'
-}
-
-const STREAM_GLOSS: Record<string, string> = {
-  nocolor : 'no color',
-  pipe    : 'piped',
-  tty     : 'on a tty'
-}
-
-const VERBOSITY_GLOSS: Record<string, string> = {
-  full  : 'full output',
-  quiet : 'quiet'
-}
 
 function resolveLine(outcome: Outcome, quiet: boolean, colorBearing: boolean): RenderedLine {
   if (quiet) return { anchor: null, anchorUbe: false, countTint: null, text: outcome.text }
@@ -74,8 +63,8 @@ export function resolveSelection(outcomeId: string, quietId: string, streamId: s
 }
 
 export function glossFor(outcomeId: string, quietId: string, streamId: string): string {
-  const outcome = OUTCOME_GLOSS[outcomeId]   ?? OUTCOME_GLOSS.clean
-  const stream  = STREAM_GLOSS[streamId]     ?? STREAM_GLOSS.tty
-  const quiet   = VERBOSITY_GLOSS[quietId]   ?? VERBOSITY_GLOSS.full
-  return `${outcome}, ${quiet}, ${stream}.`
+  const outcome = OUTCOMES.find(o => o.key === outcomeId)     ?? OUTCOMES[0]
+  const quiet   = QUIET_OPTIONS.find(q => q.id === quietId)   ?? QUIET_OPTIONS[0]
+  const stream  = STREAM_OPTIONS.find(s => s.id === streamId) ?? STREAM_OPTIONS[0]
+  return `${outcome.gloss}, ${quiet.gloss}, ${stream.gloss}.`
 }

--- a/site/.vitepress/theme/components/reference/run-summary.ts
+++ b/site/.vitepress/theme/components/reference/run-summary.ts
@@ -1,0 +1,81 @@
+type CountTint  = 'apricot' | 'celadon'
+type OutcomeKey = 'check' | 'clean' | 'diff' | 'format'
+
+interface Outcome {
+  anchor : string
+  args   : string
+  key    : OutcomeKey
+  text   : string
+  tint   : CountTint
+}
+
+export interface RenderedLine {
+  anchor    : string | null
+  anchorUbe : boolean
+  countTint : CountTint | null
+  text      : string
+}
+
+export interface SelectOption {
+  id       : string
+  mono     : string
+  preview ?: RenderedLine
+}
+
+export const OUTCOMES: readonly Outcome[] = [
+  { anchor: '🪻', args: 'check',         key: 'clean',  text: 'All clean.',                    tint: 'celadon' },
+  { anchor: '🔖', args: 'check',         key: 'check',  text: '5 diagnostics in 2 files.',     tint: 'apricot' },
+  { anchor: '🗞️', args: 'format',        key: 'format', text: 'Reformatted 4 files.',          tint: 'apricot' },
+  { anchor: '🗞️', args: 'format --diff', key: 'diff',   text: '3 files would be reformatted.', tint: 'apricot' }
+]
+
+export const QUIET_OPTIONS: readonly SelectOption[] = [
+  { id: 'full',  mono: 'default' },
+  { id: 'quiet', mono: '--quiet' }
+]
+
+export const STREAM_OPTIONS: readonly SelectOption[] = [
+  { id: 'tty',     mono: 'interactive tty' },
+  { id: 'pipe',    mono: '| cat'           },
+  { id: 'nocolor', mono: '--color never'   }
+]
+
+const OUTCOME_GLOSS: Record<string, string> = {
+  check  : 'Violations found',
+  clean  : 'A clean run',
+  diff   : 'A diff preview',
+  format : 'Files reformatted'
+}
+
+const STREAM_GLOSS: Record<string, string> = {
+  nocolor : 'no color',
+  pipe    : 'piped',
+  tty     : 'on a tty'
+}
+
+const VERBOSITY_GLOSS: Record<string, string> = {
+  full  : 'full output',
+  quiet : 'quiet'
+}
+
+function resolveLine(outcome: Outcome, quiet: boolean, colorBearing: boolean): RenderedLine {
+  if (quiet) return { anchor: null, anchorUbe: false, countTint: null, text: outcome.text }
+  return {
+    anchor    : outcome.anchor,
+    anchorUbe : colorBearing,
+    countTint : colorBearing ? outcome.tint : null,
+    text      : outcome.text
+  }
+}
+
+export function resolveSelection(outcomeId: string, quietId: string, streamId: string): RenderedLine {
+  const outcome = OUTCOMES.find(o => o.key === outcomeId) ?? OUTCOMES[0]
+  return resolveLine(outcome, quietId === 'quiet', streamId === 'tty')
+}
+
+export function glossFor(outcomeId: string, quietId: string, streamId: string): string {
+  const outcome = OUTCOME_GLOSS[outcomeId]   ?? OUTCOME_GLOSS.clean
+  const stream  = STREAM_GLOSS[streamId]     ?? STREAM_GLOSS.tty
+  const quiet   = VERBOSITY_GLOSS[quietId]   ?? VERBOSITY_GLOSS.full
+  return `${outcome}, ${quiet}, ${stream}.`
+}

--- a/site/.vitepress/theme/index.ts
+++ b/site/.vitepress/theme/index.ts
@@ -109,6 +109,15 @@ export default {
           placement       : 'top',
           triggers        : ['focus', 'hover']
         },
+        'run-summary-select': {
+          $extend        : 'dropdown',
+          delay          : { hide: 200, show: 60 },
+          handleResize   : true,
+          instantMove    : true,
+          placement      : 'bottom-start',
+          popperTriggers : ['hover'],
+          triggers       : ['hover', 'focus']
+        },
         'rule-card': {
           $extend         : 'tooltip',
           'arrow-padding' : 14,

--- a/site/reference/cli.md
+++ b/site/reference/cli.md
@@ -116,11 +116,11 @@ The [**Shell Completions**](/integrations/shell-completions) integration page co
 
 ## Run Summary
 
-Every interactive `check` or `format` run closes with a one-line summary on **stderr**, leaving stdout free for diagnostics, rewritten source, unified diffs, and the machine formats. Each outcome resolves to a single anchored line:
+Every interactive `check` or `format` run closes with a one-line summary on **stderr**, leaving stdout free for diagnostics, rewritten source, unified diffs, and the machine formats. Build an invocation to watch the line each outcome resolves to, across the run outcome, `--quiet`, and the stream's color state:
 
-<RunSummary />
+<RunSummaryExplorer />
 
-A clean run anchors on 🪻, `check` violations on ☕, and `format`'s applied or pending rewrites on 🗞️.
+A clean run anchors on 🪻, `check` violations on 🔖, and `format`'s applied or pending rewrites on 🗞️.
 
 ANSI color draws on the project palette, with **Ube** on the anchor, **Celadon** on a clean count, and **Apricot** on a violation or change count. Each span renders as 24-bit color when the terminal advertises truecolor *(via `COLORTERM`)* and falls back to ANSI 8-color otherwise.
 

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -43,7 +43,7 @@ impl Summary {
     fn anchor(&self) -> &'static str {
         match self {
             Self::Clean => "🪻",
-            Self::Diagnostics { .. } => "☕",
+            Self::Diagnostics { .. } => "🔖",
             Self::Reformatted { .. } | Self::WouldReformat { .. } => "🗞️",
         }
     }
@@ -162,8 +162,8 @@ mod tests {
 
     #[rstest]
     #[case(Summary::Clean, "🪻 All clean.\n")]
-    #[case(Summary::Diagnostics { files: 2, total: 5 }, "☕ 5 diagnostics in 2 files.\n")]
-    #[case(Summary::Diagnostics { files: 1, total: 1 }, "☕ 1 diagnostic in 1 file.\n")]
+    #[case(Summary::Diagnostics { files: 2, total: 5 }, "🔖 5 diagnostics in 2 files.\n")]
+    #[case(Summary::Diagnostics { files: 1, total: 1 }, "🔖 1 diagnostic in 1 file.\n")]
     #[case(Summary::Reformatted { files: 4 }, "🗞️ Reformatted 4 files.\n")]
     #[case(Summary::Reformatted { files: 1 }, "🗞️ Reformatted 1 file.\n")]
     #[case(Summary::WouldReformat { files: 3 }, "🗞️ 3 files would be reformatted.\n")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -171,7 +171,7 @@ fn check_json_summary_counts_a_changed_file() {
 }
 
 #[test]
-fn check_violation_summary_anchors_with_coffee() {
+fn check_violation_summary_anchors_with_bookmark() {
     let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.arg("check").arg(&path).assert().code(1);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -177,7 +177,7 @@ fn check_violation_summary_anchors_with_coffee() {
     let assert = cmd.arg("check").arg(&path).assert().code(1);
     let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
     assert!(
-        err.contains("☕ 1 diagnostic in 1 file."),
+        err.contains("🔖 1 diagnostic in 1 file."),
         "stderr was {err:?}"
     );
 }
@@ -443,7 +443,7 @@ fn quiet_check_reduces_summary_to_a_bare_count() {
         .code(1);
     let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
     assert_eq!(err.trim(), "1 diagnostic in 1 file.");
-    assert!(!err.contains('☕'), "quiet kept the anchor: {err:?}");
+    assert!(!err.contains('🔖'), "quiet kept the anchor: {err:?}");
     assert!(!err.contains('\u{1b}'), "quiet kept color: {err:?}");
 }
 


### PR DESCRIPTION
### 🪻 Quick Summary

Adds an interactive run-summary explorer to the Run Summary section of the CLI reference page, turning #134's static specimen into a control a reader drives rather than a fixed snapshot they read. Three dropdowns build a `prose` invocation across the run outcome, `--quiet`, and the stream's color state, and the summary line below re-renders live to the shape that invocation resolves to, carrying a plain-language gloss in the terminal's title bar. Every span draws from the shared `--prose-c-*` design tokens, so the page renders the same Ube anchor and Celadon-or-Apricot count the binary emits, and the section server-renders a clean default that reads without client JS. The explorer wraps the `<RunSummary>` frame from #134, now lifted from a four-line specimen into a reusable shell.

---

### 🗞️ Key Changes

- Adds `RunSummaryExplorer`, building a `prose` invocation from three floating-vue dropdowns and rendering one live summary line beneath it, with a plain-language gloss of the current selection in the terminal's title bar.

- Refactors `RunSummary` from a static four-line specimen into a reusable frame *(a `line` prop plus a `#bar` slot)* that the explorer wraps, keeping the terminal chrome and the line-rendering logic in one place.

- Adds `RunSummarySelect`, a `defineModel`-bound dropdown built on a registered `run-summary-select` floating-vue theme, whose listbox options each preview the line that choice would produce for the current cross-selection.

- Co-locates the run corpus, its types, and the line-and-gloss resolution helpers in `run-summary.ts`, resolving every summary line and its caption from one per-entry source of truth.

- Swaps the static `<RunSummary />` in the Run Summary section of `site/reference/cli.md` for `<RunSummaryExplorer />`, which server-renders a clean default outcome so the section reads on first paint and degrades to that static view without client JS.

- Swaps the `check` diagnostics anchor from `☕` to `🔖` in `src/cli/output.rs` and its unit and `cli` integration tests, aligning the binary's emitted anchor with the explorer's corpus.

---

### 🧵 Related Issues

- Closes #185
