### PR TITLE
[202] Explode inline call sites with three or more arguments to one per line

### DIFF
--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -84,6 +84,7 @@ The `[rules]` table holds one entry per rule you change. A bare bool is the shor
 | `docstring-entries` | bool | [[alphabetize]] | `true` | Reorder `name: description` entries within every Title-case-headed docstring section alongside the AST-level sorts. Set `false` to keep narrative-curated entry order while still sorting every other surface |
 | `max-atomics-per-line` | positive int \| `false` | [[collection-layout]] | `8` | Keep short collections on one line when each entry is an atomic literal and the run fits the cap. `false` removes the cap and packs by width alone |
 | `max-inline-dict-entries` | positive int \| `false` | [[collection-layout]] | `3` | Expand a dict once its entry count exceeds the cap, whatever its width. `false` disables the count trigger |
+| `max-inline-args` | positive int \| `false` | [[call-layout]] | `3` | Explode a call to one keyword argument per line once its argument count exceeds the cap. `false` disables the count trigger and leaves every call inline |
 | `allow` | list of module names | [[bare-imports]] | `["numpy", "pandas"]` | Modules whose bare-import form is preserved |
 | `allow` | list of names | [[loose-constants]] | `[]` | Module-level names exempted from the lint |
 | `allow-pattern` | regex | [[single-use-variables]] | `"^_"` | Binding names exempted from the lint |
@@ -106,7 +107,7 @@ Some rules answer a single yes-or-no question with no parameters worth tuning, s
 
 ### Rule-Specific Knobs
 
-Other rules read a project-specific input that *Prose* cannot guess from source alone, so each carries the knob shaped for its question. [[alphabetize]] takes `docstring-entries` for the docstring-entry reorder, [[bare-imports]] takes an `allow` list of modules whose bare-import form is preserved, [[collection-layout]] takes `max-atomics-per-line` to cap the inline-collection budget and `max-inline-dict-entries` to expand a dict past an entry count, [[loose-constants]] takes an `allow` list of exempt module-level names, and [[single-use-variables]] takes an `allow-pattern` regex for binding names that opt out of the lint.
+Other rules read a project-specific input that *Prose* cannot guess from source alone, so each carries the knob shaped for its question. [[alphabetize]] takes `docstring-entries` for the docstring-entry reorder, [[bare-imports]] takes an `allow` list of modules whose bare-import form is preserved, [[collection-layout]] takes `max-atomics-per-line` to cap the inline-collection budget and `max-inline-dict-entries` to expand a dict past an entry count, [[call-layout]] takes `max-inline-args` to explode a call past an argument count, [[loose-constants]] takes an `allow` list of exempt module-level names, and [[single-use-variables]] takes an `allow-pattern` regex for binding names that opt out of the lint.
 
 ## Docstring Budgets
 

--- a/site/rules/call-layout.md
+++ b/site/rules/call-layout.md
@@ -1,0 +1,28 @@
+---
+category : auto-fix
+family   : formatting
+caption  : "explodes a keyword-expressible call carrying more than the inline-argument cap to one keyword argument per line."
+related  : [alphabetize, collection-layout, signature-layout, strip-trailing-commas]
+layout   : doc
+---
+
+# call-layout
+
+<RuleLayout rule="call_layout">
+
+A call carrying enough arguments to read as a wall of positionals folds better one argument per line, where the eye reads each binding on its own and a later edit touches a single line. `call-layout` takes a call whose argument count exceeds `max-inline-args` and breaks it so each argument lands on its own line in keyword form, leaving shorter calls inline.
+
+The pass fires only on a call every argument of which is keyword-expressible. A positional argument resolves to its parameter name through the call site's in-module binding, so the exploded form reads `name=value` whatever order the source passed it. A positional-only prefix, a `*` or `**` unpacking, and a positional call whose callee does not resolve to a module function each leave the call inline, because the rule cannot name those arguments. The expanded form lays each argument one indent step past the call, the closing `)` dropping to the call's own indent, and a nested eligible call in an argument value explodes in the same pass.
+
+The rule reshapes layout and nothing more. Argument order stays with [`alphabetize`](/rules/alphabetize), which runs ahead of it, so disabling alphabetization leaves the exploded arguments in source order. The `=` spacing stays with [`align-equals`](/rules/align-equals), and whether the last argument carries a trailing comma stays with [`strip-trailing-commas`](/rules/strip-trailing-commas), which the explode carries through untouched.
+
+<template #configuration>
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `enabled` | bool | `true` | Toggle the rule on or off |
+| `max-inline-args` | positive int \| `false` | `3` | Cap on the argument count an inline call can carry. A call exceeding the cap explodes, so the default `3` explodes a call of four or more arguments. Setting `false` disables the count trigger and leaves every call inline |
+
+</template>
+
+</RuleLayout>

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,27 @@ impl Default for CacheConfig {
     }
 }
 
+/// Configuration for the `call_layout` rule.
+///
+/// `max_inline_args` caps the count threshold. A positive integer
+/// enforces the cap. `false` disables the count trigger.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct CallLayoutConfig {
+    pub enabled: bool,
+    #[serde(deserialize_with = "deserialize_max_inline_args")]
+    pub max_inline_args: Option<NonZeroUsize>,
+}
+
+impl Default for CallLayoutConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_inline_args: NonZeroUsize::new(3),
+        }
+    }
+}
+
 /// Configuration for the `collection_layout` rule.
 ///
 /// `max_atomics_per_line` and `max_inline_dict_entries` each take a
@@ -399,6 +420,7 @@ impl_rule_toggle!(
     AlignmentConfig,
     AlphabetizeConfig,
     BareImportsConfig,
+    CallLayoutConfig,
     CollectionLayoutConfig,
     LooseConstantsConfig,
     SignatureLayoutConfig,
@@ -484,6 +506,7 @@ macro_rules! optional_cap {
 }
 
 optional_cap!(deserialize_max_atomics_per_line, "max-atomics-per-line");
+optional_cap!(deserialize_max_inline_args, "max-inline-args");
 optional_cap!(
     deserialize_max_inline_dict_entries,
     "max-inline-dict-entries"

--- a/src/diagnostics/github.rs
+++ b/src/diagnostics/github.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 
 use ruff_source_file::SourceFile;
 
-use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns};
+use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, diagnostics, line_columns};
 
 pub(crate) struct Github;
 
