### PR TITLE
[183] Adopt let-chains, edition 2024, and Rust 1.95 stdlib primitives

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -9,12 +9,10 @@ inputs:
   args:
     default     : ''
     description : Additional flags passed to maturin
-    required    : false
 
   manylinux:
     default     : ''
     description : Manylinux compatibility tag (`auto` on Linux, empty elsewhere)
-    required    : false
 
   name:
     default     : sdist
@@ -23,7 +21,6 @@ inputs:
   target:
     default     : ''
     description : Cargo target triple (Linux/macOS/Windows wheel rows). Empty for sdist.
-    required    : false
 
 runs:
   using: composite
@@ -40,7 +37,6 @@ runs:
         args      : ${{ inputs.args }}
         command   : ${{ inputs.command }}
         manylinux : ${{ inputs.manylinux }}
-        sccache   : false
         target    : ${{ inputs.target }}
 
     - name : Upload artifact

--- a/.github/actions/provision-bun/action.yml
+++ b/.github/actions/provision-bun/action.yml
@@ -5,7 +5,6 @@ inputs:
   cache-dependency-glob:
     default     : bun.lock
     description : Files whose hash keys the bun deps cache. Empty disables the cache.
-    required    : false
 
 runs:
   using: composite

--- a/.github/actions/provision-cargo/action.yml
+++ b/.github/actions/provision-cargo/action.yml
@@ -5,12 +5,10 @@ inputs:
   cache:
     default     : true
     description : When `false` the Swatinem Cargo cache step is skipped and the mise toolchain cache is not written back. Use for cells (*`Format`, `Unused`*) that populate neither `target/` nor `~/.cargo/registry/`.
-    required    : false
 
   shared-key:
     default     : prose
     description : Swatinem cache scope. Distinct keys allow per-profile cache isolation.
-    required    : false
 
 runs:
   using: composite
@@ -19,7 +17,6 @@ runs:
     - name : Install mise tools
       uses : jdx/mise-action@1648a7812b9aeae629881980618f079932869151
       with:
-        cache      : true
         cache_save : ${{ inputs.cache != 'false' }}
 
     - name  : Refresh stable toolchain

--- a/.github/actions/provision-cargo/action.yml
+++ b/.github/actions/provision-cargo/action.yml
@@ -1,5 +1,5 @@
 name        : Provision the Cargo toolchain with a warm build cache
-description : Install mise tools, which provisions the Rust toolchain pinned in `mise.toml`, and restore the Swatinem Cargo cache for the given `shared-key`. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
+description : Install mise tools (provisioning the Rust toolchain `mise.toml` selects), refresh the `stable` channel so a runner image lagging a fresh release still builds against the current floor, and restore the Swatinem Cargo cache for the given `shared-key`. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
 
 inputs:
   cache:
@@ -21,6 +21,10 @@ runs:
       with:
         cache      : true
         cache_save : ${{ inputs.cache != 'false' }}
+
+    - name  : Refresh stable toolchain
+      run   : rustup update --no-self-update stable
+      shell : bash
 
     - name : Restore Cargo cache
       if   : ${{ inputs.cache != 'false' }}

