### PR TITLE
[198] Finalize `0.3.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.96"
-version      = "0.2.3"
+version      = "0.3.0"
 
 [dependencies]
 annotate-snippets  = "=0.12.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires      = ["maturin>=1.7,<2.0"]
 [project]
 authors         = [{ name = "Jybbs" }]
 classifiers     = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes the third *Prose* release and lifts the `0.2.x` line into Beta. Bumps `Cargo.toml` from `0.2.3` to `0.3.0`, regenerates `Cargo.lock` against the new version, and promotes the PyPI development-status classifier from `3 - Alpha` to `4 - Beta`. The minor crosses that maturity tier on the strength of the `0.3` cycle, which stood up the documentation site at [prose.fyi](https://prose.fyi/), added the `align-comparisons` and `signature-layout` rules, regrouped the diagnostic stream so one logical fix surfaces as one diagnostic, and opened the configuration surface to shorthand `select` / `ignore` toggles and a standalone `prose.toml`.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` from `0.2.3` to `0.3.0` and regenerates `Cargo.lock` against the new version

- Promotes the PyPI development-status classifier from `3 - Alpha` to `4 - Beta`, the maturity tier the `0.2.x` line deferred until `0.3.0`

---

### 🧵 Related Issues

- Closes #198