@@ -15,10 +15,8 @@ impl Emitter for Github {
         runs: &[Run<'_>],
         _summary: &EmitterSummary,
     ) -> io::Result<()> {
-        for (file, diagnostics) in runs {
-            for diag in *diagnostics {
-                emit_one(writer, file, diag)?;
-            }
+        for (file, diag) in diagnostics(runs) {
+            emit_one(writer, file, diag)?;
         }
         Ok(())
     }

--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -13,7 +13,8 @@ use serde::Serialize;
 
 use crate::{
     diagnostics::{
-        Diagnostic, Emitter, EmitterSummary, Run, Severity, line_columns, write_json_line,
+        Diagnostic, Emitter, EmitterSummary, Run, Severity, diagnostics, line_columns,
+        write_json_line,
     },
     rule::RuleId,
 };
@@ -31,13 +32,11 @@ impl Emitter for Json {
         runs: &[Run<'_>],
         summary: &EmitterSummary,
     ) -> io::Result<()> {
-        for (file, diagnostics) in runs {
-            for diag in *diagnostics {
-                write_json_line(
-                    writer,
-                    &JsonRecord::Diagnostic(JsonDiagnostic::new(file, diag, true)),
-                )?;
-            }
+        for (file, diag) in diagnostics(runs) {
+            write_json_line(
+                writer,
+                &JsonRecord::Diagnostic(JsonDiagnostic::new(file, diag, true)),
+            )?;
         }
         write_json_line(writer, &JsonRecord::Summary(JsonSummary::new(summary)))
     }

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -48,6 +48,15 @@ pub(crate) struct EmitterSummary {
     pub(crate) rules_fired: BTreeMap<RuleId, usize>,
 }
 
+/// Flattens every run into its `(file, diagnostic)` pairs in
+/// file-major order, the traversal each emitter walks.
+pub(crate) fn diagnostics<'a>(
+    runs: &'a [Run<'a>],
+) -> impl Iterator<Item = (&'a SourceFile, &'a Diagnostic)> {
+    runs.iter()
+        .flat_map(|(file, ds)| ds.iter().map(move |d| (*file, d)))
+}
+
 pub(crate) fn line_columns(file: &SourceFile, range: TextRange) -> (LineColumn, LineColumn) {
     let code = file.to_source_code();
     (

--- a/src/diagnostics/sarif.rs
+++ b/src/diagnostics/sarif.rs
@@ -15,7 +15,9 @@ use serde_sarif::sarif::{
 };
 
 use crate::{
-    diagnostics::{Diagnostic, Emitter, EmitterSummary, Run, line_columns, write_json_line},
+    diagnostics::{
+        Diagnostic, Emitter, EmitterSummary, Run, diagnostics, line_columns, write_json_line,
+    },
     rule::RuleId,
 };
 
@@ -41,8 +43,8 @@ fn artifact_location(file: &SourceFile) -> ArtifactLocation {
 }
 
 fn collect_rule_ids(runs: &[Run<'_>]) -> Vec<RuleId> {
-    runs.iter()
-        .flat_map(|(_, diagnostics)| diagnostics.iter().map(|d| d.rule))
+    diagnostics(runs)
+        .map(|(_, d)| d.rule)
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
@@ -109,11 +111,8 @@ fn sarif_run(runs: &[Run<'_>]) -> SarifRun {
         .iter()
         .map(|id| ReportingDescriptor::builder().id(id.as_str()).build())
         .collect();
-    let results: Vec<SarifResult> = runs
-        .iter()
-        .flat_map(|(file, diagnostics)| {
-            diagnostics.iter().map(move |diag| sarif_result(file, diag))
-        })
+    let results: Vec<SarifResult> = diagnostics(runs)
+        .map(|(file, diag)| sarif_result(file, diag))
         .collect();
     SarifRun::builder()
         .tool(

--- a/src/diagnostics/text.rs
+++ b/src/diagnostics/text.rs
@@ -6,7 +6,7 @@ use std::io::{self, Write};
 use annotate_snippets::{AnnotationKind, Level, Patch, Renderer, Snippet};
 use ruff_text_size::Ranged;
 
-use crate::diagnostics::{Emitter, EmitterSummary, Run};
+use crate::diagnostics::{Emitter, EmitterSummary, Run, diagnostics};
 
 pub(crate) struct Text {
     renderer: Renderer,
@@ -27,33 +27,31 @@ impl Emitter for Text {
         runs: &[Run<'_>],
         _summary: &EmitterSummary,
     ) -> io::Result<()> {
-        for (file, diagnostics) in runs {
-            for diag in *diagnostics {
-                let warning = Level::WARNING.primary_title(diag.message.as_str()).element(
-                    Snippet::source(file.source_text())
-                        .line_start(1)
-                        .path(file.name())
-                        .annotation(
-                            AnnotationKind::Primary
-                                .span(diag.range.to_std_range())
-                                .label(diag.rule.as_str()),
-                        ),
-                );
-                let mut groups = vec![warning];
-                if let Some(fix) = &diag.fix {
-                    let snippet = Snippet::source(file.source_text())
-                        .line_start(1)
-                        .path(file.name())
-                        .patches(fix.edits().iter().map(|edit| {
-                            Patch::new(
-                                edit.range().to_std_range(),
-                                edit.content().unwrap_or_default(),
-                            )
-                        }));
-                    groups.push(Level::HELP.secondary_title("replace with").element(snippet));
-                }
-                writeln!(writer, "{}", self.renderer.render(&groups))?;
+        for (file, diag) in diagnostics(runs) {
+            let warning = Level::WARNING.primary_title(diag.message.as_str()).element(
+                Snippet::source(file.source_text())
+                    .line_start(1)
+                    .path(file.name())
+                    .annotation(
+                        AnnotationKind::Primary
+                            .span(diag.range.to_std_range())
+                            .label(diag.rule.as_str()),
+                    ),
+            );
+            let mut groups = vec![warning];
+            if let Some(fix) = &diag.fix {
+                let snippet = Snippet::source(file.source_text())
+                    .line_start(1)
+                    .path(file.name())
+                    .patches(fix.edits().iter().map(|edit| {
+                        Patch::new(
+                            edit.range().to_std_range(),
+                            edit.content().unwrap_or_default(),
+                        )
+                    }));
+                groups.push(Level::HELP.secondary_title("replace with").element(snippet));
             }
+            writeln!(writer, "{}", self.renderer.render(&groups))?;
         }
         Ok(())
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -527,6 +527,7 @@ mod tests {
         config.rules.alphabetize.enabled = false;
         config.rules.bare_imports.enabled = false;
         config.rules.blank_lines.enabled = false;
+        config.rules.call_layout.enabled = false;
         config.rules.collection_layout.enabled = false;
         config.rules.docstring_expand.enabled = false;
         config.rules.docstring_frame.enabled = false;

--- a/src/primitives/call_keywords.rs
+++ b/src/primitives/call_keywords.rs
@@ -1,0 +1,120 @@
+//! Renders a call's arguments in keyword form for the rules that
+//! reshape call sites. [`keyword_args`] names each argument when the
+//! whole call can take keyword form, [`module_call_params`] maps
+//! in-module call sites to the signature they bind, and
+//! [`pins_positional_params`] flags a positional-binding decorator.
+
+use std::{borrow::Cow, collections::HashMap};
+
+use itertools::Itertools;
+use ruff_python_ast::{Expr, ExprCall, ParameterWithDefault, Parameters, Stmt, StmtFunctionDef};
+use ruff_text_size::{Ranged, TextRange, TextSize};
+
+use crate::source::Source;
+
+/// Every nameable argument of a call in source order, paired with the
+/// count of leading positional-only arguments that keep their slot.
+pub(crate) struct CallKeywords<'src> {
+    pub args: Vec<KeywordArg<'src>>,
+    pub posonly_prefix: usize,
+}
+
+/// One argument of a call rendered as a `name=value` keyword binding.
+pub(crate) struct KeywordArg<'src> {
+    /// The argument's source extent, the edit block.
+    pub block: TextRange,
+    /// The bound parameter or keyword name, the alphabetization key.
+    pub name: &'src str,
+    /// The `name=value` text, borrowed for a keyword already in that
+    /// form and owned for a positional argument named from its parameter.
+    pub rendered: Cow<'src, str>,
+    /// The argument's value expression, the recursion point for a
+    /// consumer that reshapes a nested call.
+    pub value: &'src Expr,
+}
+
+/// Renders `call`'s arguments past any positional-only prefix as
+/// keyword bindings, in source order. `params` carries the resolved
+/// signature when the callee binds a module function, or `None` when
+/// the callee is external. Returns `None` when an argument cannot take
+/// keyword form: a positional argument without a resolved name, a `*`
+/// or `**` unpacking, overflow past the named parameters, or a
+/// duplicate key.
+pub(crate) fn keyword_args<'src>(
+    source: &'src Source,
+    call: &'src ExprCall,
+    params: Option<&'src Parameters>,
+) -> Option<CallKeywords<'src>> {
+    let positional = &call.arguments.args;
+    let keywords = &call.arguments.keywords;
+    if positional.iter().any(Expr::is_starred_expr) || keywords.iter().any(|kw| kw.arg.is_none()) {
+        return None;
+    }
+    if !positional.is_empty() && params.is_none() {
+        return None;
+    }
+    let posonly = params.map_or(0, |p| p.posonlyargs.len());
+    let named_params: &[ParameterWithDefault] = params.map_or(&[], |p| &p.args);
+    if positional.len() > posonly + named_params.len() {
+        return None;
+    }
+    let args: Vec<KeywordArg> = positional
+        .iter()
+        .skip(posonly)
+        .zip(named_params)
+        .map(|(arg, param)| {
+            let name = param.name().as_str();
+            KeywordArg {
+                block: arg.range(),
+                name,
+                rendered: Cow::Owned(format!("{name}={}", source.slice(arg))),
+                value: arg,
+            }
+        })
+        .chain(keywords.iter().map(|kw| KeywordArg {
+            block: kw.range(),
+            name: kw.arg.as_deref().expect("`**` keyword excluded above"),
+            rendered: Cow::Borrowed(source.slice(kw)),
+            value: &kw.value,
+        }))
+        .collect();
+    args.iter()
+        .map(|arg| arg.name)
+        .all_unique()
+        .then_some(CallKeywords {
+            posonly_prefix: positional.len().min(posonly),
+            args,
+        })
+}
+
+/// Maps each in-module call's callee offset to the parameters of the
+/// top-level function it resolves to, over every function `accept`
+/// admits whose decorators do not bind by position and whose name binds
+/// uniquely to that one definition. Offsets come from `BindingAnalysis`,
+/// so a shadowing local or aliased reference resolves elsewhere.
+pub(crate) fn module_call_params<'src>(
+    source: &'src Source,
+    mut accept: impl FnMut(&'src StmtFunctionDef) -> bool,
+) -> HashMap<TextSize, &'src Parameters> {
+    let analysis = source.binding_analysis();
+    source
+        .ast()
+        .body
+        .iter()
+        .filter_map(Stmt::as_function_def_stmt)
+        .filter(|&func| !pins_positional_params(func) && accept(func))
+        .filter_map(|func| Some((analysis.module_function_reads(func.name.as_str())?, func)))
+        .flat_map(|(reads, func)| reads.iter().map(move |&offset| (offset, &*func.parameters)))
+        .collect()
+}
+
+/// True when any of `f`'s decorators is a `Call` carrying positional
+/// arguments, signalling the decorator may bind values into the
+/// signature by position.
+pub(crate) fn pins_positional_params(f: &StmtFunctionDef) -> bool {
+    f.decorator_list.iter().any(|d| {
+        d.expression
+            .as_call_expr()
+            .is_some_and(|c| !c.arguments.args.is_empty())
+    })
+}

--- a/src/primitives/docstring.rs
+++ b/src/primitives/docstring.rs
@@ -38,6 +38,13 @@ pub(crate) struct DocstringBody<'a> {
     pub(crate) text: &'a str,
 }
 
+impl DocstringBody<'_> {
+    /// True when the body spans more than one line.
+    pub(crate) fn is_multiline(&self) -> bool {
+        self.text.contains('\n')
+    }
+}
+
 /// Receiver for the docstring walker. Implementors handle each
 /// docstring `StringLiteral` reached in source order. Call `walk`
 /// to drive the receiver across `source`'s module body.
@@ -52,6 +59,67 @@ pub(crate) trait DocstringHandler {
         let body = &source.ast().body;
         visitor.consider(body);
         visitor.visit_body(body);
+    }
+}
+
+/// The classification of a docstring body line by the shared fence,
+/// blank, and list scanner. Every variant but `Body` is terminal for
+/// the line; `Body` hands the line to the walker's own dispatch.
+pub(crate) enum LineScan {
+    Blank,
+    Body,
+    Fence,
+    InFence,
+    ListContinuation,
+    ListMarker,
+}
+
+/// The fence and list state a docstring walker carries across lines.
+/// [`LineScanner::classify`] advances the state per line and returns
+/// its [`LineScan`], leaving each walker to dispatch its own effect.
+pub(crate) struct LineScanner {
+    body_indent_chars: usize,
+    in_fence: bool,
+    list_indent: Option<usize>,
+}
+
+impl LineScanner {
+    pub(crate) fn new(body_indent_chars: usize) -> Self {
+        Self {
+            body_indent_chars,
+            in_fence: false,
+            list_indent: None,
+        }
+    }
+
+    pub(crate) fn body_indent_chars(&self) -> usize {
+        self.body_indent_chars
+    }
+
+    pub(crate) fn classify(&mut self, trimmed: &str, indent_chars: usize) -> LineScan {
+        if trimmed.starts_with("```") {
+            self.in_fence = !self.in_fence;
+            self.list_indent = None;
+            return LineScan::Fence;
+        }
+        if self.in_fence {
+            return LineScan::InFence;
+        }
+        if trimmed.is_empty() {
+            self.list_indent = None;
+            return LineScan::Blank;
+        }
+        if let Some(marker) = self.list_indent {
+            if indent_chars > marker {
+                return LineScan::ListContinuation;
+            }
+            self.list_indent = None;
+        }
+        if indent_chars >= self.body_indent_chars && is_list_marker(trimmed) {
+            self.list_indent = Some(indent_chars);
+            return LineScan::ListMarker;
+        }
+        LineScan::Body
     }
 }
 
@@ -71,22 +139,18 @@ impl Ranged for SectionEntry<'_> {
 }
 
 struct EntryWalker<'src> {
-    body_indent_chars: usize,
-    in_fence: bool,
-    list_indent: Option<usize>,
     open_entry: Option<SectionEntry<'src>>,
     open_section: Option<Vec<SectionEntry<'src>>>,
+    scanner: LineScanner,
     sections: Vec<Vec<SectionEntry<'src>>>,
 }
 
 impl<'src> EntryWalker<'src> {
     fn new(body_indent_chars: usize) -> Self {
         Self {
-            body_indent_chars,
-            in_fence: false,
-            list_indent: None,
             open_entry: None,
             open_section: None,
+            scanner: LineScanner::new(body_indent_chars),
             sections: Vec::new(),
         }
     }
@@ -100,33 +164,27 @@ impl<'src> EntryWalker<'src> {
         let trimmed = &text[indent_str.len()..];
         let indent_chars = indent_str.chars().count();
 
-        if trimmed.starts_with("```") {
-            self.in_fence = !self.in_fence;
-            self.extend_open_entry(line_end);
-            self.list_indent = None;
-            return;
-        }
-        if self.in_fence {
-            self.extend_open_entry(line_end);
-            return;
-        }
-        if trimmed.is_empty() {
-            self.list_indent = None;
-            return;
-        }
-        if let Some(marker) = self.list_indent {
-            if indent_chars > marker {
+        match self.scanner.classify(trimmed, indent_chars) {
+            LineScan::Blank => {}
+            LineScan::Body => self.consume_body(line_start, line_end, trimmed, indent_chars),
+            LineScan::Fence
+            | LineScan::InFence
+            | LineScan::ListContinuation
+            | LineScan::ListMarker => {
                 self.extend_open_entry(line_end);
-                return;
             }
-            self.list_indent = None;
         }
-        if indent_chars >= self.body_indent_chars && is_list_marker(trimmed) {
-            self.list_indent = Some(indent_chars);
-            self.extend_open_entry(line_end);
-            return;
-        }
-        if indent_chars == self.body_indent_chars {
+    }
+
+    fn consume_body(
+        &mut self,
+        line_start: TextSize,
+        line_end: TextSize,
+        trimmed: &'src str,
+        indent_chars: usize,
+    ) {
+        let body_indent = self.scanner.body_indent_chars();
+        if indent_chars == body_indent {
             self.finish_section();
             if section_heading(trimmed) {
                 self.open_section = Some(Vec::new());
@@ -136,7 +194,7 @@ impl<'src> EntryWalker<'src> {
         if self.open_section.is_none() {
             return;
         }
-        if indent_chars == self.body_indent_chars + 4 && entry_description_col(trimmed).is_some() {
+        if indent_chars == body_indent + 4 && entry_description_col(trimmed).is_some() {
             self.finish_entry();
             self.open_entry = Some(SectionEntry {
                 name: entry_name(trimmed),
@@ -211,7 +269,7 @@ pub(crate) fn entry_carrying_sections<'src>(
     source: &'src Source,
     lit: &StringLiteral,
 ) -> Vec<Vec<SectionEntry<'src>>> {
-    let Some(body) = triple_quoted_body(source, lit).filter(|b| b.text.contains('\n')) else {
+    let Some(body) = triple_quoted_body(source, lit).filter(|b| b.is_multiline()) else {
         return Vec::new();
     };
     let mut walker = EntryWalker::new(indent_prefix(source, lit).chars().count());
@@ -234,21 +292,6 @@ pub(crate) fn entry_description_col(trimmed: &str) -> Option<usize> {
 /// preserving the source's mix of tabs and spaces verbatim.
 pub(crate) fn indent_prefix<'a>(source: &'a Source, lit: &StringLiteral) -> &'a str {
     leading_indentation(source.text().line_str(lit.start()))
-}
-
-/// True when `trimmed` opens with a Markdown list marker (`-`, `*`,
-/// or `+` followed by a space) or a numeric marker (one or more
-/// digits followed by `. `). Used by docstring walkers to recognize
-/// verbatim-passthrough list items.
-pub(crate) fn is_list_marker(trimmed: &str) -> bool {
-    if trimmed
-        .strip_prefix(['-', '*', '+'])
-        .is_some_and(|rest| rest.starts_with(' '))
-    {
-        return true;
-    }
-    let after_digits = trimmed.trim_start_matches(|c: char| c.is_ascii_digit());
-    after_digits.len() < trimmed.len() && after_digits.starts_with(". ")
 }
 
 /// Walks every docstring in `source` and collects the edits produced
@@ -315,6 +358,21 @@ pub(crate) fn triple_quoted_body<'a>(
 fn entry_name(trimmed: &str) -> &str {
     let colon = trimmed.find(':').expect("entry head carries a colon");
     trimmed[..colon].trim_end()
+}
+
+/// True when `trimmed` opens with a Markdown list marker (`-`, `*`,
+/// or `+` followed by a space) or a numeric marker (one or more
+/// digits followed by `. `). Used by the shared line scanner to
+/// recognize verbatim-passthrough list items.
+fn is_list_marker(trimmed: &str) -> bool {
+    if trimmed
+        .strip_prefix(['-', '*', '+'])
+        .is_some_and(|rest| rest.starts_with(' '))
+    {
+        return true;
+    }
+    let after_digits = trimmed.trim_start_matches(|c: char| c.is_ascii_digit());
+    after_digits.len() < trimmed.len() && after_digits.starts_with(". ")
 }
 
 #[cfg(test)]

--- a/src/primitives/layout.rs
+++ b/src/primitives/layout.rs
@@ -1,0 +1,31 @@
+//! Shared text builders for one-per-line expansion.
+
+use crate::primitives::INDENT_STEP;
+
+/// Builds the one-per-line expansion `(\n<prefix>item,\n…\n<indent>)`
+/// for `count` items at `indent`. `render` writes item `i` into the
+/// buffer and `comma` decides whether item `i` carries a trailing
+/// comma. Items sit one `INDENT_STEP` past `indent`, the closing `)`
+/// at `indent`.
+pub(crate) fn explode_parens(
+    newline: &str,
+    indent: usize,
+    count: usize,
+    mut render: impl FnMut(&mut String, usize),
+    comma: impl Fn(usize) -> bool,
+) -> String {
+    let prefix = " ".repeat(indent + INDENT_STEP);
+    let mut out = String::from("(");
+    for i in 0..count {
+        out.push_str(newline);
+        out.push_str(&prefix);
+        render(&mut out, i);
+        if comma(i) {
+            out.push(',');
+        }
+    }
+    out.push_str(newline);
+    out.extend(std::iter::repeat_n(' ', indent));
+    out.push(')');
+    out
+}

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod aligner;
 pub(crate) mod binding;
+pub(crate) mod call_keywords;
 pub(crate) mod colon_targets;
 pub(crate) mod docstring;
 pub(crate) mod edit;

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod colon_targets;
 pub(crate) mod docstring;
 pub(crate) mod edit;
 pub(crate) mod imports;
+pub(crate) mod layout;
 pub(crate) mod orderer;
 pub(crate) mod range;
 pub(crate) mod scope;

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -15,20 +15,22 @@ use thiserror::Error;
 
 use crate::{
     config::{
-        AlignmentConfig, AlphabetizeConfig, BareImportsConfig, CollectionLayoutConfig, Config,
-        LooseConstantsConfig, SignatureLayoutConfig, SingleUseVariablesConfig, ToggleOnly,
+        AlignmentConfig, AlphabetizeConfig, BareImportsConfig, CallLayoutConfig,
+        CollectionLayoutConfig, Config, LooseConstantsConfig, SignatureLayoutConfig,
+        SingleUseVariablesConfig, ToggleOnly,
     },
     diagnostics::Diagnostic,
     pipeline::Pipeline,
     rules::{
         align_colons::AlignColons, align_comparisons::AlignComparisons, align_equals::AlignEquals,
         align_imports::AlignImports, align_match_case::AlignMatchCase, alphabetize::Alphabetize,
-        bare_imports::BareImports, blank_lines::BlankLines, collection_layout::CollectionLayout,
-        docstring_expand::DocstringExpand, docstring_frame::DocstringFrame,
-        docstring_wrap::DocstringWrap, legacy_union_syntax::LegacyUnionSyntax,
-        loose_constants::LooseConstants, signature_layout::SignatureLayout,
-        single_use_variables::SingleUseVariables, step_narration::StepNarration,
-        strip_align_padding::StripAlignPadding, strip_trailing_commas::StripTrailingCommas,
+        bare_imports::BareImports, blank_lines::BlankLines, call_layout::CallLayout,
+        collection_layout::CollectionLayout, docstring_expand::DocstringExpand,
+        docstring_frame::DocstringFrame, docstring_wrap::DocstringWrap,
+        legacy_union_syntax::LegacyUnionSyntax, loose_constants::LooseConstants,
+        signature_layout::SignatureLayout, single_use_variables::SingleUseVariables,
+        step_narration::StepNarration, strip_align_padding::StripAlignPadding,
+        strip_trailing_commas::StripTrailingCommas,
         unused_future_annotations::UnusedFutureAnnotations,
     },
     source::Source,
@@ -302,6 +304,7 @@ macro_rules! register_rules {
 register_rules! {
     "collection-layout":         collection_layout:         CollectionLayoutConfig   => CollectionLayout        => "lay out collection literal against the line budget",
     "alphabetize":               alphabetize:               AlphabetizeConfig        => Alphabetize             => "alphabetize this group",
+    "call-layout":               call_layout:               CallLayoutConfig         => CallLayout              => "explode call arguments to one keyword per line",
     "strip-trailing-commas":     strip_trailing_commas:     ToggleOnly               => StripTrailingCommas     => "strip trailing comma",
     "docstring-expand":          docstring_expand:          ToggleOnly               => DocstringExpand         => "expand single-line docstring to multi-line form",
     "docstring-frame":           docstring_frame:           ToggleOnly               => DocstringFrame          => "place docstring opener and closer on their own lines",

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -40,6 +40,7 @@ use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use crate::{
     config::Config,
     primitives::{
+        call_keywords::{keyword_args, module_call_params, pins_positional_params},
         docstring::{entry_carrying_sections, rewrite_docstrings},
         edit::{apply_inline_edits, narrowed_replacement, singleton_groups},
         imports::{ImportGroup, import_group},
@@ -204,38 +205,19 @@ impl<'a> LeafCollector<'a> {
         let Some(&params) = self.rewrite_targets.get(&callee.range().start()) else {
             return false;
         };
-        let (args, keywords) = (&c.arguments.args, &c.arguments.keywords);
-        let posonly = params.posonlyargs.len();
-        if args.len() <= posonly
-            || args.len() > posonly + params.args.len()
-            || args.iter().any(Expr::is_starred_expr)
-            || keywords.iter().any(|kw| kw.arg.is_none())
-        {
+        let Some(keywords) = keyword_args(self.source, c, Some(params)) else {
+            return false;
+        };
+        // A call whose positional arguments are all positional-only has
+        // nothing to convert; the plain keyword reorder sorts it instead.
+        if c.arguments.args.len() <= keywords.posonly_prefix {
             return false;
         }
-        let (blocks, keys, rendered): (Vec<TextRange>, Vec<&str>, Vec<Cow<'a, str>>) = args
-            .iter()
-            .skip(posonly)
-            .zip(&params.args)
-            .map(|(arg, param)| {
-                let name = param.name().as_str();
-                (
-                    arg.range(),
-                    name,
-                    Cow::Owned(format!("{name}={}", self.source.slice(arg))),
-                )
-            })
-            .chain(keywords.iter().map(|kw| {
-                (
-                    kw.range(),
-                    kw.arg.as_deref().expect("`**` excluded above"),
-                    Cow::Borrowed(self.source.slice(kw)),
-                )
-            }))
+        let (blocks, keys, rendered): (Vec<TextRange>, Vec<&str>, Vec<Cow<'a, str>>) = keywords
+            .args
+            .into_iter()
+            .map(|arg| (arg.block, arg.name, arg.rendered))
             .multiunzip();
-        if !keys.iter().all_unique() {
-            return false;
-        }
         let mut order: Vec<usize> = (0..keys.len()).collect();
         order.sort_unstable_by_key(|&i| keys[i]);
         let assembled = assemble_blocks(self.source, &blocks, &rendered, &order, |_| None);
@@ -368,22 +350,10 @@ fn assign_run_target(stmt: &Stmt) -> Option<(&str, Option<&Expr>)> {
 }
 
 /// Maps each in-module call's callee offset to the parameters of the
-/// top-level function it resolves to, covering every function whose
-/// positional `args` reorder, whose decorators do not pin position, and
-/// whose name binds uniquely to that one definition. The offsets come
-/// from `BindingAnalysis`, so a shadowing local or an aliased reference
-/// resolves to its own binding and never lands here.
+/// top-level function it resolves to, restricted to functions whose
+/// positional `args` reorder under alphabetization.
 fn call_rewrite_targets(source: &Source) -> HashMap<TextSize, &Parameters> {
-    let analysis = source.binding_analysis();
-    source
-        .ast()
-        .body
-        .iter()
-        .filter_map(Stmt::as_function_def_stmt)
-        .filter(|&func| !pins_positional_params(func) && args_reorder(&func.parameters))
-        .filter_map(|func| Some((analysis.module_function_reads(func.name.as_str())?, func)))
-        .flat_map(|(reads, func)| reads.iter().map(move |&offset| (offset, &*func.parameters)))
-        .collect()
+    module_call_params(source, |func| args_reorder(&func.parameters))
 }
 
 /// Returns the slot ranges of consecutive items whose pairwise
@@ -723,17 +693,6 @@ fn partition_divider_slots(source: &Source, order: &[usize], items: &[DictItem])
         .filter(|(_, w)| is_multiline(w[0]) || is_multiline(w[1]))
         .map(|(i, _)| i)
         .collect()
-}
-
-/// True when any of `f`'s decorators is a `Call` carrying positional
-/// arguments, signalling the decorator may bind values into the
-/// signature by position.
-fn pins_positional_params(f: &StmtFunctionDef) -> bool {
-    f.decorator_list.iter().any(|d| {
-        d.expression
-            .as_call_expr()
-            .is_some_and(|c| !c.arguments.args.is_empty())
-    })
 }
 
 /// Rewrites a non-empty body, returning the rewritten text alongside

--- a/src/rules/blank_lines.rs
+++ b/src/rules/blank_lines.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::{
     helpers::is_docstring_stmt,
     statement_visitor::{StatementVisitor, walk_stmt},
 };
-use ruff_python_trivia::{BackwardsTokenizer, CommentRanges, lines_after, lines_before};
+use ruff_python_trivia::{CommentRanges, lines_after, lines_before};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
@@ -191,9 +191,8 @@ fn function_scope_blanks(prev: &Stmt, curr: &Stmt) -> Option<u32> {
 /// landing on the first non-trivia token. Falls back to `body_start`
 /// when the scan finds none.
 fn header_signature_end(source: &Source, body_start: TextSize) -> TextSize {
-    BackwardsTokenizer::up_to(body_start, source.text(), source.comment_ranges())
-        .skip_trivia()
-        .next()
+    source
+        .prev_non_trivia_token(body_start)
         .map_or(body_start, |t| t.end())
 }
 

--- a/src/rules/call_layout.rs
+++ b/src/rules/call_layout.rs
@@ -1,0 +1,171 @@
+//! Explodes a keyword-expressible call carrying more than
+//! `max_inline_args` arguments to one keyword argument per line, leaving
+//! shorter calls and calls that cannot take keyword form inline. The
+//! closing `)` drops to the call's own indent, and a nested call in an
+//! argument value explodes in the same pass. Argument order, `=`
+//! alignment, and trailing-comma policy stay with `alphabetize`,
+//! `align_equals`, and `strip_trailing_commas`.
+
+use std::{collections::HashMap, num::NonZeroUsize};
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::{
+    Expr, ExprCall, Parameters,
+    visitor::{Visitor as AstVisitor, walk_expr},
+};
+use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
+use ruff_text_size::{Ranged, TextRange, TextSize};
+
+use crate::{
+    config::Config,
+    primitives::{
+        INDENT_STEP,
+        call_keywords::{keyword_args, module_call_params},
+        edit::{narrowed_replacement, singleton_groups},
+    },
+    rule::{Rule, RuleId},
+    source::Source,
+};
+
+pub(crate) struct CallLayout {
+    max_inline_args: Option<usize>,
+}
+
+impl CallLayout {
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            max_inline_args: config
+                .rules
+                .call_layout
+                .max_inline_args
+                .map(NonZeroUsize::get),
+        }
+    }
+}
+
+impl Rule for CallLayout {
+    fn apply(&self, source: &Source) -> Vec<Vec<Edit>> {
+        let Some(cap) = self.max_inline_args else {
+            return Vec::new();
+        };
+        let targets = module_call_params(source, |_| true);
+        let mut exploder = Exploder {
+            cap,
+            edits: Vec::new(),
+            source,
+            targets: &targets,
+        };
+        exploder.visit_body(&source.ast().body);
+        singleton_groups(exploder.edits)
+    }
+
+    fn id(&self) -> RuleId {
+        Self::SLUG
+    }
+}
+
+struct Exploder<'a> {
+    cap: usize,
+    edits: Vec<Edit>,
+    source: &'a Source,
+    targets: &'a HashMap<TextSize, &'a Parameters>,
+}
+
+impl<'a> Exploder<'a> {
+    /// Returns the exploded `(...)` text for `call` when it carries more
+    /// than `cap` keyword-expressible arguments, the closing `)` landing
+    /// at `indent`. A nested call in an argument value explodes in the
+    /// same text. `None` leaves the call inline.
+    fn explode_args(&self, call: &ExprCall, indent: usize) -> Option<String> {
+        let arguments = &call.arguments;
+        if arguments.args.len() + arguments.keywords.len() <= self.cap {
+            return None;
+        }
+        let one = TextSize::from(1u32);
+        if self
+            .source
+            .intersects_comment(arguments.range().add_start(one).sub_end(one))
+        {
+            return None;
+        }
+        let params = call
+            .func
+            .as_name_expr()
+            .and_then(|callee| self.targets.get(&callee.range().start()).copied());
+        let keywords = keyword_args(self.source, call, params)?;
+        // A positional-only prefix cannot take keyword form, so the call
+        // stays inline rather than exploding only part of its arguments.
+        if keywords.posonly_prefix != 0 {
+            return None;
+        }
+        let item_indent = indent + INDENT_STEP;
+        let prefix = " ".repeat(item_indent);
+        let newline = self.source.newline_str();
+        let last = keywords.args.len() - 1;
+        let trailing = self.source_trailing_comma(call);
+        let mut out = String::from("(");
+        for (i, arg) in keywords.args.iter().enumerate() {
+            out.push_str(newline);
+            out.push_str(&prefix);
+            self.render_value(&mut out, arg.value, &arg.rendered, item_indent);
+            if trailing || i < last {
+                out.push(',');
+            }
+        }
+        out.push_str(newline);
+        out.extend(std::iter::repeat_n(' ', indent));
+        out.push(')');
+        Some(out)
+    }
+
+    /// Appends `rendered` to `out`, swapping a nested call value for its
+    /// own exploded form while keeping the `name=` prefix verbatim, so
+    /// nesting resolves in one pass.
+    fn render_value(&self, out: &mut String, value: &Expr, rendered: &str, indent: usize) {
+        if let Expr::Call(inner) = value
+            && let Some(args_text) = self.explode_args(inner, indent)
+        {
+            let inline = self.source.slice(value);
+            let head = rendered.strip_suffix(inline).unwrap_or(rendered);
+            let callee = self
+                .source
+                .slice(TextRange::new(inner.start(), inner.arguments.start()));
+            out.push_str(head);
+            out.push_str(callee);
+            out.push_str(&args_text);
+        } else {
+            out.push_str(rendered);
+        }
+    }
+
+    /// True when the last non-trivia token before the closing `)` is a
+    /// comma, the trailing-comma state `explode_args` carries through so
+    /// the explode neither adds nor drops one.
+    fn source_trailing_comma(&self, call: &ExprCall) -> bool {
+        BackwardsTokenizer::up_to(
+            call.arguments.end() - TextSize::from(1u32),
+            self.source.text(),
+            self.source.comment_ranges(),
+        )
+        .skip_trivia()
+        .next()
+        .is_some_and(|token| token.kind() == SimpleTokenKind::Comma)
+    }
+}
+
+impl<'a> AstVisitor<'a> for Exploder<'a> {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        if let Expr::Call(call) = expr {
+            let indent = self.source.line_indent_width(call.start());
+            if let Some(text) = self.explode_args(call, indent) {
+                self.edits.extend(narrowed_replacement(
+                    self.source,
+                    call.arguments.range(),
+                    text,
+                ));
+                return;
+            }
+        }
+        walk_expr(self, expr);
+    }
+}

--- a/src/rules/call_layout.rs
+++ b/src/rules/call_layout.rs
@@ -14,7 +14,7 @@ use ruff_python_ast::{
     visitor::{Visitor as AstVisitor, walk_expr},
 };
 use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextSize};
 
 use crate::{
     config::Config,
@@ -81,11 +81,7 @@ impl<'a> Exploder<'a> {
         if arguments.args.len() + arguments.keywords.len() <= self.cap {
             return None;
         }
-        let one = TextSize::from(1u32);
-        if self
-            .source
-            .intersects_comment(arguments.range().add_start(one).sub_end(one))
-        {
+        if self.source.intersects_comment(arguments.inner_range()) {
             return None;
         }
         let params = call
@@ -118,20 +114,16 @@ impl<'a> Exploder<'a> {
         Some(out)
     }
 
-    /// Appends `rendered` to `out`, swapping a nested call value for its
-    /// own exploded form while keeping the `name=` prefix verbatim, so
-    /// nesting resolves in one pass.
+    /// Appends `rendered` to `out`, swapping a nested call value's
+    /// argument list for its own exploded form while keeping everything
+    /// before it verbatim, so nesting resolves in one pass.
     fn render_value(&self, out: &mut String, value: &Expr, rendered: &str, indent: usize) {
         if let Expr::Call(inner) = value
             && let Some(args_text) = self.explode_args(inner, indent)
         {
-            let inline = self.source.slice(value);
-            let head = rendered.strip_suffix(inline).unwrap_or(rendered);
-            let callee = self
-                .source
-                .slice(TextRange::new(inner.start(), inner.arguments.start()));
+            let inner_args = self.source.slice(inner.arguments.range());
+            let head = rendered.strip_suffix(inner_args).unwrap_or(rendered);
             out.push_str(head);
-            out.push_str(callee);
             out.push_str(&args_text);
         } else {
             out.push_str(rendered);

--- a/src/rules/call_layout.rs
+++ b/src/rules/call_layout.rs
@@ -13,7 +13,6 @@ use ruff_python_ast::{
     Expr, ExprCall, Parameters,
     visitor::{Visitor as AstVisitor, walk_expr},
 };
-use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
 use ruff_text_size::{Ranged, TextSize};
 
 use crate::{
@@ -22,6 +21,7 @@ use crate::{
         INDENT_STEP,
         call_keywords::{keyword_args, module_call_params},
         edit::{narrowed_replacement, singleton_groups},
+        layout::explode_parens,
     },
     rule::{Rule, RuleId},
     source::Source,
@@ -95,22 +95,18 @@ impl<'a> Exploder<'a> {
             return None;
         }
         let item_indent = indent + INDENT_STEP;
-        let prefix = " ".repeat(item_indent);
-        let newline = self.source.newline_str();
         let last = keywords.args.len() - 1;
-        let trailing = self.source_trailing_comma(call);
-        let mut out = String::from("(");
-        for (i, arg) in keywords.args.iter().enumerate() {
-            out.push_str(newline);
-            out.push_str(&prefix);
-            self.render_value(&mut out, arg.value, &arg.rendered, item_indent);
-            if trailing || i < last {
-                out.push(',');
-            }
-        }
-        out.push_str(newline);
-        out.extend(std::iter::repeat_n(' ', indent));
-        out.push(')');
+        let trailing = self.source.trailing_comma(call.arguments.range()).is_some();
+        let out = explode_parens(
+            self.source.newline_str(),
+            indent,
+            keywords.args.len(),
+            |out, i| {
+                let arg = &keywords.args[i];
+                self.render_value(out, arg.value, &arg.rendered, item_indent);
+            },
+            |i| trailing || i < last,
+        );
         Some(out)
     }
 
@@ -128,20 +124,6 @@ impl<'a> Exploder<'a> {
         } else {
             out.push_str(rendered);
         }
-    }
-
-    /// True when the last non-trivia token before the closing `)` is a
-    /// comma, the trailing-comma state `explode_args` carries through so
-    /// the explode neither adds nor drops one.
-    fn source_trailing_comma(&self, call: &ExprCall) -> bool {
-        BackwardsTokenizer::up_to(
-            call.arguments.end() - TextSize::from(1u32),
-            self.source.text(),
-            self.source.comment_ranges(),
-        )
-        .skip_trivia()
-        .next()
-        .is_some_and(|token| token.kind() == SimpleTokenKind::Comma)
     }
 }
 

--- a/src/rules/docstring_expand.rs
+++ b/src/rules/docstring_expand.rs
@@ -30,8 +30,7 @@ impl DocstringExpand {
 impl Rule for DocstringExpand {
     fn apply(&self, source: &Source) -> Vec<Vec<Edit>> {
         singleton_groups(rewrite_docstrings(source, |source, lit, edits| {
-            let Some(body) = triple_quoted_body(source, lit).filter(|b| !b.text.contains('\n'))
-            else {
+            let Some(body) = triple_quoted_body(source, lit).filter(|b| !b.is_multiline()) else {
                 return;
             };
             let trimmed = body.text.trim_whitespace();

--- a/src/rules/docstring_frame.rs
+++ b/src/rules/docstring_frame.rs
@@ -29,8 +29,7 @@ impl DocstringFrame {
 impl Rule for DocstringFrame {
     fn apply(&self, source: &Source) -> Vec<Vec<Edit>> {
         singleton_groups(rewrite_docstrings(source, |source, lit, edits| {
-            let Some(body) = triple_quoted_body(source, lit).filter(|b| b.text.contains('\n'))
-            else {
+            let Some(body) = triple_quoted_body(source, lit).filter(|b| b.is_multiline()) else {
                 return;
             };
             let leading_ok = body.text.starts_with(['\n', '\r']);

--- a/src/rules/docstring_wrap.rs
+++ b/src/rules/docstring_wrap.rs
@@ -19,7 +19,7 @@ use crate::{
     config::{Config, DocstringStructuredPolicy},
     primitives::{
         docstring::{
-            entry_description_col, indent_prefix, is_list_marker, rewrite_docstrings,
+            LineScan, LineScanner, entry_description_col, indent_prefix, rewrite_docstrings,
             section_heading, triple_quoted_body,
         },
         edit::{narrowed_replacement, singleton_groups},
@@ -50,8 +50,7 @@ impl DocstringWrap {
 impl Rule for DocstringWrap {
     fn apply(&self, source: &Source) -> Vec<Vec<Edit>> {
         singleton_groups(rewrite_docstrings(source, |source, lit, edits| {
-            let Some(body) = triple_quoted_body(source, lit).filter(|b| b.text.contains('\n'))
-            else {
+            let Some(body) = triple_quoted_body(source, lit).filter(|b| b.is_multiline()) else {
                 return;
             };
             let indent = indent_prefix(source, lit);
@@ -83,14 +82,12 @@ enum Region {
 }
 
 struct Walker<'a> {
-    body_indent_chars: usize,
-    in_fence: bool,
-    list_indent: Option<usize>,
     newline: &'a str,
     out: String,
     paragraph: Paragraph,
     region: Region,
     rule: &'a DocstringWrap,
+    scanner: LineScanner,
 }
 
 impl Walker<'_> {
@@ -107,41 +104,26 @@ impl Walker<'_> {
         let trimmed = &line[indent_str.len()..];
         let indent_chars = indent_str.chars().count();
 
-        if trimmed.starts_with("```") {
-            self.flush_paragraph();
-            self.list_indent = None;
-            self.in_fence = !self.in_fence;
-            self.emit_verbatim(line);
-            return;
-        }
-        if self.in_fence {
-            self.emit_verbatim(line);
-            return;
-        }
-
-        if trimmed.is_empty() {
-            self.flush_paragraph();
-            self.list_indent = None;
-            self.out.push_str(self.newline);
-            return;
-        }
-
-        if let Some(list_indent) = self.list_indent {
-            if indent_chars > list_indent {
+        match self.scanner.classify(trimmed, indent_chars) {
+            LineScan::Fence | LineScan::ListMarker => {
+                self.flush_paragraph();
                 self.emit_verbatim(line);
                 return;
             }
-            self.list_indent = None;
+            LineScan::InFence | LineScan::ListContinuation => {
+                self.emit_verbatim(line);
+                return;
+            }
+            LineScan::Blank => {
+                self.flush_paragraph();
+                self.out.push_str(self.newline);
+                return;
+            }
+            LineScan::Body => {}
         }
 
-        if indent_chars >= self.body_indent_chars && is_list_marker(trimmed) {
-            self.flush_paragraph();
-            self.list_indent = Some(indent_chars);
-            self.emit_verbatim(line);
-            return;
-        }
-
-        if indent_chars == self.body_indent_chars && section_heading(trimmed) {
+        let body_indent = self.scanner.body_indent_chars();
+        if indent_chars == body_indent && section_heading(trimmed) {
             self.flush_paragraph();
             self.region = Region::Section;
             self.emit_verbatim(line);
@@ -158,8 +140,8 @@ impl Walker<'_> {
         }
 
         let prose_indent = match self.region {
-            Region::Description => self.body_indent_chars,
-            Region::Section => self.body_indent_chars + 4,
+            Region::Description => body_indent,
+            Region::Section => body_indent + 4,
             Region::SectionEntry(_) => unreachable!("entries handled above"),
         };
         if indent_chars > prose_indent {
@@ -224,7 +206,7 @@ impl Walker<'_> {
         hanging_col: usize,
     ) -> bool {
         indent_chars == hanging_col
-            || (indent_chars == self.body_indent_chars + 4
+            || (indent_chars == self.scanner.body_indent_chars() + 4
                 && entry_description_col(trimmed).is_none())
     }
 
@@ -246,14 +228,12 @@ fn rewrite_body(
     let (content, closer_indent) = body.strip_prefix(newline)?.rsplit_once(newline)?;
 
     let mut walker = Walker {
-        body_indent_chars: body_indent.chars().count(),
-        in_fence: false,
-        list_indent: None,
         newline,
         out: String::with_capacity(content.len()),
         paragraph: Paragraph::default(),
         region: Region::Description,
         rule,
+        scanner: LineScanner::new(body_indent.chars().count()),
     };
     for line in content.split(newline) {
         walker.consume(line);

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod align_match_case;
 pub(crate) mod alphabetize;
 pub(crate) mod bare_imports;
 pub(crate) mod blank_lines;
+pub(crate) mod call_layout;
 pub(crate) mod collection_layout;
 pub(crate) mod docstring_expand;
 pub(crate) mod docstring_frame;

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -16,8 +16,8 @@ use unicode_width::UnicodeWidthStr;
 use crate::{
     config::Config,
     primitives::{
-        INDENT_STEP,
         edit::{narrowed_replacement, singleton_groups},
+        layout::explode_parens,
     },
     rule::{Rule, RuleId},
     source::Source,
@@ -70,17 +70,14 @@ struct Layout<'a> {
 impl Layout<'_> {
     /// Builds the canonical expanded text spanning `(` through `:`.
     fn build_expanded(&self, fd: &StmtFunctionDef, indent: usize) -> String {
-        let prefix = " ".repeat(indent + INDENT_STEP);
-        let mut out = String::from("(");
-        for part in self.signature_parts(&fd.parameters) {
-            out.push_str(self.newline);
-            out.push_str(&prefix);
-            out.push_str(part);
-            out.push(',');
-        }
-        out.push_str(self.newline);
-        out.extend(std::iter::repeat_n(' ', indent));
-        out.push(')');
+        let parts: Vec<&str> = self.signature_parts(&fd.parameters).collect();
+        let mut out = explode_parens(
+            self.newline,
+            indent,
+            parts.len(),
+            |out, i| out.push_str(parts[i]),
+            |_| true,
+        );
         self.push_return_and_colon(&mut out, fd);
         out
     }

--- a/src/rules/strip_trailing_commas.rs
+++ b/src/rules/strip_trailing_commas.rs
@@ -10,8 +10,7 @@ use ruff_python_ast::{
     Arguments, Expr, Stmt, TypeParams,
     visitor::{Visitor, walk_arguments, walk_expr, walk_stmt, walk_type_params},
 };
-use ruff_python_trivia::{BackwardsTokenizer, SimpleTokenKind};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::{
     config::Config,
@@ -54,15 +53,9 @@ impl Stripper<'_> {
     /// is a comma.
     fn process_container(&mut self, container: TextRange) {
         self.edits.extend(
-            BackwardsTokenizer::up_to(
-                container.end() - TextSize::from(1u32),
-                self.source.text(),
-                self.source.comment_ranges(),
-            )
-            .skip_trivia()
-            .next()
-            .filter(|t| t.kind() == SimpleTokenKind::Comma)
-            .map(|t| Edit::range_deletion(t.range)),
+            self.source
+                .trailing_comma(container)
+                .map(Edit::range_deletion),
         );
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -7,7 +7,10 @@ use ruff_python_ast::{
     token::{Token, Tokens},
 };
 use ruff_python_parser::{ParseError, Parsed, parse_module};
-use ruff_python_trivia::{CommentRanges, leading_indentation, lines_before};
+use ruff_python_trivia::{
+    BackwardsTokenizer, CommentRanges, SimpleToken, SimpleTokenKind, leading_indentation,
+    lines_before,
+};
 use ruff_source_file::{
     LineColumn, LineEnding, LineRanges, OneIndexed, SourceFile, SourceFileBuilder, find_newline,
 };
@@ -165,6 +168,14 @@ impl Source {
             .as_str()
     }
 
+    /// Returns the first non-trivia token scanning backward from
+    /// `offset`, or `None` when the scan finds none.
+    pub(crate) fn prev_non_trivia_token(&self, offset: TextSize) -> Option<SimpleToken> {
+        BackwardsTokenizer::up_to(offset, self.text(), self.comment_ranges())
+            .skip_trivia()
+            .next()
+    }
+
     /// Reparses with replacement source text, preserving the original name.
     ///
     /// Diagnostic labels keep the original path or `<source>` placeholder.
@@ -201,6 +212,15 @@ impl Source {
     /// Borrows the token stream produced during parsing.
     pub fn tokens(&self) -> &Tokens {
         self.parsed.tokens()
+    }
+
+    /// Returns the range of the trailing comma immediately before the
+    /// closing bracket of `container`, or `None` when the last
+    /// non-trivia token there is not a comma.
+    pub(crate) fn trailing_comma(&self, container: TextRange) -> Option<TextRange> {
+        self.prev_non_trivia_token(container.end() - TextSize::from(1u32))
+            .filter(|token| token.kind() == SimpleTokenKind::Comma)
+            .map(|token| token.range)
     }
 }
 

--- a/tests/fixtures/call_layout/all_keyword_external_explodes/diagnostics.snap
+++ b/tests/fixtures/call_layout/all_keyword_external_explodes/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/all_keyword_external_explodes/input.py
+---
+call-layout@17..53

--- a/tests/fixtures/call_layout/all_keyword_external_explodes/input.py
+++ b/tests/fixtures/call_layout/all_keyword_external_explodes/input.py
@@ -1,0 +1,1 @@
+response = fetch(headers=h, method=m, params=p, url=u)

--- a/tests/fixtures/call_layout/all_keyword_external_explodes/input.py.snap
+++ b/tests/fixtures/call_layout/all_keyword_external_explodes/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/all_keyword_external_explodes/input.py
+---
+response = fetch(
+    headers=h,
+    method=m,
+    params=p,
+    url=u
+)

--- a/tests/fixtures/call_layout/all_keyword_external_explodes/meta.toml
+++ b/tests/fixtures/call_layout/all_keyword_external_explodes/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = true
+title       = "Explode an All-Keyword Call to an External Function"
+
+description = '''
+A four-argument all-keyword call explodes regardless of where its callee is defined, because every argument already names its parameter and needs no signature resolution.
+'''

--- a/tests/fixtures/call_layout/already_exploded_no_comma_noop/diagnostics.snap
+++ b/tests/fixtures/call_layout/already_exploded_no_comma_noop/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/already_exploded_no_comma_noop/input.py
+---
+

--- a/tests/fixtures/call_layout/already_exploded_no_comma_noop/input.py
+++ b/tests/fixtures/call_layout/already_exploded_no_comma_noop/input.py
@@ -1,0 +1,6 @@
+response = fetch(
+    headers=h,
+    method=m,
+    params=p,
+    url=u
+)

--- a/tests/fixtures/call_layout/already_exploded_no_comma_noop/input.py.snap
+++ b/tests/fixtures/call_layout/already_exploded_no_comma_noop/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/already_exploded_no_comma_noop/input.py
+---
+response = fetch(
+    headers=h,
+    method=m,
+    params=p,
+    url=u
+)

--- a/tests/fixtures/call_layout/already_exploded_no_comma_noop/meta.toml
+++ b/tests/fixtures/call_layout/already_exploded_no_comma_noop/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "An Exploded Call Without a Trailing Comma Is Left Alone"
+
+description = '''
+A call already laid out one argument per line with no trailing comma matches the rule's canonical shape, so the pass emits no edit.
+'''

--- a/tests/fixtures/call_layout/custom_cap_holds_five_inline/config.toml
+++ b/tests/fixtures/call_layout/custom_cap_holds_five_inline/config.toml
@@ -1,0 +1,2 @@
+[rules]
+call-layout = { max-inline-args = 5 }

--- a/tests/fixtures/call_layout/custom_cap_holds_five_inline/diagnostics.snap
+++ b/tests/fixtures/call_layout/custom_cap_holds_five_inline/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/custom_cap_holds_five_inline/input.py
+---
+

--- a/tests/fixtures/call_layout/custom_cap_holds_five_inline/input.py
+++ b/tests/fixtures/call_layout/custom_cap_holds_five_inline/input.py
@@ -1,0 +1,1 @@
+response = fetch(body=b, headers=h, method=m, params=p, url=u)

--- a/tests/fixtures/call_layout/custom_cap_holds_five_inline/input.py.snap
+++ b/tests/fixtures/call_layout/custom_cap_holds_five_inline/input.py.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/custom_cap_holds_five_inline/input.py
+---
+response = fetch(body=b, headers=h, method=m, params=p, url=u)

--- a/tests/fixtures/call_layout/custom_cap_holds_five_inline/meta.toml
+++ b/tests/fixtures/call_layout/custom_cap_holds_five_inline/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "A Raised `max-inline-args` Holds More Arguments Inline"
+
+description = '''
+Lifting the cap to five keeps a five-argument call on one line, the rule exploding only past the configured threshold.
+'''

--- a/tests/fixtures/call_layout/double_star_unpacking_stays_inline/diagnostics.snap
+++ b/tests/fixtures/call_layout/double_star_unpacking_stays_inline/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/double_star_unpacking_stays_inline/input.py
+---
+

--- a/tests/fixtures/call_layout/double_star_unpacking_stays_inline/input.py
+++ b/tests/fixtures/call_layout/double_star_unpacking_stays_inline/input.py
@@ -1,0 +1,1 @@
+merged = merge(alpha=1, beta=2, gamma=3, **overrides)

--- a/tests/fixtures/call_layout/double_star_unpacking_stays_inline/input.py.snap
+++ b/tests/fixtures/call_layout/double_star_unpacking_stays_inline/input.py.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/double_star_unpacking_stays_inline/input.py
+---
+merged = merge(alpha=1, beta=2, gamma=3, **overrides)

--- a/tests/fixtures/call_layout/double_star_unpacking_stays_inline/meta.toml
+++ b/tests/fixtures/call_layout/double_star_unpacking_stays_inline/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "Double-Star Unpacking Blocks the Explode"
+
+description = '''
+A `**` unpacking at the call site cannot be expressed as a keyword argument, so the call stays inline.
+'''

--- a/tests/fixtures/call_layout/exploded_trailing_comma_preserved/diagnostics.snap
+++ b/tests/fixtures/call_layout/exploded_trailing_comma_preserved/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/exploded_trailing_comma_preserved/input.py
+---
+

--- a/tests/fixtures/call_layout/exploded_trailing_comma_preserved/input.py
+++ b/tests/fixtures/call_layout/exploded_trailing_comma_preserved/input.py
@@ -1,0 +1,6 @@
+response = fetch(
+    headers=h,
+    method=m,
+    params=p,
+    url=u,
+)

--- a/tests/fixtures/call_layout/exploded_trailing_comma_preserved/input.py.snap
+++ b/tests/fixtures/call_layout/exploded_trailing_comma_preserved/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/exploded_trailing_comma_preserved/input.py
+---
+response = fetch(
+    headers=h,
+    method=m,
+    params=p,
+    url=u,
+)

--- a/tests/fixtures/call_layout/exploded_trailing_comma_preserved/meta.toml
+++ b/tests/fixtures/call_layout/exploded_trailing_comma_preserved/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "An Exploded Call Keeps Its Trailing Comma"
+
+description = '''
+A call already exploded with a trailing comma is left untouched, the rule deferring comma policy to `strip-trailing-commas`.
+'''

--- a/tests/fixtures/call_layout/explodes_above_threshold/diagnostics.snap
+++ b/tests/fixtures/call_layout/explodes_above_threshold/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/explodes_above_threshold/input.py
+---
+call-layout@99..109

--- a/tests/fixtures/call_layout/explodes_above_threshold/input.py
+++ b/tests/fixtures/call_layout/explodes_above_threshold/input.py
@@ -1,0 +1,5 @@
+def connect(host, port, timeout, user):
+    return (host, port, timeout, user)
+
+
+session = connect(h, p, t, u)

--- a/tests/fixtures/call_layout/explodes_above_threshold/input.py.snap
+++ b/tests/fixtures/call_layout/explodes_above_threshold/input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/explodes_above_threshold/input.py
+---
+def connect(host, port, timeout, user):
+    return (host, port, timeout, user)
+
+
+session = connect(
+    host=h,
+    port=p,
+    timeout=t,
+    user=u
+)

--- a/tests/fixtures/call_layout/explodes_above_threshold/meta.toml
+++ b/tests/fixtures/call_layout/explodes_above_threshold/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = true
+previewable = true
+title       = "Explode a Call Above the Argument Threshold"
+
+description = '''
+A four-argument call to an in-module function explodes to one keyword argument per line, each positional argument named from the resolved signature and the closing `)` dropping to the call's own indent.
+'''

--- a/tests/fixtures/call_layout/inline_trailing_comma_kept/diagnostics.snap
+++ b/tests/fixtures/call_layout/inline_trailing_comma_kept/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/inline_trailing_comma_kept/input.py
+---
+call-layout@16..50

--- a/tests/fixtures/call_layout/inline_trailing_comma_kept/input.py
+++ b/tests/fixtures/call_layout/inline_trailing_comma_kept/input.py
@@ -1,0 +1,1 @@
+report = render(alpha=1, beta=2, gamma=3, delta=4,)

--- a/tests/fixtures/call_layout/inline_trailing_comma_kept/input.py.snap
+++ b/tests/fixtures/call_layout/inline_trailing_comma_kept/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/inline_trailing_comma_kept/input.py
+---
+report = render(
+    alpha=1,
+    beta=2,
+    gamma=3,
+    delta=4,
+)

--- a/tests/fixtures/call_layout/inline_trailing_comma_kept/meta.toml
+++ b/tests/fixtures/call_layout/inline_trailing_comma_kept/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "An Inline Trailing Comma Carries Through the Explode"
+
+description = '''
+A call carrying a trailing comma keeps it across the explode, since adding or dropping the comma belongs to `strip-trailing-commas`.
+'''

--- a/tests/fixtures/call_layout/interior_comment_pins_shape/diagnostics.snap
+++ b/tests/fixtures/call_layout/interior_comment_pins_shape/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/interior_comment_pins_shape/input.py
+---
+

--- a/tests/fixtures/call_layout/interior_comment_pins_shape/input.py
+++ b/tests/fixtures/call_layout/interior_comment_pins_shape/input.py
@@ -1,0 +1,6 @@
+result = build(
+    alpha=1,  # keep this note anchored
+    beta=2,
+    gamma=3,
+    delta=4
+)

--- a/tests/fixtures/call_layout/interior_comment_pins_shape/input.py.snap
+++ b/tests/fixtures/call_layout/interior_comment_pins_shape/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/interior_comment_pins_shape/input.py
+---
+result = build(
+    alpha=1,  # keep this note anchored
+    beta=2,
+    gamma=3,
+    delta=4
+)

--- a/tests/fixtures/call_layout/interior_comment_pins_shape/meta.toml
+++ b/tests/fixtures/call_layout/interior_comment_pins_shape/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "An Interior Comment Pins the Existing Shape"
+
+description = '''
+A comment inside the argument list leaves the call untouched, because reshaping the arguments would orphan the comment from the line it annotates.
+'''

--- a/tests/fixtures/call_layout/max_inline_args_false_never_explodes/config.toml
+++ b/tests/fixtures/call_layout/max_inline_args_false_never_explodes/config.toml
@@ -1,0 +1,2 @@
+[rules]
+call-layout = { max-inline-args = false }

--- a/tests/fixtures/call_layout/max_inline_args_false_never_explodes/diagnostics.snap
+++ b/tests/fixtures/call_layout/max_inline_args_false_never_explodes/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/max_inline_args_false_never_explodes/input.py
+---
+

--- a/tests/fixtures/call_layout/max_inline_args_false_never_explodes/input.py
+++ b/tests/fixtures/call_layout/max_inline_args_false_never_explodes/input.py
@@ -1,0 +1,1 @@
+response = fetch(headers=h, method=m, params=p, url=u)

--- a/tests/fixtures/call_layout/max_inline_args_false_never_explodes/input.py.snap
+++ b/tests/fixtures/call_layout/max_inline_args_false_never_explodes/input.py.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/max_inline_args_false_never_explodes/input.py
+---
+response = fetch(headers=h, method=m, params=p, url=u)

--- a/tests/fixtures/call_layout/max_inline_args_false_never_explodes/meta.toml
+++ b/tests/fixtures/call_layout/max_inline_args_false_never_explodes/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "Setting `max-inline-args` to `false` Disables the Explode"
+
+description = '''
+With the count trigger turned off, the rule never explodes a call whatever its argument count.
+'''

--- a/tests/fixtures/call_layout/method_call_explodes/diagnostics.snap
+++ b/tests/fixtures/call_layout/method_call_explodes/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/method_call_explodes/input.py
+---
+call-layout@15..51

--- a/tests/fixtures/call_layout/method_call_explodes/input.py
+++ b/tests/fixtures/call_layout/method_call_explodes/input.py
@@ -1,0 +1,1 @@
+client.request(headers=h, method=m, params=p, url=u)

--- a/tests/fixtures/call_layout/method_call_explodes/input.py.snap
+++ b/tests/fixtures/call_layout/method_call_explodes/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/method_call_explodes/input.py
+---
+client.request(
+    headers=h,
+    method=m,
+    params=p,
+    url=u
+)

--- a/tests/fixtures/call_layout/method_call_explodes/meta.toml
+++ b/tests/fixtures/call_layout/method_call_explodes/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = true
+title       = "Explode a Keyword Method Call"
+
+description = '''
+An all-keyword method call explodes the same as a free function, the attribute callee carrying its arguments without any signature resolution.
+'''

--- a/tests/fixtures/call_layout/nested_call_explodes_together/diagnostics.snap
+++ b/tests/fixtures/call_layout/nested_call_explodes_together/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/nested_call_explodes_together/input.py
+---
+call-layout@171..242

--- a/tests/fixtures/call_layout/nested_call_explodes_together/input.py
+++ b/tests/fixtures/call_layout/nested_call_explodes_together/input.py
@@ -1,0 +1,9 @@
+def outer(alpha, beta, gamma, delta):
+    return (alpha, beta, gamma, delta)
+
+
+def inner(east, north, south, west):
+    return (east, north, south, west)
+
+
+result = outer(alpha=1, beta=inner(east=2, north=3, south=4, west=5), gamma=6, delta=7)

--- a/tests/fixtures/call_layout/nested_call_explodes_together/input.py.snap
+++ b/tests/fixtures/call_layout/nested_call_explodes_together/input.py.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/nested_call_explodes_together/input.py
+---
+def outer(alpha, beta, gamma, delta):
+    return (alpha, beta, gamma, delta)
+
+
+def inner(east, north, south, west):
+    return (east, north, south, west)
+
+
+result = outer(
+    alpha=1,
+    beta=inner(
+        east=2,
+        north=3,
+        south=4,
+        west=5
+    ),
+    gamma=6,
+    delta=7
+)

--- a/tests/fixtures/call_layout/nested_call_explodes_together/meta.toml
+++ b/tests/fixtures/call_layout/nested_call_explodes_together/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = true
+title       = "A Nested Call Explodes in the Same Pass"
+
+description = '''
+An eligible call passed as an argument value explodes alongside its enclosing call, the recursion resolving both levels before the rule returns so the layout is stable in one pass.
+'''

--- a/tests/fixtures/call_layout/order_preserved_not_alphabetized/diagnostics.snap
+++ b/tests/fixtures/call_layout/order_preserved_not_alphabetized/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/order_preserved_not_alphabetized/input.py
+---
+call-layout@95..105

--- a/tests/fixtures/call_layout/order_preserved_not_alphabetized/input.py
+++ b/tests/fixtures/call_layout/order_preserved_not_alphabetized/input.py
@@ -1,0 +1,5 @@
+def draw(width, height, depth, color):
+    return (width, height, depth, color)
+
+
+shape = draw(w, h, d, c)

--- a/tests/fixtures/call_layout/order_preserved_not_alphabetized/input.py.snap
+++ b/tests/fixtures/call_layout/order_preserved_not_alphabetized/input.py.snap
@@ -1,0 +1,15 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/order_preserved_not_alphabetized/input.py
+---
+def draw(width, height, depth, color):
+    return (width, height, depth, color)
+
+
+shape = draw(
+    width=w,
+    height=h,
+    depth=d,
+    color=c
+)

--- a/tests/fixtures/call_layout/order_preserved_not_alphabetized/meta.toml
+++ b/tests/fixtures/call_layout/order_preserved_not_alphabetized/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "The Explode Preserves Argument Order"
+
+description = '''
+The rule emits arguments in the order it receives them, leaving alphabetization to the `alphabetize` rule that runs ahead of it.
+'''

--- a/tests/fixtures/call_layout/positional_only_prefix_stays_inline/diagnostics.snap
+++ b/tests/fixtures/call_layout/positional_only_prefix_stays_inline/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/positional_only_prefix_stays_inline/input.py
+---
+

--- a/tests/fixtures/call_layout/positional_only_prefix_stays_inline/input.py
+++ b/tests/fixtures/call_layout/positional_only_prefix_stays_inline/input.py
@@ -1,0 +1,5 @@
+def render(data, /, height, width, color):
+    return (data, height, width, color)
+
+
+out = render(d, h, w, c)

--- a/tests/fixtures/call_layout/positional_only_prefix_stays_inline/input.py.snap
+++ b/tests/fixtures/call_layout/positional_only_prefix_stays_inline/input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/positional_only_prefix_stays_inline/input.py
+---
+def render(data, /, height, width, color):
+    return (data, height, width, color)
+
+
+out = render(d, h, w, c)

--- a/tests/fixtures/call_layout/positional_only_prefix_stays_inline/meta.toml
+++ b/tests/fixtures/call_layout/positional_only_prefix_stays_inline/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "A Positional-Only Prefix Blocks the Explode"
+
+description = '''
+An argument bound to a positional-only parameter cannot take keyword form, so a call carrying one stays inline whatever its argument count.
+'''

--- a/tests/fixtures/call_layout/positional_to_external_stays_inline/diagnostics.snap
+++ b/tests/fixtures/call_layout/positional_to_external_stays_inline/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/positional_to_external_stays_inline/input.py
+---
+

--- a/tests/fixtures/call_layout/positional_to_external_stays_inline/input.py
+++ b/tests/fixtures/call_layout/positional_to_external_stays_inline/input.py
@@ -1,0 +1,1 @@
+result = compute(alpha, beta, gamma, delta)

--- a/tests/fixtures/call_layout/positional_to_external_stays_inline/input.py.snap
+++ b/tests/fixtures/call_layout/positional_to_external_stays_inline/input.py.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/positional_to_external_stays_inline/input.py
+---
+result = compute(alpha, beta, gamma, delta)

--- a/tests/fixtures/call_layout/positional_to_external_stays_inline/meta.toml
+++ b/tests/fixtures/call_layout/positional_to_external_stays_inline/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "A Positional Call to an Unresolved Callee Stays Inline"
+
+description = '''
+The rule cannot name the positional arguments of a call whose callee does not resolve to a module function, so the call reads as written.
+'''

--- a/tests/fixtures/call_layout/star_unpacking_stays_inline/diagnostics.snap
+++ b/tests/fixtures/call_layout/star_unpacking_stays_inline/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/star_unpacking_stays_inline/input.py
+---
+

--- a/tests/fixtures/call_layout/star_unpacking_stays_inline/input.py
+++ b/tests/fixtures/call_layout/star_unpacking_stays_inline/input.py
@@ -1,0 +1,5 @@
+def send(body, head, tail, wrap):
+    return (body, head, tail, wrap)
+
+
+send(*parts, extra, more, last)

--- a/tests/fixtures/call_layout/star_unpacking_stays_inline/input.py.snap
+++ b/tests/fixtures/call_layout/star_unpacking_stays_inline/input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/star_unpacking_stays_inline/input.py
+---
+def send(body, head, tail, wrap):
+    return (body, head, tail, wrap)
+
+
+send(*parts, extra, more, last)

--- a/tests/fixtures/call_layout/star_unpacking_stays_inline/meta.toml
+++ b/tests/fixtures/call_layout/star_unpacking_stays_inline/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = false
+title       = "Star Unpacking Blocks the Explode"
+
+description = '''
+A `*` unpacking at the call site cannot be expressed as a keyword argument, so the call stays inline.
+'''

--- a/tests/fixtures/call_layout/three_args_stay_inline/diagnostics.snap
+++ b/tests/fixtures/call_layout/three_args_stay_inline/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/call_layout/three_args_stay_inline/input.py
+---
+

--- a/tests/fixtures/call_layout/three_args_stay_inline/input.py
+++ b/tests/fixtures/call_layout/three_args_stay_inline/input.py
@@ -1,0 +1,5 @@
+def place(depth, height, width):
+    return (depth, height, width)
+
+
+box = place(d, h, w)

--- a/tests/fixtures/call_layout/three_args_stay_inline/input.py.snap
+++ b/tests/fixtures/call_layout/three_args_stay_inline/input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/call_layout/three_args_stay_inline/input.py
+---
+def place(depth, height, width):
+    return (depth, height, width)
+
+
+box = place(d, h, w)

--- a/tests/fixtures/call_layout/three_args_stay_inline/meta.toml
+++ b/tests/fixtures/call_layout/three_args_stay_inline/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+canonical   = false
+previewable = true
+title       = "A Call at the Threshold Stays Inline"
+
+description = '''
+A three-argument call sits at the default `max-inline-args` cap and reads fine on one line, so the rule leaves it untouched.
+'''

--- a/tests/fixtures/config/every_knob_overridden/config.snap
+++ b/tests/fixtures/config/every_knob_overridden/config.snap
@@ -32,6 +32,12 @@ Config {
             docstring_entries: false,
             enabled: false,
         },
+        call_layout: CallLayoutConfig {
+            enabled: false,
+            max_inline_args: Some(
+                6,
+            ),
+        },
         strip_trailing_commas: ToggleOnly {
             enabled: false,
         },

--- a/tests/fixtures/config/every_knob_overridden/input.toml
+++ b/tests/fixtures/config/every_knob_overridden/input.toml
@@ -14,6 +14,7 @@ align-imports             = false
 alphabetize               = { docstring-entries = false, enabled = false }
 bare-imports     = { allow = ["scipy", "torch"], enabled = false }
 blank-lines               = false
+call-layout               = { enabled = false, max-inline-args = 6 }
 collection-layout         = { enabled = false, max-atomics-per-line = 3, max-inline-dict-entries = 5 }
 legacy-union-syntax       = false
 loose-constants           = { allow = ["LOG_LEVEL"], enabled = false }

--- a/tests/fixtures/config/lone_key_rest_default/config.snap
+++ b/tests/fixtures/config/lone_key_rest_default/config.snap
@@ -32,6 +32,12 @@ Config {
             docstring_entries: true,
             enabled: true,
         },
+        call_layout: CallLayoutConfig {
+            enabled: true,
+            max_inline_args: Some(
+                3,
+            ),
+        },
         strip_trailing_commas: ToggleOnly {
             enabled: true,
         },

--- a/tests/fixtures/config/rule_toggle_shorthand/config.snap
+++ b/tests/fixtures/config/rule_toggle_shorthand/config.snap
@@ -32,6 +32,12 @@ Config {
             docstring_entries: true,
             enabled: false,
         },
+        call_layout: CallLayoutConfig {
+            enabled: true,
+            max_inline_args: Some(
+                3,
+            ),
+        },
         strip_trailing_commas: ToggleOnly {
             enabled: true,
         },


### PR DESCRIPTION
### 🪻 Quick Summary

Adds `call-layout`, a rule that explodes a keyword-expressible call carrying more than `max-inline-args` arguments to one keyword argument per line, leaving shorter calls and calls that cannot take keyword form inline. A call dense enough to read as a wall of positionals folds better one binding per line, where the eye lands on each name and a later edit touches a single row. The rule reshapes layout alone, leaving argument order to `alphabetize`, `=` alignment to `align-equals`, and trailing-comma policy to `strip-trailing-commas`, so disabling any of those changes the result rather than fighting the explode.

Registering after `alphabetize` lets it reuse #201's binding-aware keyword machinery, lifted here into a shared primitive, and that lift surfaced enough adjacent duplication across the formatter that the branch folds several more shared primitives in alongside it.

---

### 🗞️ Key Changes

- Adds the `call-layout` rule, exploding a keyword-expressible call past `max-inline-args` to one keyword argument per line and registering it after `alphabetize` so it reshapes the keyword-rewritten calls the reorder leaves.

- Adds `CallLayoutConfig` with `max-inline-args` (*default `3`, so a call of four or more arguments explodes*), reading through the shared `optional_cap!` deserializer that spells the disable as `false`.

- Lifts #201's keyword-availability gate and per-argument naming out of `alphabetize` into `src/primitives/call_keywords.rs`, consumed unchanged by `alphabetize` and freshly by `call-layout`.

- Adds `explode_parens` in `src/primitives/layout.rs`, the one-per-line paren-explosion builder `signature-layout` now sources too, recursing into a nested eligible call value so the whole nest explodes in one pass.

- Adds `Source::trailing_comma` and the `prev_non_trivia_token` it sits on, moving `strip-trailing-commas` and `blank-lines` off their hand-rolled `BackwardsTokenizer` walks.

- Consolidates two further repeated shapes the lift surfaced, the docstring fence, blank, and list scanner into a shared `LineScanner` and the diagnostic emitters' per-run flatten into `diagnostics(runs)`, plus `DocstringBody::is_multiline`.

- Covers the rule with fixtures spanning the threshold, each disqualifier gate, external all-keyword eligibility, trailing-comma carry-through, nesting, and the cap knob, and documents it on the rule page and the configuration reference.

---

### ☕ Implementation Notes

The implementation departs from the spec in scope, eligibility, and default cap, and the branch absorbs cross-cutting primitive consolidation beyond the rule. Each departure is recorded in [a comment on the issue](https://github.com/Jybbs/prose/issues/202#issuecomment-4597789339).

---

### 🧵 Related Issues

- Closes #202