--- a/.github/actions/provision-uv/action.yml
+++ b/.github/actions/provision-uv/action.yml
@@ -5,7 +5,6 @@ inputs:
   cache-dependency-glob:
     default     : .github/scripts/*.py
     description : Files whose hash keys the uv cache. Empty disables the cache.
-    required    : false
 
 runs:
   using: composite

--- a/.github/workflows/warm.yml
+++ b/.github/workflows/warm.yml
@@ -106,8 +106,5 @@ jobs:
         uses : ./.github/actions/provision-cargo
         with : { shared-key: "prose-wheel-${{ matrix.name }}" }
 
-      - name : Refresh stable toolchain
-        run  : rustup update --no-self-update stable
-
       - name : Build release artifacts for ${{ matrix.target }}
         run  : mise exec -- cargo build --release --locked --target ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 categories   = ["development-tools"]
 description  = "A Python typesetter for the reader."
-edition      = "2021"
+edition      = "2024"
 keywords     = ["formatter", "linter", "python", "style"]
 license      = "MIT"
 name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
-rust-version = "1.95"
+rust-version = "1.96"
 version      = "0.2.3"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <img src="site/public/title-with-tagline.svg" alt="Prose, a Python typesetter for the reader." width="800">
 
-[![Rust](site/public/badges/rust.svg)![1.95+](https://img.shields.io/badge/1.95+-8a80cb?style=for-the-badge)](https://www.rust-lang.org/)
+[![Rust](site/public/badges/rust.svg)![1.96+](https://img.shields.io/badge/1.96+-8a80cb?style=for-the-badge)](https://www.rust-lang.org/)
 [![Python](site/public/badges/python.svg)![3.10+](https://img.shields.io/badge/3.10+-8a80cb?style=for-the-badge)](https://www.python.org/)
 [![Coverage](site/public/badges/coverage.svg)![percent](https://img.shields.io/codecov/c/github/Jybbs/prose?style=for-the-badge&label=&color=8a80cb)](https://codecov.io/gh/Jybbs/prose)
 [![Documentation](site/public/badges/docs.svg)![Docs](https://img.shields.io/badge/Docs-8a80cb?style=for-the-badge)](https://prose.fyi/)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -64,7 +64,7 @@ impl Cache {
         self
     }
 
-    fn entries(&self) -> impl Iterator<Item = (DirEntry, Metadata)> {
+    fn entries(&self) -> impl Iterator<Item = (DirEntry, Metadata)> + use<> {
         fs_err::read_dir(&self.root)
             .into_iter()
             .flatten()
@@ -321,9 +321,10 @@ mod tests {
         let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
         let hex = key.0.to_hex();
         assert_eq!(hex.len(), 64);
-        assert!(hex
-            .chars()
-            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -17,8 +17,10 @@ use std::{
     time::SystemTime,
 };
 
-use bincode::config::standard;
-use bincode::serde::{decode_from_std_read, encode_into_std_write};
+use bincode::{
+    config::standard,
+    serde::{decode_from_std_read, encode_into_std_write},
+};
 use fs_err::DirEntry;
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,10 +10,12 @@
 //! concurrent reader never observes a partial entry. LRU eviction by
 //! mtime caps the directory at the configured size on every insert.
 
-use std::fs::Metadata;
-use std::io::{self, BufReader, BufWriter, Write};
-use std::path::{Path, PathBuf};
-use std::time::SystemTime;
+use std::{
+    fs::Metadata,
+    io::{self, BufReader, BufWriter, Write},
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
 
 use bincode::config::standard;
 use bincode::serde::{decode_from_std_read, encode_into_std_write};

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -3,8 +3,11 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use clap::builder::{PossibleValuesParser, TypedValueParser};
-use clap::{ColorChoice, CommandFactory, Parser, Subcommand, error::ErrorKind};
+use clap::{
+    ColorChoice, CommandFactory, Parser, Subcommand,
+    builder::{PossibleValuesParser, TypedValueParser},
+    error::ErrorKind,
+};
 use clap_complete::Shell;
 
 use super::exit_status::ExitStatus;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::builder::{PossibleValuesParser, TypedValueParser};
-use clap::{error::ErrorKind, ColorChoice, CommandFactory, Parser, Subcommand};
+use clap::{ColorChoice, CommandFactory, Parser, Subcommand, error::ErrorKind};
 use clap_complete::Shell;
 
 use super::exit_status::ExitStatus;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,6 @@
 //! Clap-derived argument types and parse-time validation.
 
-use std::path::PathBuf;
-use std::process::ExitCode;
+use std::{path::PathBuf, process::ExitCode};
 
 use clap::{
     ColorChoice, CommandFactory, Parser, Subcommand,
@@ -11,8 +10,7 @@ use clap::{
 use clap_complete::Shell;
 
 use super::exit_status::ExitStatus;
-use crate::pipeline::Pipeline;
-use crate::rule::RuleId;
+use crate::{pipeline::Pipeline, rule::RuleId};
 
 /// Matrix appended to `prose --help` via `after_long_help`.
 const EXIT_CODE_TABLE: &str = "\

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -1,7 +1,6 @@
 //! `prose cache` subcommand handlers and their shared helpers.
 
-use std::io::Write;
-use std::time::SystemTime;
+use std::{io::Write, time::SystemTime};
 
 use anyhow::Context;
 

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -4,8 +4,7 @@ use std::{io::Write, time::SystemTime};
 
 use anyhow::Context;
 
-use super::exit_status::ExitStatus;
-use super::load_config_or_status;
+use super::{exit_status::ExitStatus, load_config_or_status};
 use crate::cache::{Cache, CleanReport};
 
 pub(crate) fn clean<W: Write>(stdout: W) -> anyhow::Result<ExitStatus> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,8 +18,10 @@
 //! rendering. `exit_status` carries the matrix every subcommand
 //! resolves into.
 
-use std::io::{self, IsTerminal, Write};
-use std::process::ExitCode;
+use std::{
+    io::{self, IsTerminal, Write},
+    process::ExitCode,
+};
 
 use anstream::{AutoStream, stream::RawStream};
 use anyhow::Context;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,7 +21,7 @@
 use std::io::{self, IsTerminal, Write};
 use std::process::ExitCode;
 
-use anstream::{stream::RawStream, AutoStream};
+use anstream::{AutoStream, stream::RawStream};
 use anyhow::Context;
 use clap::{ColorChoice, CommandFactory, Parser};
 use clap_complete::generate;
@@ -33,8 +33,8 @@ mod output;
 mod runner;
 
 use args::{
-    normalize_stdin_dash, report_clap_error, validate_diff_format_combination, CacheAction, Cli,
-    Command,
+    CacheAction, Cli, Command, normalize_stdin_dash, report_clap_error,
+    validate_diff_format_combination,
 };
 use exit_status::ExitStatus;
 use output::Presentation;

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -1,7 +1,9 @@
 //! Pipeline orchestration: load source, run, emit diagnostics, classify outcome.
 
-use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
+use std::{
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
 use rayon::iter::{ParallelBridge, ParallelIterator};

--- a/src/cli/runner.rs
+++ b/src/cli/runner.rs
@@ -7,15 +7,19 @@ use anyhow::Context;
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use ruff_source_file::{SourceFile, SourceFileBuilder};
 
-use super::args::{CheckArgs, FormatArgs, OutputFormat, RuleFilter};
-use super::exit_status::ExitStatus;
-use super::output::{self, Presentation, Summary};
-use crate::cache::{Cache, CacheEntry, CacheKey};
-use crate::config::Config;
-use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Github, Json, Run, Sarif, Text};
-use crate::pipeline::Pipeline;
-use crate::source::Source;
-use crate::walker;
+use super::{
+    args::{CheckArgs, FormatArgs, OutputFormat, RuleFilter},
+    exit_status::ExitStatus,
+    output::{self, Presentation, Summary},
+};
+use crate::{
+    cache::{Cache, CacheEntry, CacheKey},
+    config::Config,
+    diagnostics::{Diagnostic, Emitter, EmitterSummary, Github, Json, Run, Sarif, Text},
+    pipeline::Pipeline,
+    source::Source,
+    walker,
+};
 
 /// One file's contribution to the run.
 #[derive(Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,15 +12,19 @@
 //! Each rule's configuration lives under `[tool.prose.rules]`, where
 //! a bare bool toggles the rule and a sub-table carries its knobs.
 
-use std::fmt;
-use std::marker::PhantomData;
-use std::num::NonZeroUsize;
-use std::path::{Path, PathBuf};
+use std::{
+    fmt,
+    marker::PhantomData,
+    num::NonZeroUsize,
+    path::{Path, PathBuf},
+};
 
 use regex_lite::Regex;
 use ruff_python_ast::PythonVersion;
-use serde::de::{IntoDeserializer, MapAccess, Visitor, value::MapAccessDeserializer};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{IntoDeserializer, MapAccess, Visitor, value::MapAccessDeserializer},
+};
 use thiserror::Error;
 
 pub use crate::rule::RuleConfigs;
@@ -212,10 +216,10 @@ impl Config {
                 }
                 return parse_prose_toml(&contents, &mut on_notice);
             }
-            if let Some(contents) = read_optional(dir.join(PYPROJECT_TOML))? {
-                if let Some(config) = parse_pyproject(&contents, &mut on_notice)? {
-                    return Ok(config);
-                }
+            if let Some(contents) = read_optional(dir.join(PYPROJECT_TOML))?
+                && let Some(config) = parse_pyproject(&contents, &mut on_notice)?
+            {
+                return Ok(config);
             }
         }
         Ok(Self::default())

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 
 use regex_lite::Regex;
 use ruff_python_ast::PythonVersion;
-use serde::de::{value::MapAccessDeserializer, IntoDeserializer, MapAccess, Visitor};
+use serde::de::{IntoDeserializer, MapAccess, Visitor, value::MapAccessDeserializer};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
@@ -921,11 +921,13 @@ mod tests {
         )
         .expect("parses");
 
-        assert!(config
-            .rules
-            .single_use_variables
-            .allow_pattern
-            .is_match("tmp_x"));
+        assert!(
+            config
+                .rules
+                .single_use_variables
+                .allow_pattern
+                .is_match("tmp_x")
+        );
         assert!(config.rules.single_use_variables.enabled);
     }
 
@@ -992,16 +994,20 @@ mod tests {
         )
         .expect("parses");
 
-        assert!(config
-            .rules
-            .single_use_variables
-            .allow_pattern
-            .is_match("tmp_x"));
-        assert!(!config
-            .rules
-            .single_use_variables
-            .allow_pattern
-            .is_match("xtmp_"));
+        assert!(
+            config
+                .rules
+                .single_use_variables
+                .allow_pattern
+                .is_match("tmp_x")
+        );
+        assert!(
+            !config
+                .rules
+                .single_use_variables
+                .allow_pattern
+                .is_match("xtmp_")
+        );
     }
 
     #[test]

--- a/src/diagnostics/github.rs
+++ b/src/diagnostics/github.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 
 use ruff_source_file::SourceFile;
 
-use crate::diagnostics::{line_columns, Diagnostic, Emitter, EmitterSummary, Run};
+use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns};
 
 pub(crate) struct Github;
 

--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -1,8 +1,10 @@
 //! Json emitter: NDJSON of Ruff-shaped diagnostic records closed by a
 //! summary envelope.
 
-use std::collections::BTreeMap;
-use std::io::{self, Write};
+use std::{
+    collections::BTreeMap,
+    io::{self, Write},
+};
 
 use ruff_diagnostics::{Applicability, Edit};
 use ruff_source_file::{LineColumn, OneIndexed, SourceFile};

--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -11,8 +11,10 @@ use ruff_source_file::{LineColumn, OneIndexed, SourceFile};
 use ruff_text_size::Ranged;
 use serde::Serialize;
 
-use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns, write_json_line};
-use crate::rule::RuleId;
+use crate::{
+    diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns, write_json_line},
+    rule::RuleId,
+};
 
 /// Bumps on any breaking change to existing field shapes, leaving
 /// additive fields to land unversioned.

--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -9,7 +9,7 @@ use ruff_source_file::{LineColumn, OneIndexed, SourceFile};
 use ruff_text_size::Ranged;
 use serde::Serialize;
 
-use crate::diagnostics::{line_columns, write_json_line, Diagnostic, Emitter, EmitterSummary, Run};
+use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns, write_json_line};
 use crate::rule::RuleId;
 
 /// Bumps on any breaking change to existing field shapes, leaving
@@ -143,7 +143,7 @@ impl<'a> JsonSummary<'a> {
 mod tests {
     use pretty_assertions::assert_eq;
     use ruff_text_size::TextRange;
-    use serde_json::{json, Value};
+    use serde_json::{Value, json};
 
     use super::*;
     use crate::diagnostics::Severity;
@@ -246,14 +246,18 @@ mod tests {
             &EmitterSummary::default(),
         );
         let mut lines = text.lines();
-        assert!(lines
-            .next()
-            .expect("diagnostic line")
-            .starts_with("{\"kind\":\"diagnostic\""));
-        assert!(lines
-            .next()
-            .expect("summary line")
-            .starts_with("{\"kind\":\"summary\""));
+        assert!(
+            lines
+                .next()
+                .expect("diagnostic line")
+                .starts_with("{\"kind\":\"diagnostic\"")
+        );
+        assert!(
+            lines
+                .next()
+                .expect("summary line")
+                .starts_with("{\"kind\":\"summary\"")
+        );
     }
 
     #[test]

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -1,7 +1,9 @@
 //! Diagnostic model and output emitters.
 
-use std::collections::BTreeMap;
-use std::io::{self, Write};
+use std::{
+    collections::BTreeMap,
+    io::{self, Write},
+};
 
 use ruff_source_file::{LineColumn, SourceFile};
 use ruff_text_size::TextRange;

--- a/src/diagnostics/sarif.rs
+++ b/src/diagnostics/sarif.rs
@@ -14,8 +14,10 @@ use serde_sarif::sarif::{
     Sarif as SarifDoc, ToolComponent,
 };
 
-use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns, write_json_line};
-use crate::rule::RuleId;
+use crate::{
+    diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns, write_json_line},
+    rule::RuleId,
+};
 
 pub(crate) struct Sarif;
 

--- a/src/diagnostics/sarif.rs
+++ b/src/diagnostics/sarif.rs
@@ -1,7 +1,9 @@
 //! Sarif emitter: SARIF 2.1.0 document for GitHub Code Scanning.
 
-use std::collections::BTreeSet;
-use std::io::{self, Write};
+use std::{
+    collections::BTreeSet,
+    io::{self, Write},
+};
 
 use ruff_diagnostics::Edit;
 use ruff_source_file::{LineColumn, SourceFile};

--- a/src/diagnostics/sarif.rs
+++ b/src/diagnostics/sarif.rs
@@ -12,7 +12,7 @@ use serde_sarif::sarif::{
     Sarif as SarifDoc, ToolComponent,
 };
 
-use crate::diagnostics::{line_columns, write_json_line, Diagnostic, Emitter, EmitterSummary, Run};
+use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns, write_json_line};
 use crate::rule::RuleId;
 
 pub(crate) struct Sarif;
@@ -69,10 +69,12 @@ fn sarif_fix(file: &SourceFile, edits: &[Edit]) -> Fix {
         })
         .collect();
     Fix::builder()
-        .artifact_changes(vec![ArtifactChange::builder()
-            .artifact_location(artifact_location(file))
-            .replacements(replacements)
-            .build()])
+        .artifact_changes(vec![
+            ArtifactChange::builder()
+                .artifact_location(artifact_location(file))
+                .replacements(replacements)
+                .build(),
+        ])
         .build()
 }
 
@@ -82,14 +84,16 @@ fn sarif_result(file: &SourceFile, diag: &Diagnostic) -> SarifResult {
         .rule_id(diag.rule.as_str())
         .level(ResultLevel::Warning)
         .message(diag.message.as_str())
-        .locations(vec![Location::builder()
-            .physical_location(
-                PhysicalLocation::builder()
-                    .artifact_location(artifact_location(file))
-                    .region(region(start, end))
-                    .build(),
-            )
-            .build()]);
+        .locations(vec![
+            Location::builder()
+                .physical_location(
+                    PhysicalLocation::builder()
+                        .artifact_location(artifact_location(file))
+                        .region(region(start, end))
+                        .build(),
+                )
+                .build(),
+        ]);
     match &diag.fix {
         Some(edits) => builder.fixes(vec![sarif_fix(file, edits)]).build(),
         None => builder.build(),
@@ -199,10 +203,10 @@ mod tests {
             severity: Severity::Format,
         };
         let v = emit_value(source.source_file(), std::slice::from_ref(&diag));
-        let replacements = v["runs"][0]["results"][0]["fixes"][0]["artifactChanges"][0]
-            ["replacements"]
-            .as_array()
-            .expect("replacements array");
+        let replacements =
+            v["runs"][0]["results"][0]["fixes"][0]["artifactChanges"][0]["replacements"]
+                .as_array()
+                .expect("replacements array");
         assert_eq!(replacements.len(), 2);
         assert_eq!(replacements[0]["insertedContent"]["text"], "a");
         assert_eq!(replacements[1]["insertedContent"]["text"], "b");

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -10,10 +10,12 @@ use ruff_python_parser::ParseError;
 use ruff_text_size::Ranged;
 use thiserror::Error;
 
-use crate::diagnostics::{Diagnostic, Severity};
-use crate::primitives::edit::apply_edits;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    diagnostics::{Diagnostic, Severity},
+    primitives::edit::apply_edits,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 /// Ordered sequence of enabled rules, run against each source file.
 pub struct Pipeline {

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -5,8 +5,10 @@
 //! one-space buffer between content and the aligned token.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::token::{Token, TokenKind};
-use ruff_python_ast::{AnyParameterRef, Parameters, Stmt};
+use ruff_python_ast::{
+    AnyParameterRef, Parameters, Stmt,
+    token::{Token, TokenKind},
+};
 use ruff_python_trivia::PythonWhitespace;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};

--- a/src/primitives/aligner.rs
+++ b/src/primitives/aligner.rs
@@ -14,9 +14,11 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use unicode_width::UnicodeWidthStr;
 
-use crate::config::{AlignmentConfig, MaxAlignShiftPolicy};
-use crate::rule::RuleId;
-use crate::source::Source;
+use crate::{
+    config::{AlignmentConfig, MaxAlignShiftPolicy},
+    rule::RuleId,
+    source::Source,
+};
 
 /// Bundles the `groups` accumulator, `settings`, the owning `rule`, and
 /// borrowed `source` shared by every alignment-rule visitor. Each entry

--- a/src/primitives/binding.rs
+++ b/src/primitives/binding.rs
@@ -17,11 +17,11 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use ruff_python_ast::visitor::{Visitor, walk_arguments, walk_expr, walk_parameters, walk_stmt};
 use ruff_python_ast::{
     Expr, ExprDictComp, ExprGenerator, ExprLambda, ExprList, ExprListComp, ExprNamed, ExprSetComp,
     ExprTuple, Identifier, ModModule, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtAugAssign,
     StmtClassDef, StmtFor, StmtFunctionDef, StmtImport, StmtImportFrom, StmtTry, StmtWith,
+    visitor::{Visitor, walk_arguments, walk_expr, walk_parameters, walk_stmt},
 };
 use ruff_text_size::{Ranged, TextSize};
 use serde::Serialize;

--- a/src/primitives/binding.rs
+++ b/src/primitives/binding.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use ruff_python_ast::visitor::{walk_arguments, walk_expr, walk_parameters, walk_stmt, Visitor};
+use ruff_python_ast::visitor::{Visitor, walk_arguments, walk_expr, walk_parameters, walk_stmt};
 use ruff_python_ast::{
     Expr, ExprDictComp, ExprGenerator, ExprLambda, ExprList, ExprListComp, ExprNamed, ExprSetComp,
     ExprTuple, Identifier, ModModule, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtAugAssign,
@@ -119,7 +119,10 @@ impl BindingAnalysis {
     /// Returns the binding ids declared directly inside the local
     /// scope of `stmt`. `stmt` must be a `Stmt::FunctionDef`; any
     /// other statement yields an empty iterator.
-    pub(crate) fn bindings_in_scope(&self, stmt: &Stmt) -> impl Iterator<Item = BindingId> + '_ {
+    pub(crate) fn bindings_in_scope(
+        &self,
+        stmt: &Stmt,
+    ) -> impl Iterator<Item = BindingId> + '_ + use<'_> {
         self.function_scope_at
             .get(&stmt.range().start())
             .copied()

--- a/src/primitives/binding.rs
+++ b/src/primitives/binding.rs
@@ -122,7 +122,7 @@ impl BindingAnalysis {
     pub(crate) fn bindings_in_scope(
         &self,
         stmt: &Stmt,
-    ) -> impl Iterator<Item = BindingId> + '_ + use<'_> {
+    ) -> impl Iterator<Item = BindingId> + use<'_> {
         self.function_scope_at
             .get(&stmt.range().start())
             .copied()

--- a/src/primitives/colon_targets.rs
+++ b/src/primitives/colon_targets.rs
@@ -15,9 +15,7 @@ use ruff_python_trivia::PythonWhitespace;
 use ruff_source_file::UniversalNewlines;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::primitives::aligner;
-use crate::rule::RuleId;
-use crate::source::Source;
+use crate::{primitives::aligner, rule::RuleId, source::Source};
 
 /// Receiver for the colon-context walker. `handle` is the catch-all
 /// for class fields, docstring args, and parameters. `dict` carries

--- a/src/primitives/colon_targets.rs
+++ b/src/primitives/colon_targets.rs
@@ -6,10 +6,10 @@
 //! them to strip pre-colon padding from groups that have no column to
 //! align to.
 
-use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::visitor::{Visitor as AstVisitor, walk_expr, walk_parameters, walk_stmt};
 use ruff_python_ast::{
     AnyParameterRef, DictItem, Expr, ExprDict, ExprStringLiteral, MatchCase, Parameters, Stmt,
+    token::TokenKind,
+    visitor::{Visitor as AstVisitor, walk_expr, walk_parameters, walk_stmt},
 };
 use ruff_python_trivia::PythonWhitespace;
 use ruff_source_file::UniversalNewlines;

--- a/src/primitives/colon_targets.rs
+++ b/src/primitives/colon_targets.rs
@@ -7,7 +7,7 @@
 //! align to.
 
 use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::visitor::{walk_expr, walk_parameters, walk_stmt, Visitor as AstVisitor};
+use ruff_python_ast::visitor::{Visitor as AstVisitor, walk_expr, walk_parameters, walk_stmt};
 use ruff_python_ast::{
     AnyParameterRef, DictItem, Expr, ExprDict, ExprStringLiteral, MatchCase, Parameters, Stmt,
 };

--- a/src/primitives/docstring.rs
+++ b/src/primitives/docstring.rs
@@ -14,8 +14,10 @@ use std::sync::LazyLock;
 
 use regex_lite::Regex;
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
-use ruff_python_ast::{ExprStringLiteral, Stmt, StringFlags, StringLiteral};
+use ruff_python_ast::{
+    ExprStringLiteral, Stmt, StringFlags, StringLiteral,
+    statement_visitor::{StatementVisitor, walk_stmt},
+};
 use ruff_python_trivia::{has_leading_content, leading_indentation};
 use ruff_source_file::{Line, LineRanges, UniversalNewlineIterator};
 use ruff_text_size::{Ranged, TextRange, TextSize};

--- a/src/primitives/docstring.rs
+++ b/src/primitives/docstring.rs
@@ -14,7 +14,7 @@ use std::sync::LazyLock;
 
 use regex_lite::Regex;
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{ExprStringLiteral, Stmt, StringFlags, StringLiteral};
 use ruff_python_trivia::{has_leading_content, leading_indentation};
 use ruff_source_file::{Line, LineRanges, UniversalNewlineIterator};

--- a/src/primitives/orderer.rs
+++ b/src/primitives/orderer.rs
@@ -5,8 +5,7 @@
 //! interstitial text between adjacent items stays in source
 //! position.
 
-use std::borrow::Cow;
-use std::ops::Range;
+use std::{borrow::Cow, ops::Range};
 
 use ruff_python_trivia::CommentRanges;
 use ruff_source_file::LineRanges;

--- a/src/primitives/orderer.rs
+++ b/src/primitives/orderer.rs
@@ -52,8 +52,8 @@ pub(crate) fn block_range<T: Ranged>(
     outer: TextRange,
 ) -> TextRange {
     let item = items[i].range();
-    let lower = items[..i].last().map_or(outer.start(), |t| t.end());
-    let upper = items.get(i + 1).map_or(outer.end(), |t| t.start());
+    let lower = items[..i].last().map_or(outer.start(), Ranged::end);
+    let upper = items.get(i + 1).map_or(outer.end(), Ranged::start);
     TextRange::new(
         leading_attached_start(source, item.start(), lower),
         source.text().line_end(item.end()).min(upper),

--- a/src/primitives/range.rs
+++ b/src/primitives/range.rs
@@ -1,6 +1,6 @@
 //! Parenthesis-aware source ranges for expression nodes.
 
-use ruff_python_ast::token::{parenthesized_range, Tokens};
+use ruff_python_ast::token::{Tokens, parenthesized_range};
 use ruff_python_ast::{AnyNodeRef, ExprRef};
 use ruff_text_size::{Ranged, TextRange};
 

--- a/src/primitives/range.rs
+++ b/src/primitives/range.rs
@@ -1,7 +1,9 @@
 //! Parenthesis-aware source ranges for expression nodes.
 
-use ruff_python_ast::token::{Tokens, parenthesized_range};
-use ruff_python_ast::{AnyNodeRef, ExprRef};
+use ruff_python_ast::{
+    AnyNodeRef, ExprRef,
+    token::{Tokens, parenthesized_range},
+};
 use ruff_text_size::{Ranged, TextRange};
 
 /// Returns `expr`'s range widened to the explicit parentheses recovered

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -20,26 +20,18 @@ use crate::config::{
 };
 use crate::diagnostics::Diagnostic;
 use crate::pipeline::Pipeline;
-use crate::rules::align_colons::AlignColons;
-use crate::rules::align_comparisons::AlignComparisons;
-use crate::rules::align_equals::AlignEquals;
-use crate::rules::align_imports::AlignImports;
-use crate::rules::alphabetize::Alphabetize;
-use crate::rules::bare_import_allowlist::BareImportAllowlist;
-use crate::rules::blank_lines::BlankLines;
-use crate::rules::collection_layout::CollectionLayout;
-use crate::rules::docstring_wrap::DocstringWrap;
-use crate::rules::legacy_union_syntax::LegacyUnionSyntax;
-use crate::rules::loose_constants::LooseConstants;
-use crate::rules::match_case_align::MatchCaseAlign;
-use crate::rules::multi_line_docstrings::MultiLineDocstrings;
-use crate::rules::no_single_line_docstrings::NoSingleLineDocstrings;
-use crate::rules::no_step_narration::NoStepNarration;
-use crate::rules::signature_layout::SignatureLayout;
-use crate::rules::single_use_variables::SingleUseVariables;
-use crate::rules::singleton_rule::SingletonRule;
-use crate::rules::strip_trailing_commas::StripTrailingCommas;
-use crate::rules::unused_future_annotations::UnusedFutureAnnotations;
+use crate::rules::{
+    align_colons::AlignColons, align_comparisons::AlignComparisons, align_equals::AlignEquals,
+    align_imports::AlignImports, alphabetize::Alphabetize,
+    bare_import_allowlist::BareImportAllowlist, blank_lines::BlankLines,
+    collection_layout::CollectionLayout, docstring_wrap::DocstringWrap,
+    legacy_union_syntax::LegacyUnionSyntax, loose_constants::LooseConstants,
+    match_case_align::MatchCaseAlign, multi_line_docstrings::MultiLineDocstrings,
+    no_single_line_docstrings::NoSingleLineDocstrings, no_step_narration::NoStepNarration,
+    signature_layout::SignatureLayout, single_use_variables::SingleUseVariables,
+    singleton_rule::SingletonRule, strip_trailing_commas::StripTrailingCommas,
+    unused_future_annotations::UnusedFutureAnnotations,
+};
 use crate::source::Source;
 
 /// Returned when a string fails to match any registered rule slug.

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -7,8 +7,7 @@
 //! [`Pipeline::for_rule`], [`Pipeline::with_defaults`], and
 //! [`Pipeline::with_filters`] from a registry table.
 
-use std::fmt;
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use ruff_diagnostics::Edit;
 use serde::{Deserialize, Serialize};

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -157,7 +157,7 @@ const fn is_valid_slug(bytes: &[u8]) -> bool {
                 return false;
             }
             prev_was_dash = true;
-        } else if matches!(b, b'a'..=b'z' | b'0'..=b'9') {
+        } else if b.is_ascii_lowercase() || b.is_ascii_digit() {
             prev_was_dash = false;
         } else {
             return false;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -13,25 +13,27 @@ use ruff_diagnostics::Edit;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::config::{
-    AlignmentConfig, AlphabetizeConfig, BareImportAllowlistConfig, CollectionLayoutConfig, Config,
-    LooseConstantsConfig, SignatureLayoutConfig, SingleUseVariablesConfig, ToggleOnly,
+use crate::{
+    config::{
+        AlignmentConfig, AlphabetizeConfig, BareImportAllowlistConfig, CollectionLayoutConfig,
+        Config, LooseConstantsConfig, SignatureLayoutConfig, SingleUseVariablesConfig, ToggleOnly,
+    },
+    diagnostics::Diagnostic,
+    pipeline::Pipeline,
+    rules::{
+        align_colons::AlignColons, align_comparisons::AlignComparisons, align_equals::AlignEquals,
+        align_imports::AlignImports, alphabetize::Alphabetize,
+        bare_import_allowlist::BareImportAllowlist, blank_lines::BlankLines,
+        collection_layout::CollectionLayout, docstring_wrap::DocstringWrap,
+        legacy_union_syntax::LegacyUnionSyntax, loose_constants::LooseConstants,
+        match_case_align::MatchCaseAlign, multi_line_docstrings::MultiLineDocstrings,
+        no_single_line_docstrings::NoSingleLineDocstrings, no_step_narration::NoStepNarration,
+        signature_layout::SignatureLayout, single_use_variables::SingleUseVariables,
+        singleton_rule::SingletonRule, strip_trailing_commas::StripTrailingCommas,
+        unused_future_annotations::UnusedFutureAnnotations,
+    },
+    source::Source,
 };
-use crate::diagnostics::Diagnostic;
-use crate::pipeline::Pipeline;
-use crate::rules::{
-    align_colons::AlignColons, align_comparisons::AlignComparisons, align_equals::AlignEquals,
-    align_imports::AlignImports, alphabetize::Alphabetize,
-    bare_import_allowlist::BareImportAllowlist, blank_lines::BlankLines,
-    collection_layout::CollectionLayout, docstring_wrap::DocstringWrap,
-    legacy_union_syntax::LegacyUnionSyntax, loose_constants::LooseConstants,
-    match_case_align::MatchCaseAlign, multi_line_docstrings::MultiLineDocstrings,
-    no_single_line_docstrings::NoSingleLineDocstrings, no_step_narration::NoStepNarration,
-    signature_layout::SignatureLayout, single_use_variables::SingleUseVariables,
-    singleton_rule::SingletonRule, strip_trailing_commas::StripTrailingCommas,
-    unused_future_annotations::UnusedFutureAnnotations,
-};
-use crate::source::Source;
 
 /// Returned when a string fails to match any registered rule slug.
 /// Carries the offending input so callers can surface it verbatim.

--- a/src/rules/align_colons.rs
+++ b/src/rules/align_colons.rs
@@ -10,8 +10,7 @@ use ruff_python_ast::ExprDict;
 use ruff_text_size::Ranged;
 
 use crate::config::Config;
-use crate::primitives::aligner;
-use crate::primitives::colon_targets::ColonEmitter;
+use crate::primitives::{aligner, colon_targets::ColonEmitter};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/align_colons.rs
+++ b/src/rules/align_colons.rs
@@ -9,10 +9,12 @@ use ruff_diagnostics::Edit;
 use ruff_python_ast::ExprDict;
 use ruff_text_size::Ranged;
 
-use crate::config::Config;
-use crate::primitives::{aligner, colon_targets::ColonEmitter};
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::{aligner, colon_targets::ColonEmitter},
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct AlignColons {
     settings: aligner::Settings,

--- a/src/rules/align_comparisons.rs
+++ b/src/rules/align_comparisons.rs
@@ -14,10 +14,12 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::config::Config;
-use crate::primitives::aligner;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::aligner,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct AlignComparisons {
     settings: aligner::Settings,

--- a/src/rules/align_comparisons.rs
+++ b/src/rules/align_comparisons.rs
@@ -7,9 +7,11 @@
 //! or a blank line in the gap breaks the run.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::visitor::{Visitor as AstVisitor, walk_expr};
-use ruff_python_ast::{CmpOp, Expr, ExprBoolOp};
+use ruff_python_ast::{
+    CmpOp, Expr, ExprBoolOp,
+    token::TokenKind,
+    visitor::{Visitor as AstVisitor, walk_expr},
+};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::config::Config;

--- a/src/rules/align_comparisons.rs
+++ b/src/rules/align_comparisons.rs
@@ -8,7 +8,7 @@
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::visitor::{walk_expr, Visitor as AstVisitor};
+use ruff_python_ast::visitor::{Visitor as AstVisitor, walk_expr};
 use ruff_python_ast::{CmpOp, Expr, ExprBoolOp};
 use ruff_text_size::{Ranged, TextRange};
 

--- a/src/rules/align_equals.rs
+++ b/src/rules/align_equals.rs
@@ -10,7 +10,7 @@
 //! Parameter widths reflect the post-`align_colons` source.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{walk_body, walk_stmt, StatementVisitor};
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_body, walk_stmt};
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{AnyParameterRef, Parameters, Stmt};
 use ruff_text_size::{Ranged, TextRange, TextSize};

--- a/src/rules/align_equals.rs
+++ b/src/rules/align_equals.rs
@@ -10,9 +10,11 @@
 //! Parameter widths reflect the post-`align_colons` source.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_body, walk_stmt};
-use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::{AnyParameterRef, Parameters, Stmt};
+use ruff_python_ast::{
+    AnyParameterRef, Parameters, Stmt,
+    statement_visitor::{StatementVisitor, walk_body, walk_stmt},
+    token::TokenKind,
+};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::config::Config;

--- a/src/rules/align_equals.rs
+++ b/src/rules/align_equals.rs
@@ -17,10 +17,12 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::config::Config;
-use crate::primitives::aligner;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::aligner,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct AlignEquals {
     settings: aligner::Settings,

--- a/src/rules/align_imports.rs
+++ b/src/rules/align_imports.rs
@@ -17,10 +17,12 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{Ranged, TextRange};
 
-use crate::config::Config;
-use crate::primitives::aligner;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::aligner,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct AlignImports {
     settings: aligner::Settings,

--- a/src/rules/align_imports.rs
+++ b/src/rules/align_imports.rs
@@ -10,9 +10,11 @@
 //! because shifting the keyword would break the continuation indent.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::Stmt;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_body};
-use ruff_python_ast::token::TokenKind;
+use ruff_python_ast::{
+    Stmt,
+    statement_visitor::{StatementVisitor, walk_body},
+    token::TokenKind,
+};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::config::Config;

--- a/src/rules/align_imports.rs
+++ b/src/rules/align_imports.rs
@@ -10,9 +10,9 @@
 //! because shifting the keyword would break the continuation indent.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{walk_body, StatementVisitor};
-use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::Stmt;
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_body};
+use ruff_python_ast::token::TokenKind;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::config::Config;

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -20,7 +20,7 @@ use std::ops::Range;
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::{any_over_expr, is_compound_statement, is_dunder, map_callable};
-use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor as AstVisitor};
+use ruff_python_ast::visitor::{Visitor as AstVisitor, walk_expr, walk_stmt};
 use ruff_python_ast::{
     Alias, Decorator, DictItem, ExceptHandler, Expr, ExprCall, ExprDict, ExprLambda, ExprSet,
     Identifier, ParameterWithDefault, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtDelete,
@@ -32,7 +32,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use crate::config::Config;
 use crate::primitives::docstring::{entry_carrying_sections, rewrite_docstrings};
 use crate::primitives::edit::{apply_inline_edits, narrowed_replacement, singleton_groups};
-use crate::primitives::imports::{import_group, ImportGroup};
+use crate::primitives::imports::{ImportGroup, import_group};
 use crate::primitives::orderer::{
     assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
 };
@@ -804,7 +804,7 @@ fn rewrite_stmt<'src>(
         Stmt::ClassDef(c) => (&c.body, c.range(), BodyScope::Class),
         Stmt::FunctionDef(f) => (&f.body, f.range(), BodyScope::Function),
         s if is_compound_statement(s) => {
-            return rewrite_compound(source, stmt, block, parent_scope, leaf_edits, first_party)
+            return rewrite_compound(source, stmt, block, parent_scope, leaf_edits, first_party);
         }
         _ => return apply_inline_edits(source, block, leaf_edits),
     };

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -14,33 +14,37 @@
 //! outer scope's replacement text, so each outermost reordering scope
 //! emits a single edit covering its descendants.
 
-use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
-use std::ops::Range;
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    ops::Range,
+};
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::helpers::{any_over_expr, is_compound_statement, is_dunder, map_callable};
-use ruff_python_ast::visitor::{Visitor as AstVisitor, walk_expr, walk_stmt};
 use ruff_python_ast::{
     Alias, Decorator, DictItem, ExceptHandler, Expr, ExprCall, ExprDict, ExprLambda, ExprSet,
     Identifier, ParameterWithDefault, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtDelete,
     StmtFunctionDef,
+    helpers::{any_over_expr, is_compound_statement, is_dunder, map_callable},
+    visitor::{Visitor as AstVisitor, walk_expr, walk_stmt},
 };
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
-use crate::config::Config;
-use crate::primitives::{
-    docstring::{entry_carrying_sections, rewrite_docstrings},
-    edit::{apply_inline_edits, narrowed_replacement, singleton_groups},
-    imports::{ImportGroup, import_group},
-    orderer::{
-        assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
+use crate::{
+    config::Config,
+    primitives::{
+        docstring::{entry_carrying_sections, rewrite_docstrings},
+        edit::{apply_inline_edits, narrowed_replacement, singleton_groups},
+        imports::{ImportGroup, import_group},
+        orderer::{
+            assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
+        },
+        scope::BodyScope,
     },
-    scope::BodyScope,
+    rule::{Rule, RuleId},
+    source::Source,
 };
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
 
 pub(crate) struct Alphabetize {
     docstring_entries: bool,

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -30,13 +30,15 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::config::Config;
-use crate::primitives::docstring::{entry_carrying_sections, rewrite_docstrings};
-use crate::primitives::edit::{apply_inline_edits, narrowed_replacement, singleton_groups};
-use crate::primitives::imports::{ImportGroup, import_group};
-use crate::primitives::orderer::{
-    assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
+use crate::primitives::{
+    docstring::{entry_carrying_sections, rewrite_docstrings},
+    edit::{apply_inline_edits, narrowed_replacement, singleton_groups},
+    imports::{ImportGroup, import_group},
+    orderer::{
+        assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
+    },
+    scope::BodyScope,
 };
-use crate::primitives::scope::BodyScope;
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/bare_import_allowlist.rs
+++ b/src/rules/bare_import_allowlist.rs
@@ -3,8 +3,8 @@
 
 use std::collections::HashSet;
 
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::Stmt;
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 
 use crate::config::Config;
 use crate::diagnostics::Diagnostic;

--- a/src/rules/bare_import_allowlist.rs
+++ b/src/rules/bare_import_allowlist.rs
@@ -3,8 +3,10 @@
 
 use std::collections::HashSet;
 
-use ruff_python_ast::Stmt;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
+use ruff_python_ast::{
+    Stmt,
+    statement_visitor::{StatementVisitor, walk_stmt},
+};
 
 use crate::config::Config;
 use crate::diagnostics::Diagnostic;

--- a/src/rules/bare_import_allowlist.rs
+++ b/src/rules/bare_import_allowlist.rs
@@ -8,11 +8,13 @@ use ruff_python_ast::{
     statement_visitor::{StatementVisitor, walk_stmt},
 };
 
-use crate::config::Config;
-use crate::diagnostics::Diagnostic;
-use crate::primitives::binding::top_level_module;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    diagnostics::Diagnostic,
+    primitives::binding::top_level_module,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct BareImportAllowlist {
     allow: HashSet<String>,

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -14,9 +14,7 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::config::Config;
-use crate::primitives::edit::singleton_groups;
-use crate::primitives::imports::import_group;
-use crate::primitives::scope::BodyScope;
+use crate::primitives::{edit::singleton_groups, imports::import_group, scope::BodyScope};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -7,9 +7,9 @@
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_docstring_stmt;
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{CmpOp, Expr, Stmt};
-use ruff_python_trivia::{lines_after, lines_before, BackwardsTokenizer, CommentRanges};
+use ruff_python_trivia::{BackwardsTokenizer, CommentRanges, lines_after, lines_before};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -224,11 +224,7 @@ fn is_main_guard(stmt: &Stmt) -> bool {
 /// leading `#` and surrounding whitespace, consists of 5 or more
 /// identical non-alphanumeric characters.
 fn is_rule_line(line: &str) -> bool {
-    let stripped = line
-        .trim_start()
-        .strip_prefix('#')
-        .map(str::trim)
-        .unwrap_or("");
+    let stripped = line.trim_start().strip_prefix('#').map_or("", str::trim);
     let bytes = stripped.as_bytes();
     bytes.len() >= 5 && !bytes[0].is_ascii_alphanumeric() && bytes.iter().all(|&b| b == bytes[0])
 }

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -6,17 +6,21 @@
 //! below a description block, and 1 blank line below a banner block.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::helpers::is_docstring_stmt;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
-use ruff_python_ast::{CmpOp, Expr, Stmt};
+use ruff_python_ast::{
+    CmpOp, Expr, Stmt,
+    helpers::is_docstring_stmt,
+    statement_visitor::{StatementVisitor, walk_stmt},
+};
 use ruff_python_trivia::{BackwardsTokenizer, CommentRanges, lines_after, lines_before};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::config::Config;
-use crate::primitives::{edit::singleton_groups, imports::import_group, scope::BodyScope};
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::{edit::singleton_groups, imports::import_group, scope::BodyScope},
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct BlankLines {
     first_party: Vec<String>,

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -11,9 +11,11 @@ use std::borrow::Cow;
 use std::ops::Range;
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::helpers::is_dotted_name;
-use ruff_python_ast::visitor::{Visitor, walk_expr};
-use ruff_python_ast::{AnyNodeRef, DictItem, Expr, ExprDict};
+use ruff_python_ast::{
+    AnyNodeRef, DictItem, Expr, ExprDict,
+    helpers::is_dotted_name,
+    visitor::{Visitor, walk_expr},
+};
 use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -7,8 +7,7 @@
 //! `item_indent + INDENT_STEP`. Comprehensions and any literal
 //! whose source range contains a comment are out of scope.
 
-use std::borrow::Cow;
-use std::ops::Range;
+use std::{borrow::Cow, ops::Range};
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::{
@@ -19,14 +18,16 @@ use ruff_python_ast::{
 use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 
-use crate::config::Config;
-use crate::primitives::{
-    INDENT_STEP,
-    edit::{narrowed_replacement, singleton_groups},
-    range::paren_aware_range,
+use crate::{
+    config::Config,
+    primitives::{
+        INDENT_STEP,
+        edit::{narrowed_replacement, singleton_groups},
+        range::paren_aware_range,
+    },
+    rule::{Rule, RuleId},
+    source::Source,
 };
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
 
 pub(crate) struct CollectionLayout {
     code_line_length: usize,

--- a/src/rules/collection_layout.rs
+++ b/src/rules/collection_layout.rs
@@ -12,16 +12,16 @@ use std::ops::Range;
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_dotted_name;
-use ruff_python_ast::visitor::{walk_expr, Visitor};
+use ruff_python_ast::visitor::{Visitor, walk_expr};
 use ruff_python_ast::{AnyNodeRef, DictItem, Expr, ExprDict};
 use ruff_text_size::{Ranged, TextRange};
 use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
 use crate::primitives::{
+    INDENT_STEP,
     edit::{narrowed_replacement, singleton_groups},
     range::paren_aware_range,
-    INDENT_STEP,
 };
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -302,16 +302,16 @@ mod tests {
     fn description_wraps_to_default_76_character_budget() {
         let src = "\"\"\"\nThis is a long description line that exceeds the seventy six character docstring budget by a margin.\n\"\"\"\n";
         let out = run(src);
-        assert!(out
-            .lines()
-            .filter(|l| !l.starts_with("\"\"\""))
-            .all(|l| l.chars().count() <= 76));
+        assert!(
+            out.lines()
+                .filter(|l| !l.starts_with("\"\"\""))
+                .all(|l| l.chars().count() <= 76)
+        );
     }
 
     #[test]
     fn fenced_code_block_passes_through_verbatim() {
-        let src =
-            "\"\"\"\nSummary.\n\n```python\nx = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12\n```\n\"\"\"\n";
+        let src = "\"\"\"\nSummary.\n\n```python\nx = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12\n```\n\"\"\"\n";
         assert_eq!(run(src), src);
     }
 

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -16,11 +16,13 @@ use ruff_python_trivia::leading_indentation;
 use textwrap::Options;
 
 use crate::config::{Config, DocstringStructuredPolicy};
-use crate::primitives::docstring::{
-    entry_description_col, indent_prefix, is_list_marker, rewrite_docstrings, section_heading,
-    triple_quoted_body,
+use crate::primitives::{
+    docstring::{
+        entry_description_col, indent_prefix, is_list_marker, rewrite_docstrings, section_heading,
+        triple_quoted_body,
+    },
+    edit::{narrowed_replacement, singleton_groups},
 };
-use crate::primitives::edit::{narrowed_replacement, singleton_groups};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -15,16 +15,18 @@ use ruff_diagnostics::Edit;
 use ruff_python_trivia::leading_indentation;
 use textwrap::Options;
 
-use crate::config::{Config, DocstringStructuredPolicy};
-use crate::primitives::{
-    docstring::{
-        entry_description_col, indent_prefix, is_list_marker, rewrite_docstrings, section_heading,
-        triple_quoted_body,
+use crate::{
+    config::{Config, DocstringStructuredPolicy},
+    primitives::{
+        docstring::{
+            entry_description_col, indent_prefix, is_list_marker, rewrite_docstrings,
+            section_heading, triple_quoted_body,
+        },
+        edit::{narrowed_replacement, singleton_groups},
     },
-    edit::{narrowed_replacement, singleton_groups},
+    rule::{Rule, RuleId},
+    source::Source,
 };
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
 
 pub(crate) struct DocstringWrap {
     description_width: usize,

--- a/src/rules/legacy_union_syntax.rs
+++ b/src/rules/legacy_union_syntax.rs
@@ -10,11 +10,13 @@ use ruff_python_ast::{
     visitor::{Visitor, walk_expr, walk_stmt},
 };
 
-use crate::config::Config;
-use crate::diagnostics::Diagnostic;
-use crate::primitives::{binding::top_level_module, range::paren_aware_range};
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    diagnostics::Diagnostic,
+    primitives::{binding::top_level_module, range::paren_aware_range},
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct LegacyUnionSyntax {
     target_version: Option<PythonVersion>,

--- a/src/rules/legacy_union_syntax.rs
+++ b/src/rules/legacy_union_syntax.rs
@@ -4,14 +4,15 @@
 
 use std::collections::HashMap;
 
-use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
-use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
-use ruff_python_ast::{AnyNodeRef, Expr, ExprSubscript, Identifier, PythonVersion, Stmt};
+use ruff_python_ast::{
+    AnyNodeRef, Expr, ExprSubscript, Identifier, PythonVersion, Stmt,
+    name::{QualifiedName, UnqualifiedName},
+    visitor::{Visitor, walk_expr, walk_stmt},
+};
 
 use crate::config::Config;
 use crate::diagnostics::Diagnostic;
-use crate::primitives::binding::top_level_module;
-use crate::primitives::range::paren_aware_range;
+use crate::primitives::{binding::top_level_module, range::paren_aware_range};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/legacy_union_syntax.rs
+++ b/src/rules/legacy_union_syntax.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 
 use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
-use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
 use ruff_python_ast::{AnyNodeRef, Expr, ExprSubscript, Identifier, PythonVersion, Stmt};
 
 use crate::config::Config;

--- a/src/rules/loose_constants.rs
+++ b/src/rules/loose_constants.rs
@@ -13,10 +13,12 @@ use ruff_python_ast::{
 };
 use ruff_text_size::Ranged;
 
-use crate::config::Config;
-use crate::diagnostics::Diagnostic;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    diagnostics::Diagnostic,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct LooseConstants {
     allow: HashSet<String>,

--- a/src/rules/loose_constants.rs
+++ b/src/rules/loose_constants.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::name::UnqualifiedName;
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{Expr, ExprName, Stmt, StmtIf};
 use ruff_text_size::Ranged;
 
@@ -69,17 +69,17 @@ impl<'a> StatementVisitor<'a> for Walker<'a> {
             Stmt::FunctionDef(_) | Stmt::ClassDef(_) => return,
             Stmt::If(if_stmt) if is_type_checking_block(if_stmt) => return,
             Stmt::Assign(a) => {
-                if let [Expr::Name(target)] = a.targets.as_slice() {
-                    if is_loose_constant_target(target, Some(a.value.as_ref()), self.allow) {
-                        self.emit(stmt, &target.id);
-                    }
+                if let [Expr::Name(target)] = a.targets.as_slice()
+                    && is_loose_constant_target(target, Some(a.value.as_ref()), self.allow)
+                {
+                    self.emit(stmt, &target.id);
                 }
             }
             Stmt::AnnAssign(a) => {
-                if let Expr::Name(target) = a.target.as_ref() {
-                    if is_loose_constant_target(target, a.value.as_deref(), self.allow) {
-                        self.emit(stmt, &target.id);
-                    }
+                if let Expr::Name(target) = a.target.as_ref()
+                    && is_loose_constant_target(target, a.value.as_deref(), self.allow)
+                {
+                    self.emit(stmt, &target.id);
                 }
             }
             _ => {}

--- a/src/rules/loose_constants.rs
+++ b/src/rules/loose_constants.rs
@@ -5,10 +5,12 @@
 
 use std::collections::HashSet;
 
-use ruff_python_ast::helpers::is_dunder;
-use ruff_python_ast::name::UnqualifiedName;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
-use ruff_python_ast::{Expr, ExprName, Stmt, StmtIf};
+use ruff_python_ast::{
+    Expr, ExprName, Stmt, StmtIf,
+    helpers::is_dunder,
+    name::UnqualifiedName,
+    statement_visitor::{StatementVisitor, walk_stmt},
+};
 use ruff_text_size::Ranged;
 
 use crate::config::Config;

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -9,9 +9,11 @@
 //! on the next line. Nested matches recurse.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::helpers::is_compound_statement;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
-use ruff_python_ast::{MatchCase, Stmt, StmtMatch};
+use ruff_python_ast::{
+    MatchCase, Stmt, StmtMatch,
+    helpers::is_compound_statement,
+    statement_visitor::{StatementVisitor, walk_stmt},
+};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use unicode_width::UnicodeWidthStr;
 

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -10,13 +10,13 @@
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_compound_statement;
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{MatchCase, Stmt, StmtMatch};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
-use crate::primitives::{aligner, colon_targets, INDENT_STEP};
+use crate::primitives::{INDENT_STEP, aligner, colon_targets};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/match_case_align.rs
+++ b/src/rules/match_case_align.rs
@@ -17,10 +17,12 @@ use ruff_python_ast::{
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use unicode_width::UnicodeWidthStr;
 
-use crate::config::Config;
-use crate::primitives::{INDENT_STEP, aligner, colon_targets};
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::{INDENT_STEP, aligner, colon_targets},
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct MatchCaseAlign {
     code_line_length: usize,

--- a/src/rules/multi_line_docstrings.rs
+++ b/src/rules/multi_line_docstrings.rs
@@ -9,8 +9,10 @@ use ruff_diagnostics::Edit;
 use ruff_python_trivia::has_leading_content;
 
 use crate::config::Config;
-use crate::primitives::docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body};
-use crate::primitives::edit::{narrowed_replacement, singleton_groups};
+use crate::primitives::{
+    docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body},
+    edit::{narrowed_replacement, singleton_groups},
+};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/multi_line_docstrings.rs
+++ b/src/rules/multi_line_docstrings.rs
@@ -8,13 +8,15 @@
 use ruff_diagnostics::Edit;
 use ruff_python_trivia::has_leading_content;
 
-use crate::config::Config;
-use crate::primitives::{
-    docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body},
-    edit::{narrowed_replacement, singleton_groups},
+use crate::{
+    config::Config,
+    primitives::{
+        docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body},
+        edit::{narrowed_replacement, singleton_groups},
+    },
+    rule::{Rule, RuleId},
+    source::Source,
 };
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
 
 pub(crate) struct MultiLineDocstrings;
 

--- a/src/rules/no_single_line_docstrings.rs
+++ b/src/rules/no_single_line_docstrings.rs
@@ -10,8 +10,10 @@ use ruff_diagnostics::Edit;
 use ruff_python_trivia::PythonWhitespace;
 
 use crate::config::Config;
-use crate::primitives::docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body};
-use crate::primitives::edit::{narrowed_replacement, singleton_groups};
+use crate::primitives::{
+    docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body},
+    edit::{narrowed_replacement, singleton_groups},
+};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/no_single_line_docstrings.rs
+++ b/src/rules/no_single_line_docstrings.rs
@@ -9,13 +9,15 @@
 use ruff_diagnostics::Edit;
 use ruff_python_trivia::PythonWhitespace;
 
-use crate::config::Config;
-use crate::primitives::{
-    docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body},
-    edit::{narrowed_replacement, singleton_groups},
+use crate::{
+    config::Config,
+    primitives::{
+        docstring::{indent_prefix, rewrite_docstrings, triple_quoted_body},
+        edit::{narrowed_replacement, singleton_groups},
+    },
+    rule::{Rule, RuleId},
+    source::Source,
 };
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
 
 pub(crate) struct NoSingleLineDocstrings;
 

--- a/src/rules/no_step_narration.rs
+++ b/src/rules/no_step_narration.rs
@@ -3,7 +3,7 @@
 //! decimal-version comments are excluded.
 
 use ruff_python_trivia::{
-    is_pragma_comment, is_python_whitespace, CommentRanges, Cursor, PythonWhitespace,
+    CommentRanges, Cursor, PythonWhitespace, is_pragma_comment, is_python_whitespace,
 };
 
 use crate::config::Config;

--- a/src/rules/no_step_narration.rs
+++ b/src/rules/no_step_narration.rs
@@ -6,10 +6,12 @@ use ruff_python_trivia::{
     CommentRanges, Cursor, PythonWhitespace, is_pragma_comment, is_python_whitespace,
 };
 
-use crate::config::Config;
-use crate::diagnostics::Diagnostic;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    diagnostics::Diagnostic,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct NoStepNarration;
 

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -13,13 +13,15 @@ use ruff_python_ast::{
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use unicode_width::UnicodeWidthStr;
 
-use crate::config::Config;
-use crate::primitives::{
-    INDENT_STEP,
-    edit::{narrowed_replacement, singleton_groups},
+use crate::{
+    config::Config,
+    primitives::{
+        INDENT_STEP,
+        edit::{narrowed_replacement, singleton_groups},
+    },
+    rule::{Rule, RuleId},
+    source::Source,
 };
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
 
 pub(crate) struct SignatureLayout {
     code_line_length: usize,

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -5,7 +5,7 @@
 use std::num::NonZeroUsize;
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{ParameterWithDefault, Parameters, Stmt, StmtFunctionDef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -13,8 +13,8 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::config::Config;
 use crate::primitives::{
-    edit::{narrowed_replacement, singleton_groups},
     INDENT_STEP,
+    edit::{narrowed_replacement, singleton_groups},
 };
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -5,9 +5,11 @@
 use std::num::NonZeroUsize;
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
-use ruff_python_ast::token::TokenKind;
-use ruff_python_ast::{ParameterWithDefault, Parameters, Stmt, StmtFunctionDef};
+use ruff_python_ast::{
+    ParameterWithDefault, Parameters, Stmt, StmtFunctionDef,
+    statement_visitor::{StatementVisitor, walk_stmt},
+    token::TokenKind,
+};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use unicode_width::UnicodeWidthStr;
 

--- a/src/rules/single_use_variables.rs
+++ b/src/rules/single_use_variables.rs
@@ -17,8 +17,8 @@
 //!   `def`/`class` bindings out of the diagnostic surface.
 
 use regex_lite::Regex;
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::Stmt;
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::config::Config;

--- a/src/rules/single_use_variables.rs
+++ b/src/rules/single_use_variables.rs
@@ -23,11 +23,13 @@ use ruff_python_ast::{
 };
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::config::Config;
-use crate::diagnostics::Diagnostic;
-use crate::primitives::binding::{BindingAnalysis, BindingId, BindingKind};
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    diagnostics::Diagnostic,
+    primitives::binding::{BindingAnalysis, BindingId, BindingKind},
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct SingleUseVariables {
     allow_pattern: Regex,

--- a/src/rules/single_use_variables.rs
+++ b/src/rules/single_use_variables.rs
@@ -17,8 +17,10 @@
 //!   `def`/`class` bindings out of the diagnostic surface.
 
 use regex_lite::Regex;
-use ruff_python_ast::Stmt;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
+use ruff_python_ast::{
+    Stmt,
+    statement_visitor::{StatementVisitor, walk_stmt},
+};
 use ruff_text_size::{TextRange, TextSize};
 
 use crate::config::Config;

--- a/src/rules/singleton_rule.rs
+++ b/src/rules/singleton_rule.rs
@@ -10,10 +10,12 @@
 
 use ruff_diagnostics::Edit;
 
-use crate::config::Config;
-use crate::primitives::{aligner, colon_targets::ColonEmitter, edit::singleton_groups};
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::{aligner, colon_targets::ColonEmitter, edit::singleton_groups},
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct SingletonRule;
 

--- a/src/rules/singleton_rule.rs
+++ b/src/rules/singleton_rule.rs
@@ -11,9 +11,7 @@
 use ruff_diagnostics::Edit;
 
 use crate::config::Config;
-use crate::primitives::aligner;
-use crate::primitives::colon_targets::ColonEmitter;
-use crate::primitives::edit::singleton_groups;
+use crate::primitives::{aligner, colon_targets::ColonEmitter, edit::singleton_groups};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/strip_trailing_commas.rs
+++ b/src/rules/strip_trailing_commas.rs
@@ -6,7 +6,7 @@
 //! final non-trivia token is not a comma are left unchanged.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::visitor::{walk_arguments, walk_expr, walk_stmt, walk_type_params, Visitor};
+use ruff_python_ast::visitor::{Visitor, walk_arguments, walk_expr, walk_stmt, walk_type_params};
 use ruff_python_ast::{Arguments, Expr, Stmt, TypeParams};
 use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextRange, TextSize};

--- a/src/rules/strip_trailing_commas.rs
+++ b/src/rules/strip_trailing_commas.rs
@@ -13,10 +13,12 @@ use ruff_python_ast::{
 use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
-use crate::config::Config;
-use crate::primitives::edit::singleton_groups;
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::edit::singleton_groups,
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 pub(crate) struct StripTrailingCommas;
 

--- a/src/rules/strip_trailing_commas.rs
+++ b/src/rules/strip_trailing_commas.rs
@@ -6,8 +6,10 @@
 //! final non-trivia token is not a comma are left unchanged.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::visitor::{Visitor, walk_arguments, walk_expr, walk_stmt, walk_type_params};
-use ruff_python_ast::{Arguments, Expr, Stmt, TypeParams};
+use ruff_python_ast::{
+    Arguments, Expr, Stmt, TypeParams,
+    visitor::{Visitor, walk_arguments, walk_expr, walk_stmt, walk_type_params},
+};
 use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 

--- a/src/rules/unused_future_annotations.rs
+++ b/src/rules/unused_future_annotations.rs
@@ -13,10 +13,12 @@ use ruff_python_ast::{
 use ruff_source_file::LineRanges;
 use ruff_text_size::TextRange;
 
-use crate::config::Config;
-use crate::primitives::{binding::BindingAnalysis, edit::singleton_groups};
-use crate::rule::{Rule, RuleId};
-use crate::source::Source;
+use crate::{
+    config::Config,
+    primitives::{binding::BindingAnalysis, edit::singleton_groups},
+    rule::{Rule, RuleId},
+    source::Source,
+};
 
 const FUTURE_ANNOTATIONS: &str = "annotations";
 const FUTURE_MODULE: &str = "__future__";

--- a/src/rules/unused_future_annotations.rs
+++ b/src/rules/unused_future_annotations.rs
@@ -5,17 +5,16 @@
 //! is module-scope-defined before that annotation's offset.
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::helpers::any_over_expr;
-use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{
     AnyParameterRef, Expr, PythonVersion, Stmt, StmtAnnAssign, StmtFunctionDef, StmtImportFrom,
+    helpers::any_over_expr,
+    statement_visitor::{StatementVisitor, walk_stmt},
 };
 use ruff_source_file::LineRanges;
 use ruff_text_size::TextRange;
 
 use crate::config::Config;
-use crate::primitives::binding::BindingAnalysis;
-use crate::primitives::edit::singleton_groups;
+use crate::primitives::{binding::BindingAnalysis, edit::singleton_groups};
 use crate::rule::{Rule, RuleId};
 use crate::source::Source;
 

--- a/src/rules/unused_future_annotations.rs
+++ b/src/rules/unused_future_annotations.rs
@@ -6,7 +6,7 @@
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::any_over_expr;
-use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{
     AnyParameterRef, Expr, PythonVersion, Stmt, StmtAnnAssign, StmtFunctionDef, StmtImportFrom,
 };

--- a/src/source.rs
+++ b/src/source.rs
@@ -3,12 +3,12 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use ruff_python_ast::token::{Token, Tokens};
 use ruff_python_ast::ModModule;
-use ruff_python_parser::{parse_module, ParseError, Parsed};
-use ruff_python_trivia::{leading_indentation, lines_before, CommentRanges};
+use ruff_python_ast::token::{Token, Tokens};
+use ruff_python_parser::{ParseError, Parsed, parse_module};
+use ruff_python_trivia::{CommentRanges, leading_indentation, lines_before};
 use ruff_source_file::{
-    find_newline, LineColumn, LineEnding, LineRanges, OneIndexed, SourceFile, SourceFileBuilder,
+    LineColumn, LineEnding, LineRanges, OneIndexed, SourceFile, SourceFileBuilder, find_newline,
 };
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use thiserror::Error;

--- a/src/source.rs
+++ b/src/source.rs
@@ -3,8 +3,10 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use ruff_python_ast::ModModule;
-use ruff_python_ast::token::{Token, Tokens};
+use ruff_python_ast::{
+    ModModule,
+    token::{Token, Tokens},
+};
 use ruff_python_parser::{ParseError, Parsed, parse_module};
 use ruff_python_trivia::{CommentRanges, leading_indentation, lines_before};
 use ruff_source_file::{

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,7 +1,6 @@
 //! Source-text wrapper bundling parsed AST, token stream, and line index.
 
-use std::path::Path;
-use std::str::FromStr;
+use std::{path::Path, str::FromStr};
 
 use ruff_python_ast::{
     ModModule,
@@ -15,8 +14,7 @@ use ruff_source_file::{
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use thiserror::Error;
 
-use crate::primitives::binding::BindingAnalysis;
-use crate::suppression::SuppressionMap;
+use crate::{primitives::binding::BindingAnalysis, suppression::SuppressionMap};
 
 /// Owned wrapper around a parsed Python source file.
 ///

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -460,9 +460,11 @@ mod tests {
     fn nested_prose_off_after_non_pragma_hash_is_recognized() {
         let source = parse("# my note # prose: off\nx = 1\n");
         let x_offset = source.text().find('x').expect("x is present") as u32;
-        assert!(source
-            .suppression_map()
-            .intersects(range(x_offset, x_offset + 5)),);
+        assert!(
+            source
+                .suppression_map()
+                .intersects(range(x_offset, x_offset + 5)),
+        );
     }
 
     #[rstest]
@@ -477,9 +479,10 @@ mod tests {
     ) {
         let src = parse(text);
         let x_offset = src.text().find('x').expect("x is present") as u32;
-        assert!(src
-            .suppression_map()
-            .intersects(range(x_offset, x_offset + 5)));
+        assert!(
+            src.suppression_map()
+                .intersects(range(x_offset, x_offset + 5))
+        );
     }
 
     #[test]

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -16,7 +16,7 @@ use ruff_python_ast::PySourceType;
 /// source. Returns an empty iterator when `paths` is empty.
 pub(crate) fn walk(
     paths: &[PathBuf],
-) -> impl Iterator<Item = Result<PathBuf, ignore::Error>> + Send {
+) -> impl Iterator<Item = Result<PathBuf, ignore::Error>> + Send + use<> {
     let builder = paths.split_first().map(|(first, rest)| {
         let mut builder = WalkBuilder::new(first);
         for path in rest {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,8 +1,7 @@
 //! End-to-end tests against the `prose` binary, exercising
 //! `cli::run` and the exit-code matrix.
 
-use std::fs::write;
-use std::path::PathBuf;
+use std::{fs::write, path::PathBuf};
 
 use assert_cmd::Command;
 use pretty_assertions::assert_eq;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use assert_cmd::Command;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 
 fn fixture(name: &str, source: &str) -> (TempDir, PathBuf) {
     let dir = tempdir().expect("tempdir");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,13 +2,9 @@
 
 #![allow(dead_code)]
 
-use std::ffi::OsStr;
-use std::io::ErrorKind;
-use std::path::Path;
+use std::{ffi::OsStr, io::ErrorKind, path::Path};
 
-use prose::config::Config;
-use prose::pipeline::Pipeline;
-use prose::rule::RuleId;
+use prose::{config::Config, pipeline::Pipeline, rule::RuleId};
 use serde::Deserialize;
 use similar::TextDiff;
 

--- a/tests/diagnostics.rs
+++ b/tests/diagnostics.rs
@@ -4,8 +4,7 @@
 
 mod common;
 
-use prose::diagnostics::Diagnostic;
-use prose::source::Source;
+use prose::{diagnostics::Diagnostic, source::Source};
 
 fn render(diagnostics: &[Diagnostic]) -> String {
     let mut lines: Vec<String> = diagnostics

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,8 +2,7 @@
 
 mod common;
 
-use prose::pipeline::Pipeline;
-use prose::source::Source;
+use prose::{pipeline::Pipeline, source::Source};
 use ruff_python_formatter::{PyFormatOptions, format_module_source};
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,7 +4,7 @@ mod common;
 
 use prose::pipeline::Pipeline;
 use prose::source::Source;
-use ruff_python_formatter::{format_module_source, PyFormatOptions};
+use ruff_python_formatter::{PyFormatOptions, format_module_source};
 
 #[test]
 fn fixtures() {

--- a/tests/site.rs
+++ b/tests/site.rs
@@ -2,8 +2,10 @@
 //! registry and the per-case fixture tree, so a drifted `<Fixture>`
 //! pointer or a malformed `meta.toml` fails a test rather than a build.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
 
 use ignore::{WalkBuilder, types::TypesBuilder};
 use prose::pipeline::Pipeline;

--- a/tests/site.rs
+++ b/tests/site.rs
@@ -5,7 +5,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use ignore::{types::TypesBuilder, WalkBuilder};
+use ignore::{WalkBuilder, types::TypesBuilder};
 use prose::pipeline::Pipeline;
 use regex_lite::Regex;
 use serde::Deserialize;


### PR DESCRIPTION
### 🪻 Quick Summary

Adopts Rust edition 2024 across the crate and raises the MSRV to **1.96**, absorbing the language surface that floor unlocks as a behavior-preserving sweep where every snapshot stays **byte-identical**. The mechanical migration runs through `cargo fix`, the nested `if let` blocks that fold cleanly become let-chains, a const-context byte-range guard gives way to `is_ascii` predicates, and a handful of call sites compact through `map_or` and method references.

Alongside the edition work, the crate adopts nested-brace `use` grouping codebase-wide, consolidating every run of same-root `use` statements into one declaration per import group so the brace structure mirrors the path structure at a glance.

---

### 🗞️ Key Changes

- Migrates the crate to edition 2024 through `cargo fix`, adding `+ use<...>` precise-capture bounds to three iterator signatures and folding in the style-edition reformatting, and raises `rust-version` to `1.96` with the `README` badge moved to match.

- Folds every behavior-preserving nested `if let` into a let-chain, covering the two `loose-constants` blocks and `Config`'s pyproject-discovery branch, and swaps a `matches!` byte-range guard in `is_valid_slug` for `is_ascii_lowercase` and `is_ascii_digit`.

- Compacts several call sites, collapsing a `map`-then-`unwrap_or` into `map_or`, replacing two closures with `Ranged::end` and `Ranged::start` references, and dropping a redundant `+ '_` bound where `use<'_>` already pins the captured lifetime.

- Adopts nested-brace `use` grouping across `src` and `tests`, consolidating every run of same-root `use` statements into one declaration per import group, so each file carries at most one `use std::{...}`, one `use crate::{...}`, and so on per group.

---

### ☕ Implementation Notes

#### MSRV Moves to 1.96

The issue framed the floor as 1.95. The implementation raises `rust-version` to `1.96` to sit on the current stable, which both the edition-2024 work and the let-chain stabilization predate, so nothing in the sweep depends on the half-version bump beyond keeping the floor current. The `README` Rust badge moves with it, keeping the parity gate green.

#### Nested-Brace Imports Land Codebase-Wide

The import-grouping change is the file-count majority of this PR and sits beside the edition theme rather than under it. It reverses the prior single-level-only convention, after the nested shape *(`use crate::primitives::{INDENT_STEP, edit::{...}, range::...}`)* proved more legible than a column of one-line statements. Every same-root run consolidates into one declaration per import group, applied by a deterministic merge so the result is uniform rather than per-file judgment, leaving each file with at most one statement per root.

Imports carry no runtime weight, so behavior is untouched and the full suite stays green.

---

### 🧵 Related Issues

- Closes #183