### PR TITLE
[191] Animate the Before/After fixture toggle with Shiki magic-move

### DIFF
--- a/site/.vitepress/data/landing-typing-demo.data.ts
+++ b/site/.vitepress/data/landing-typing-demo.data.ts
@@ -3,10 +3,8 @@ import fs               from 'node:fs'
 import os               from 'node:os'
 import path             from 'node:path'
 
-import { getSingletonHighlighter }                   from 'shiki'
-import { codeToKeyedTokens, createMagicMoveMachine } from 'shiki-magic-move/core'
-import type { KeyedTokensInfo }                      from 'shiki-magic-move/types'
-import { defineLoader }                              from 'vitepress'
+import type { KeyedTokensInfo } from 'shiki-magic-move/types'
+import { defineLoader }         from 'vitepress'
 
 import { ENTRIES, PRELUDE, RESET_ROWS, RULES, SOURCE } from '../theme/components/landing/typing-demo-fixtures'
 import type {
@@ -14,8 +12,8 @@ import type {
   LandingTypingDemoEntry,
   LandingTypingDemoResetRow
 } from '../theme/components/landing/typing-demo-fixtures'
-import { SHIKI_THEMES } from '../lib/shared/constants'
-import { repoRoot }     from '../lib/shared/paths'
+import { precompileMagicMove } from '../lib/markdown/magic-move'
+import { repoRoot }            from '../lib/shared/paths'
 
 export type {
   LandingTypingDemoEditEntry,
@@ -53,25 +51,11 @@ export default defineLoader({
       }
     }
 
-    const highlighter = await getSingletonHighlighter({
-      langs  : ['python'],
-      themes : Object.values(SHIKI_THEMES)
-    })
-
-    const machine = createMagicMoveMachine(code =>
-      codeToKeyedTokens(highlighter, code, { lang: 'python', themes: SHIKI_THEMES })
-    )
-    const pythonStateSteps: KeyedTokensInfo[] = []
-    for (const state of states) {
-      const { current } = machine.commit(state)
-      pythonStateSteps.push(current)
-    }
-
     return {
-      entries   : ENTRIES,
-      prelude   : PRELUDE,
-      pythonStateSteps,
-      resetRows : RESET_ROWS
+      entries          : ENTRIES,
+      prelude          : PRELUDE,
+      pythonStateSteps : await precompileMagicMove(states),
+      resetRows        : RESET_ROWS
     }
   }
 })

--- a/site/.vitepress/lib/markdown/magic-move.ts
+++ b/site/.vitepress/lib/markdown/magic-move.ts
@@ -1,0 +1,19 @@
+import { codeToKeyedTokens, createMagicMoveMachine }                from 'shiki-magic-move/core'
+import type { KeyedTokensInfo }                                     from 'shiki-magic-move/types'
+import { createJavaScriptRegexEngine, getSingletonHighlighterCore } from 'shiki/core'
+
+import { SHIKI_THEMES } from '../shared/constants'
+
+// Commits each code state through one machine so consecutive steps share
+// token keys, which is what lets the renderer slide surviving tokens.
+export async function precompileMagicMove(states: readonly string[]): Promise<KeyedTokensInfo[]> {
+  const highlighter = await getSingletonHighlighterCore({
+    engine : createJavaScriptRegexEngine(),
+    langs  : [import('shiki/langs/python.mjs')],
+    themes : [import('shiki/themes/github-light.mjs'), import('shiki/themes/github-dark.mjs')]
+  })
+  const machine = createMagicMoveMachine(code =>
+    codeToKeyedTokens(highlighter, code, { lang: 'python', themes: SHIKI_THEMES })
+  )
+  return states.map(state => machine.commit(state).current)
+}

--- a/site/.vitepress/lib/markdown/magic-move.ts
+++ b/site/.vitepress/lib/markdown/magic-move.ts
@@ -1,6 +1,7 @@
-import { codeToKeyedTokens, createMagicMoveMachine }                from 'shiki-magic-move/core'
-import type { KeyedTokensInfo }                                     from 'shiki-magic-move/types'
-import { createJavaScriptRegexEngine, getSingletonHighlighterCore } from 'shiki/core'
+import { codeToKeyedTokens, createMagicMoveMachine } from 'shiki-magic-move/core'
+import type { KeyedTokensInfo }                      from 'shiki-magic-move/types'
+import { getSingletonHighlighterCore }               from 'shiki/core'
+import { createJavaScriptRegexEngine }               from 'shiki/engine/javascript'
 
 import { SHIKI_THEMES } from '../shared/constants'
 

