### PR TITLE
[211] Insert the dict-entry separator before a trailing comment

### DIFF
--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -335,7 +335,7 @@ fn assemble_dict_items_multiline(
         }
         if !is_last {
             out.push('\n');
-            if divider_slots.contains(&slot) {
+            if divider_slots.binary_search(&slot).is_ok() {
                 out.push('\n');
             }
         }

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -305,11 +305,14 @@ fn args_reorder(params: &Parameters) -> bool {
     !params.args.iter().filter_map(classify_param).is_sorted()
 }
 
-/// Concatenates dict-item block texts in `order`, normalizing trailing
-/// commas so non-last slots always have one and the new-last slot
-/// matches `source_last_has_comma`. Inserts a blank line at every
-/// slot listed in `divider_slots`.
+/// Concatenates dict-item block texts in `order`, placing each slot's
+/// separator comma against the entry's value span so it lands after the
+/// value and before any trailing line comment. Non-last slots always
+/// carry a comma and the new-last slot matches `source_last_has_comma`.
+/// Inserts a blank line at every slot listed in `divider_slots`.
 fn assemble_dict_items_multiline(
+    items: &[DictItem],
+    blocks: &[TextRange],
     block_texts: &[Cow<'_, str>],
     order: &[usize],
     divider_slots: &[usize],
@@ -317,11 +320,18 @@ fn assemble_dict_items_multiline(
 ) -> String {
     let mut out = String::new();
     for (slot, &idx) in order.iter().enumerate() {
-        let text = block_texts[idx].trim_end_matches(',');
-        out.push_str(text);
+        let block_text = &block_texts[idx];
+        let tail_len = (blocks[idx].end() - items[idx].range().end()).to_usize();
+        let (code, tail) = block_text.split_at(block_text.len() - tail_len);
+        let (separator, comment) = tail.split_at(tail.find('#').unwrap_or(tail.len()));
+        out.push_str(code);
         let is_last = slot + 1 == order.len();
         if !is_last || source_last_has_comma {
             out.push(',');
+        }
+        if !comment.is_empty() {
+            out.extend(separator.chars().filter(|&c| c != ','));
+            out.push_str(comment);
         }
         if !is_last {
             out.push('\n');
@@ -826,11 +836,15 @@ fn rewrite_dict_text<'src>(
     let permuted = permute_full(&mut order, &d.items, |item| dict_sort_key(source, item));
     let assembled = if multi_line {
         let divider_slots = partition_divider_slots(source, &order, &d.items);
-        let source_last_has_comma = source
-            .slice(*blocks.last().expect("non-empty"))
-            .trim_end()
-            .ends_with(',');
-        assemble_dict_items_multiline(&block_texts, &order, &divider_slots, source_last_has_comma)
+        let source_last_has_comma = source.trailing_comma(d.range()).is_some();
+        assemble_dict_items_multiline(
+            &d.items,
+            &blocks,
+            &block_texts,
+            &order,
+            &divider_slots,
+            source_last_has_comma,
+        )
     } else {
         assemble_blocks(source, &blocks, &block_texts, &order, |_| None)
     };

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -318,7 +318,7 @@ fn assemble_dict_items_multiline(
     divider_slots: &[usize],
     source_last_has_comma: bool,
 ) -> String {
-    let mut out = String::new();
+    let mut out = String::with_capacity(blocks_span(blocks).len().to_usize());
     for (slot, &idx) in order.iter().enumerate() {
         let block_text = &block_texts[idx];
         let tail_len = (blocks[idx].end() - items[idx].range().end()).to_usize();

--- a/tests/fixtures/alphabetize/dict_commented_already_sorted/diagnostics.snap
+++ b/tests/fixtures/alphabetize/dict_commented_already_sorted/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/dict_commented_already_sorted/input.py
+---
+

--- a/tests/fixtures/alphabetize/dict_commented_already_sorted/input.py
+++ b/tests/fixtures/alphabetize/dict_commented_already_sorted/input.py
@@ -1,0 +1,5 @@
+palette = {
+    "amber": "warm",  # sunset
+    "cyan": "cool",  # ocean
+    "magenta": "vivid",  # bloom
+}

--- a/tests/fixtures/alphabetize/dict_commented_already_sorted/input.py.snap
+++ b/tests/fixtures/alphabetize/dict_commented_already_sorted/input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/dict_commented_already_sorted/input.py
+---
+palette = {
+    "amber": "warm",  # sunset
+    "cyan": "cool",  # ocean
+    "magenta": "vivid",  # bloom
+}

--- a/tests/fixtures/alphabetize/dict_commented_already_sorted/meta.toml
+++ b/tests/fixtures/alphabetize/dict_commented_already_sorted/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "An Ordered Commented Dict Stays Untouched"
+
+description = '''
+A dict already in key order keeps its trailing `#` comments and magic trailing `,` exactly as written, emitting **no edit**. The reassembly reproduces the source verbatim, so an ordered commented dict is left alone.
+'''

--- a/tests/fixtures/alphabetize/dict_commented_entries_reorder/diagnostics.snap
+++ b/tests/fixtures/alphabetize/dict_commented_entries_reorder/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/dict_commented_entries_reorder/input.py
+---
+alphabetize@15..125

--- a/tests/fixtures/alphabetize/dict_commented_entries_reorder/input.py
+++ b/tests/fixtures/alphabetize/dict_commented_entries_reorder/input.py
@@ -1,0 +1,5 @@
+theme = {
+    "ruler": "#888",  # subtle gray
+    "accent": "#ff8800",  # warm orange
+    "background": "#000",  # pure black
+}

--- a/tests/fixtures/alphabetize/dict_commented_entries_reorder/input.py.snap
+++ b/tests/fixtures/alphabetize/dict_commented_entries_reorder/input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/dict_commented_entries_reorder/input.py
+---
+theme = {
+    "accent": "#ff8800",  # warm orange
+    "background": "#000",  # pure black
+    "ruler": "#888",  # subtle gray
+}

--- a/tests/fixtures/alphabetize/dict_commented_entries_reorder/meta.toml
+++ b/tests/fixtures/alphabetize/dict_commented_entries_reorder/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = true
+title       = "Trailing Comments Travel with Their Entries"
+
+description = '''
+Reordering a multi-line dict keeps every entry's trailing `#` comment, with the separator `,` placed after the value and before the comment. Values carrying their own `#`, such as hex color strings, **stay intact** because the comma resolves against the value span rather than a raw `#` scan.
+'''

--- a/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/diagnostics.snap
+++ b/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/dict_commented_last_lacks_comma/input.py
+---
+alphabetize@18..102

--- a/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/input.py
+++ b/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/input.py
@@ -1,0 +1,5 @@
+versions = {
+    "stable": "1.0",  # current
+    "legacy": "0.9",  # old
+    "edge": "2.0"  # bleeding
+}

--- a/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/input.py.snap
+++ b/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/dict_commented_last_lacks_comma/input.py
+---
+versions = {
+    "edge": "2.0",  # bleeding
+    "legacy": "0.9",  # old
+    "stable": "1.0"  # current
+}

--- a/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/meta.toml
+++ b/tests/fixtures/alphabetize/dict_commented_last_lacks_comma/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "A Comma-Less Last Entry Keeps Its Separator"
+
+description = '''
+When the original last entry carries a trailing `#` comment but no `,`, sorting it out of last position places a **real separator** after its value and ahead of the comment. The new last entry stays comma-less, matching the source dict's absent magic trailing comma.
+'''

--- a/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/diagnostics.snap
+++ b/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/dict_nested_value_trailing_comment/input.py
+---
+alphabetize@35..81

--- a/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/input.py
+++ b/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/input.py
@@ -1,0 +1,7 @@
+data = {
+    "scalar": 1,  # plain
+    "nested": {
+        "b": 2,
+        "a": 1,
+    },  # block
+}

--- a/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/input.py.snap
+++ b/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/dict_nested_value_trailing_comment/input.py
+---
+data = {
+    "scalar": 1,  # plain
+
+    "nested": {
+        "a": 1,
+        "b": 2,
+    },  # block
+}

--- a/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/meta.toml
+++ b/tests/fixtures/alphabetize/dict_nested_value_trailing_comment/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "A Nested Block Value Keeps Its Trailing Comment"
+
+description = '''
+A keyed entry whose value is a multi-line dict reorders its inner keys while its trailing `#` comment stays attached, with the separator `,` landing after the closing `}` rather than inside the comment. The partition keeps the multi-line entry isolated by a **blank divider**.
+'''

--- a/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/diagnostics.snap
+++ b/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/input.py
+---
+alphabetize@16..84

--- a/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/input.py
+++ b/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/input.py
@@ -1,0 +1,5 @@
+merged = {
+    "zulu": 1,  # last alpha
+    **base,  # spread
+    "alpha": 2,  # first alpha
+}

--- a/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/input.py.snap
+++ b/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/input.py.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/input.py
+---
+merged = {
+    "alpha": 2,  # first alpha
+    **base,  # spread
+    "zulu": 1,  # last alpha
+}

--- a/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/meta.toml
+++ b/tests/fixtures/alphabetize/dict_spread_entry_trailing_comment/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "A Spread Entry Keeps Its Trailing Comment"
+
+description = '''
+A `**`-unpacked entry pins in source position yet still carries its trailing `#` comment cleanly, with the separator `,` resolved against the value span even though the entry has no key.
+'''


### PR DESCRIPTION
### 🪻 Quick Summary

Inserts a reordered dict entry's separator comma against its value span, so the comma lands after the value and before any trailing `#` comment rather than after the comment. `alphabetize`'s multi-line dict reassembly trimmed a trailing `,` off each entry's block text and pushed one back on, but an entry carrying a trailing comment ends its block text inside that comment, so the appended comma fell after the `#` and the separator was swallowed. A comma-less commented entry moving out of last position lost its separator entirely, the reordered dict no longer parsed, and the pipeline aborted with exit 4 on both `prose check` and `prose format`. The fix splits each entry's block text at the value end and reads the source dict's magic trailing comma through `Source::trailing_comma`, so a trailing comment no longer hides the separator or the comma that governs the new last entry.

---

### 🗞️ Key Changes

- Resolves each reordered entry's separator `,` against its value span in `assemble_dict_items_multiline`, splitting the block text at the value end so the comma lands before any trailing `#` comment, where it previously trailed off the end of the block text and fell after the comment.

- Reads the source dict's magic trailing comma through `Source::trailing_comma` rather than scanning the last block's text, so a trailing comment no longer masks the comma that decides whether the new last entry keeps its separator.

- Covers the fix with fixtures spanning a commented reorder on every entry, a comma-less last entry that gains a real separator on the move, an already-ordered commented control, a nested multi-line block value, and a `**`-spread entry, each parseable and idempotent across a second pass.

---

### 🧵 Related Issues

- Closes #211