--- a/site/.vitepress/theme/components/fixtures/Fixture.vue
+++ b/site/.vitepress/theme/components/fixtures/Fixture.vue
@@ -55,13 +55,12 @@ useEventListener('hashchange', syncWithHash)
     :data-family="family"
     :data-edits="entry.changesSource"
   >
-    <div class="fixture-card-summary-row">
+    <div class="fixture-card-summary-row" @click="toggle">
       <button
         type="button"
         class="fixture-card-summary"
         :aria-expanded="isOpen"
         :aria-controls="`${id}-body`"
-        @click="toggle"
       >
         <span class="fixture-card-num" aria-hidden="true" />
         <span class="fixture-card-title" v-html="titleHtml" />
@@ -69,6 +68,7 @@ useEventListener('hashchange', syncWithHash)
       <div
         class="fixture-card-actions"
         :class="{ 'is-active': isOpen }"
+        @click.stop
       >
         <FixtureToggle v-if="entry.changesSource" v-model="activeTab" />
         <FixtureNoChange v-else />

--- a/site/.vitepress/theme/components/fixtures/FixturePairDoc.vue
+++ b/site/.vitepress/theme/components/fixtures/FixturePairDoc.vue
@@ -64,7 +64,7 @@ const { stop } = useIntersectionObserver(root, ([entry]) => {
       :steps="steps"
       :step="step"
       :animate="animate && !reducedMotion"
-      :options="{ containerStyle: false, duration, stagger: 3 }"
+      :options="{ containerStyle: false, delayMove: 0, duration, stagger: 3 }"
     />
     <div v-else class="fixture-pair-panel" v-html="activeHtml" />
   </div>

--- a/site/.vitepress/theme/components/fixtures/FixturePairDoc.vue
+++ b/site/.vitepress/theme/components/fixtures/FixturePairDoc.vue
@@ -1,15 +1,71 @@
 <script setup lang="ts">
+import { useIntersectionObserver, useMediaQuery } from '@vueuse/core'
+import type { KeyedTokensInfo }                   from 'shiki-magic-move/types'
+import { computed, nextTick, ref, shallowRef, useTemplateRef } from 'vue'
+import type { Component }                         from 'vue'
+
 import type { FixtureTab } from '../../../lib/shared/fixture-tab'
 
-defineProps<{
+const props = defineProps<{
   activeTab  : FixtureTab
   inputHtml  : string
   outputHtml : string
 }>()
+
+const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
+const root          = useTemplateRef<HTMLElement>('root')
+
+const animate  = ref(false)
+const duration = ref(0)
+const panel    = shallowRef<Component | null>(null)
+const steps    = shallowRef<readonly KeyedTokensInfo[]>([])
+
+const activeHtml = computed(() => props.activeTab === 'before' ? props.inputHtml : props.outputHtml)
+const step       = computed(() => props.activeTab === 'before' ? 0 : 1)
+
+// Recover the source from a prebuilt highlight, reading only `<pre><code>` so
+// the lang chip and copy button stay out of the retokenized code.
+function codeFrom(html: string): string {
+  return new DOMParser().parseFromString(html, 'text/html')
+    .querySelector('pre code')?.textContent?.replace(/\s+$/, '') ?? ''
+}
+
+// Once the fixture scrolls into view, load the renderer and highlighter,
+// paint the active step, then enable motion for later toggles. The
+// `.fixture-card-rule` draw and the move share `--prose-rule-draw-ms`.
+async function prepare(): Promise<void> {
+  if (panel.value || reducedMotion.value) return
+  const before = codeFrom(props.inputHtml)
+  const after  = codeFrom(props.outputHtml)
+  if (before === after) return
+  const [{ precompileMagicMove }, { ShikiMagicMovePrecompiled }] = await Promise.all([
+    import('../../../lib/markdown/magic-move'),
+    import('shiki-magic-move/vue')
+  ])
+  const rootStyle = getComputedStyle(document.documentElement)
+  steps.value    = await precompileMagicMove([before, after])
+  duration.value = Number(rootStyle.getPropertyValue('--prose-rule-draw-ms'))
+  panel.value    = ShikiMagicMovePrecompiled
+  await nextTick()
+  animate.value = true
+}
+
+const { stop } = useIntersectionObserver(root, ([entry]) => {
+  if (entry.isIntersecting) { prepare(); stop() }
+})
 </script>
 
 <template>
-  <div class="fixture-pair fixture-pair-doc">
-    <div class="fixture-pair-panel" v-html="activeTab === 'before' ? inputHtml : outputHtml" />
+  <div ref="root" class="fixture-pair fixture-pair-doc">
+    <component
+      :is="panel"
+      v-if="panel"
+      class="fixture-pair-panel"
+      :steps="steps"
+      :step="step"
+      :animate="animate && !reducedMotion"
+      :options="{ containerStyle: false, duration, stagger: 3 }"
+    />
+    <div v-else class="fixture-pair-panel" v-html="activeHtml" />
   </div>
 </template>

--- a/site/.vitepress/theme/components/fixtures/FixturePairDoc.vue
+++ b/site/.vitepress/theme/components/fixtures/FixturePairDoc.vue
@@ -27,7 +27,7 @@ const step       = computed(() => props.activeTab === 'before' ? 0 : 1)
 // the lang chip and copy button stay out of the retokenized code.
 function codeFrom(html: string): string {
   return new DOMParser().parseFromString(html, 'text/html')
-    .querySelector('pre code')?.textContent?.replace(/\s+$/, '') ?? ''
+    .querySelector('pre code')?.textContent?.trimEnd() ?? ''
 }
 
 // Once the fixture scrolls into view, load the renderer and highlighter,

--- a/site/.vitepress/theme/components/fixtures/fixture-card.css
+++ b/site/.vitepress/theme/components/fixtures/fixture-card.css
@@ -209,7 +209,7 @@
   background       : var(--headline-paint, var(--family-color, var(--prose-c-chambray)));
   transform        : scaleX(0);
   transform-origin : left;
-  transition       : transform 0.42s ease;
+  transition       : transform calc(var(--prose-rule-draw-ms) * 1ms) ease;
 }
 
 .fixture-card.is-open .fixture-card-rule {

--- a/site/.vitepress/theme/components/fixtures/fixture-card.css
+++ b/site/.vitepress/theme/components/fixtures/fixture-card.css
@@ -59,6 +59,7 @@
   align-items           : center;
   gap                   : 12px;
   padding               : 4px 12px 4px 4px;
+  cursor                : pointer;
 }
 
 .fixture-card-summary {
@@ -90,33 +91,27 @@
 }
 
 .fixture-card-title {
-  justify-self            : start;
-  width                   : fit-content;
-  max-width               : 100%;
-  font-family             : var(--vp-font-family-mono);
-  font-weight             : 600;
-  font-size               : var(--prose-text-sm);
-  letter-spacing          : 0.02em;
-  line-height             : 1.35;
-  text-transform          : uppercase;
-  background              : var(--headline-paint, var(--family-color, var(--vp-c-text-1)));
-  -webkit-background-clip : text;
-  background-clip         : text;
-  color                   : transparent;
+  justify-self   : start;
+  width          : fit-content;
+  max-width      : 100%;
+  font-family    : var(--vp-font-family-mono);
+  font-weight    : 600;
+  font-size      : var(--prose-text-sm);
+  letter-spacing : 0.02em;
+  line-height    : 1.35;
+  text-transform : uppercase;
+  color          : var(--vp-c-text-1);
 }
 
 .fixture-card[data-edits="false"] .fixture-card-title {
-  background              : none;
-  color                   : var(--vp-c-text-3);
-  -webkit-text-fill-color : var(--vp-c-text-3);
+  color : var(--vp-c-text-3);
 }
 
 .fixture-card-title code {
-  font-family             : var(--vp-font-family-mono);
-  font-size               : 0.85em;
-  text-transform          : none;
-  color                   : var(--prose-c-ube);
-  -webkit-text-fill-color : var(--prose-c-ube);
+  font-family    : var(--vp-font-family-mono);
+  font-size      : 0.85em;
+  text-transform : none;
+  color          : var(--prose-c-ube);
 }
 
 .fixture-card-actions {

--- a/site/.vitepress/theme/components/fixtures/fixture.css
+++ b/site/.vitepress/theme/components/fixtures/fixture.css
@@ -84,3 +84,13 @@
   border-radius : 0;
   background    : transparent;
 }
+
+.fixture-pair-doc .shiki-magic-move-container {
+  margin      : 0;
+  padding     : 14px 16px;
+  background  : transparent;
+  font-family : var(--vp-font-family-mono);
+  font-size   : var(--prose-text-code);
+  line-height : 1.55;
+  overflow-x  : auto;
+}

--- a/site/.vitepress/theme/styles/tokens.css
+++ b/site/.vitepress/theme/styles/tokens.css
@@ -40,6 +40,7 @@
   --prose-transition             : 0.15s ease;
   --prose-transition-slow        : 0.2s ease;
   --prose-transition-card        : var(--prose-transition-slow);
+  --prose-rule-draw-ms           : 420;
 
   --prose-ease-emphasized        : cubic-bezier(0.4, 0, 0.2, 1);
 


### PR DESCRIPTION
### 🪻 Quick Summary

Animates the Before/After toggle on every `<Fixture>`, bringing the landing typing-demo's token motion to the docs-site's per-rule examples. Toggling between `before` and `after` once swapped one pre-rendered HTML blob for the other through `v-html`, an instant redraw with no motion, whereas the toggle now slides every surviving token to its new position through Shiki magic-move so a reader watches the formatting happen rather than blink between two stills. The motion runs in the same interval the fixture card's rule-divider draws on expansion, sourced from one `--prose-rule-draw-ms` token both sides read, such that the rule-line draw and the first toggle land as one gesture. The steps a fixture animates between compile lazily in the browser the first time a card scrolls into view, recovered from the highlight HTML already on the page, leaving the every-page data bundle flat rather than shipping precompiled steps for the whole fixture tree.

---

### 🗞️ Key Changes

- Reworks `FixturePairDoc` from a `v-html` swap into a lazy, in-view `ShikiMagicMovePrecompiled` render keyed `before` to step 0 and `after` to step 1, sliding surviving tokens between the two states while holding a static `v-html` fallback for the server render, `prefers-reduced-motion` readers, and no-change cases.

- Lifts the build-time magic-move precompile into a shared `precompileMagicMove` helper, so the landing typing-demo loader and the fixture toggle build their `KeyedTokensInfo` steps through one path over a singleton core highlighter rather than each standing up its own.

- Adds a `--prose-rule-draw-ms` token read by both the magic-move `duration` *(through `getComputedStyle`)* and the `.fixture-card-rule` draw transition, giving the rule-line interval one source of truth the two motions cannot drift from.

- Runs Shiki's JavaScript regex engine through the canonical `shiki/engine/javascript` entry, so the deferred toggle chunk carries no Oniguruma wasm, measured byte-identical to the static render across every fixture.

- Expands a fixture card from anywhere in its summary row *(holding the open toggle area inert)* and renders card titles in the default text color rather than the family color.

---

### ☕ Implementation Notes

#### Animating On First View

Nothing about the animation is built into the page data. When a fixture card first scrolls into view, it reads its two code snippets back out of the syntax-highlighted HTML the page already carries *(taking only the `<pre><code>` text, so the language label and copy button stay out of it)*. A shared helper re-highlights both snippets and tags the tokens that survive from one to the other, which is what lets the animation glide each token to its new place instead of repainting the whole block. The toggle then slides between those two tagged states, `before` first and `after` second.

The animation code itself loads on demand the moment that first scroll happens, so the JavaScript every page already loads does not grow, and only a reader who actually reaches a fixture downloads it, once *(~78 KB gzipped)*. The opening frame renders without animating, so nothing lurches on load and only a deliberate toggle slides. Readers who ask for reduced motion, the server-rendered first paint, and fixtures whose code does not change skip all of this and show the plain highlighted block.

---

### 🧵 Related Issues

- Closes #191
