### PR TITLE
[210] Pin definition order against evaluation-time references

### DIFF
--- a/site/.vitepress/lib/glossary/entries.ts
+++ b/site/.vitepress/lib/glossary/entries.ts
@@ -156,8 +156,10 @@ export const glossary: Record<string, GlossaryEntry> = {
     aliases   : ['annotations', 'type annotation', 'type annotations'],
     definition: 'An annotation is a `name: Type` declaration on a function parameter, return '
               + 'value, or variable. Type checkers and version-gated rules like '
-              + '`legacy-union-syntax` and `unused-future-annotations` read it.',
-    families  : ['lint', 'alignment'],
+              + '`legacy-union-syntax` and `unused-future-annotations` read it, and '
+              + '`alphabetize` treats a non-deferred annotation as a reference that pins '
+              + 'definition order.',
+    families  : ['lint', 'alignment', 'ordering'],
     href      : 'https://docs.python.org/3/glossary.html#term-annotation'
   },
 
@@ -316,8 +318,11 @@ export const glossary: Record<string, GlossaryEntry> = {
     definition: 'A forward reference is an annotation that names a class or alias defined '
               + 'later in the file. The `from __future__ import annotations` directive made '
               + 'these safe on older Python runtimes, and `unused-future-annotations` removes '
-              + 'the directive when no annotation needs the forward reference.',
-    families  : ['lint'],
+              + 'the directive when no annotation needs the forward reference. `alphabetize` '
+              + 'never introduces one, holding a class or function behind any sibling it names '
+              + 'at evaluation time so the reorder cannot lift a definition above a name it '
+              + 'depends on.',
+    families  : ['lint', 'ordering'],
     href      : '/rules/unused-future-annotations'
   },
 

--- a/site/rules/alphabetize.md
+++ b/site/rules/alphabetize.md
@@ -25,6 +25,8 @@ A reader who already knows the codebase carries a **mental map** of where things
 
 The rule fires on siblings whose order does not carry meaning. It leaves alone every surface where ordering is load-bearing (*positional-only parameters before the `/` separator, enum members with explicit integer or string values, tuple-unpacking targets bound to positional results*).
 
+A class or function definition also holds its place behind any sibling it names at evaluation time (*a base class, a decorator, a parameter default, a non-deferred annotation, or a class-body value*), since sorting it ahead of that sibling would move the name out of scope and raise `NameError` on import. A run whose references form a cycle stays in source order untouched.
+
 When a function's parameters reorder, `alphabetize` rewrites each in-module call's positional arguments to keyword form, keyed to the parameter each bound to under the original order, so the reorder never silently rebinds a caller. Calls that forward `*args`, unpack `**`, or reach the function through a reassigned name stay as they read.
 
 Pair with [[align-imports]] to align the `import` keyword across the freshly-sorted block, with [[align-colons]] to align dataclass-field annotations after the sort, and with [[blank-lines]] for the blank-line discipline around class members and the single blank line between the import groups.

--- a/src/primitives/imports.rs
+++ b/src/primitives/imports.rs
@@ -2,7 +2,10 @@
 //! bare → external `from` → local-package. First-party detection
 //! reads the package-name list from `[tool.prose.imports]`.
 
-use ruff_python_ast::Stmt;
+use ruff_python_ast::{Stmt, StmtImportFrom};
+
+const FUTURE_ANNOTATIONS: &str = "annotations";
+const FUTURE_MODULE: &str = "__future__";
 
 /// Canonical import group. Derived `Ord` ranks the variants in
 /// declaration order, so a sort by group lands bare imports first,
@@ -12,6 +15,18 @@ pub(crate) enum ImportGroup {
     Bare,
     ExternalFrom,
     Local,
+}
+
+/// Returns the position of the `annotations` alias in a
+/// `from __future__ import …` statement, or `None` for any other
+/// import.
+pub(crate) fn future_annotations_alias(node: &StmtImportFrom) -> Option<usize> {
+    if node.level != 0 || node.module.as_deref() != Some(FUTURE_MODULE) {
+        return None;
+    }
+    node.names
+        .iter()
+        .position(|alias| alias.name.id == FUTURE_ANNOTATIONS)
 }
 
 /// Returns the canonical group of an `import` or `from`-import

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -32,7 +32,7 @@ use ruff_python_ast::{
     Identifier, ParameterWithDefault, Parameters, Stmt, StmtAnnAssign, StmtAssign, StmtDelete,
     StmtFunctionDef,
     helpers::{any_over_expr, is_compound_statement, is_dunder, map_callable},
-    visitor::{Visitor as AstVisitor, walk_expr, walk_stmt},
+    visitor::{Visitor as AstVisitor, walk_expr, walk_parameters, walk_stmt},
 };
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
@@ -43,7 +43,7 @@ use crate::{
         call_keywords::{keyword_args, module_call_params, pins_positional_params},
         docstring::{entry_carrying_sections, rewrite_docstrings},
         edit::{apply_inline_edits, narrowed_replacement, singleton_groups},
-        imports::{ImportGroup, import_group},
+        imports::{ImportGroup, future_annotations_alias, import_group},
         orderer::{
             assemble_blocks, block_range, blocks_span, permute_full, permute_in_place, reorder_text,
         },
@@ -86,6 +86,7 @@ impl Rule for Alphabetize {
             BodyScope::Module,
             &leaf_edits,
             &self.first_party,
+            defers_annotations(body),
         );
         let edits = match body_text {
             Cow::Borrowed(_) => leaf_edits,
@@ -98,6 +99,58 @@ impl Rule for Alphabetize {
 
     fn id(&self) -> RuleId {
         Self::SLUG
+    }
+}
+
+/// Collects every `Name` load in a definition's evaluation-time
+/// surface: its decorators, base classes and class keywords, parameter
+/// defaults, non-deferred annotations, and the top level of a class
+/// body, descending into nested definitions but pruning every function
+/// and lambda body. Annotation positions are skipped when
+/// `defer_annotations` holds.
+struct EvalRefVisitor<'src> {
+    defer_annotations: bool,
+    names: Vec<&'src str>,
+}
+
+impl<'src> AstVisitor<'src> for EvalRefVisitor<'src> {
+    fn visit_annotation(&mut self, annotation: &'src Expr) {
+        if !self.defer_annotations {
+            self.visit_expr(annotation);
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &'src Expr) {
+        match expr {
+            Expr::Lambda(lambda) => {
+                if let Some(params) = lambda.parameters.as_deref() {
+                    walk_parameters(self, params);
+                }
+            }
+            Expr::Name(name) if name.ctx.is_load() => self.names.push(name.id.as_str()),
+            _ => walk_expr(self, expr),
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &'src Stmt) {
+        match stmt {
+            Stmt::AnnAssign(ann) => {
+                self.visit_annotation(&ann.annotation);
+                if let Some(value) = &ann.value {
+                    self.visit_expr(value);
+                }
+            }
+            Stmt::FunctionDef(func) => {
+                for decorator in &func.decorator_list {
+                    self.visit_expr(&decorator.expression);
+                }
+                walk_parameters(self, &func.parameters);
+                if let Some(returns) = &func.returns {
+                    self.visit_annotation(returns);
+                }
+            }
+            _ => walk_stmt(self, stmt),
+        }
     }
 }
 
@@ -517,6 +570,60 @@ fn decorator_simple_name(decorator: &Decorator) -> Option<&str> {
     }
 }
 
+/// Returns a per-member `(tier, key)` lookup keyed by each definition's
+/// start offset, or `None` when the run cannot reorder. The run skips
+/// when two members share a name or when the intra-run reference graph
+/// carries a cycle. A member depends on every other sibling it names in
+/// its evaluation-time surface, and the composite `(tier, key)` combines
+/// a Kahn-style topological tier with the member's existing sort key, so
+/// a definition never sorts ahead of a sibling it names at evaluation
+/// time.
+fn def_run_tier_keys<'src, K: Copy>(
+    body: &'src [Stmt],
+    defer_annotations: bool,
+    member: impl Fn(&'src Stmt) -> Option<(&'src str, K)>,
+) -> Option<HashMap<TextSize, (usize, K)>> {
+    let members: Vec<(&'src Stmt, &'src str, K)> = body
+        .iter()
+        .filter_map(|stmt| member(stmt).map(|(name, key)| (stmt, name, key)))
+        .collect();
+    let name_to_idx = unique_name_index(members.iter().map(|&(_, name, _)| name))?;
+    let dep_sets: Vec<HashSet<usize>> = members
+        .iter()
+        .enumerate()
+        .map(|(idx, &(stmt, _, _))| {
+            let mut visitor = EvalRefVisitor {
+                defer_annotations,
+                names: Vec::new(),
+            };
+            visitor.visit_stmt(stmt);
+            visitor
+                .names
+                .iter()
+                .filter_map(|name| name_to_idx.get(name).copied())
+                // A recursive self-reference does not constrain sibling order.
+                .filter(|&dep| dep != idx)
+                .collect()
+        })
+        .collect();
+    let tiers = tier_levels(&dep_sets)?;
+    Some(
+        members
+            .iter()
+            .zip(tiers)
+            .map(|(&(stmt, _, key), tier)| (stmt.range().start(), (tier, key)))
+            .collect(),
+    )
+}
+
+/// True when the module carries `from __future__ import annotations`,
+/// deferring every annotation's evaluation per PEP 563.
+fn defers_annotations(body: &[Stmt]) -> bool {
+    body.iter()
+        .filter_map(Stmt::as_import_from_stmt)
+        .any(|node| future_annotations_alias(node).is_some())
+}
+
 /// Composite dict-item sort key. `**unpacked` items return `None` and
 /// pin in source position. Keyed items sort single-line entries before
 /// multi-line entries and alphabetize within each partition by the
@@ -638,12 +745,7 @@ fn module_assign_tier_keys<'src>(
     }
     let extracted: Vec<(&'src str, Option<&'src Expr>)> =
         run.iter().map(assign_run_target).collect::<Option<_>>()?;
-    let mut target_to_idx: HashMap<&str, usize> = HashMap::with_capacity(extracted.len());
-    for (i, &(name, _)) in extracted.iter().enumerate() {
-        if target_to_idx.insert(name, i).is_some() {
-            return None;
-        }
-    }
+    let target_to_idx = unique_name_index(extracted.iter().map(|&(name, _)| name))?;
     let analysis = source.binding_analysis();
     let run_start = first.range().start();
     let dep_sets: Vec<HashSet<usize>> = extracted
@@ -695,6 +797,19 @@ fn partition_divider_slots(source: &Source, order: &[usize], items: &[DictItem])
         .collect()
 }
 
+/// Tiers the definition run selected by `member` and permutes `order`
+/// by `(tier, key)`, leaving `order` untouched when the run declines.
+fn permute_defs<'src, K: Copy + Ord>(
+    order: &mut [usize],
+    body: &'src [Stmt],
+    defer_annotations: bool,
+    member: impl Fn(&'src Stmt) -> Option<(&'src str, K)>,
+) {
+    if let Some(keys) = def_run_tier_keys(body, defer_annotations, member) {
+        permute_full(order, body, |s| keys.get(&s.range().start()).copied());
+    }
+}
+
 /// Rewrites a non-empty body, returning the rewritten text alongside
 /// the block-extent span it covers. The text is `Cow::Owned` when any
 /// sibling reorder fires, any descendant rewrite produces owned
@@ -708,6 +823,7 @@ fn rewrite_body<'src>(
     scope: BodyScope,
     leaf_edits: &[Edit],
     first_party: &[String],
+    defer_annotations: bool,
 ) -> (Cow<'src, str>, TextRange) {
     let (blocks, rendered): (Vec<TextRange>, Vec<Cow<'src, str>>) = body
         .iter()
@@ -716,7 +832,15 @@ fn rewrite_body<'src>(
             let block = block_range(source, body, i, outer);
             (
                 block,
-                rewrite_stmt(source, stmt, block, scope, leaf_edits, first_party),
+                rewrite_stmt(
+                    source,
+                    stmt,
+                    block,
+                    scope,
+                    leaf_edits,
+                    first_party,
+                    defer_annotations,
+                ),
             )
         })
         .unzip();
@@ -725,8 +849,11 @@ fn rewrite_body<'src>(
     let mut order: Vec<usize> = (0..n).collect();
     let in_class = scope == BodyScope::Class;
     if scope != BodyScope::Function {
-        permute_full(&mut order, body, |s| {
-            s.as_class_def_stmt().map(|c| c.name.as_str())
+        permute_defs(&mut order, body, defer_annotations, |s| {
+            s.as_class_def_stmt().map(|c| {
+                let name = c.name.as_str();
+                (name, name)
+            })
         });
         if in_class {
             permute_full(&mut order, body, |s| {
@@ -735,9 +862,11 @@ fn rewrite_body<'src>(
             permute_full(&mut order, body, simple_name_assign);
         }
         if !(in_class && class_pins_methods(body)) {
-            permute_full(&mut order, body, |s| {
-                s.as_function_def_stmt()
-                    .map(|f| (method_group(f), f.name.as_str()))
+            permute_defs(&mut order, body, defer_annotations, |s| {
+                s.as_function_def_stmt().map(|f| {
+                    let name = f.name.as_str();
+                    (name, (method_group(f), name))
+                })
             });
         }
     }
@@ -783,11 +912,22 @@ fn rewrite_compound<'src>(
     scope: BodyScope,
     leaf_edits: &[Edit],
     first_party: &[String],
+    defer_annotations: bool,
 ) -> Cow<'src, str> {
     let bodies = compound_sub_bodies(stmt)
         .into_iter()
         .filter(|(body, _)| !body.is_empty())
-        .map(|(body, outer)| rewrite_body(source, body, outer, scope, leaf_edits, first_party));
+        .map(|(body, outer)| {
+            rewrite_body(
+                source,
+                body,
+                outer,
+                scope,
+                leaf_edits,
+                first_party,
+                defer_annotations,
+            )
+        });
     splice_bodies(source, block, bodies, leaf_edits)
 }
 
@@ -873,20 +1013,36 @@ fn rewrite_stmt<'src>(
     parent_scope: BodyScope,
     leaf_edits: &[Edit],
     first_party: &[String],
+    defer_annotations: bool,
 ) -> Cow<'src, str> {
     let (body, body_outer, scope): (&[Stmt], TextRange, BodyScope) = match stmt {
         Stmt::ClassDef(c) => (&c.body, c.range(), BodyScope::Class),
         Stmt::FunctionDef(f) => (&f.body, f.range(), BodyScope::Function),
         s if is_compound_statement(s) => {
-            return rewrite_compound(source, stmt, block, parent_scope, leaf_edits, first_party);
+            return rewrite_compound(
+                source,
+                stmt,
+                block,
+                parent_scope,
+                leaf_edits,
+                first_party,
+                defer_annotations,
+            );
         }
         _ => return apply_inline_edits(source, block, leaf_edits),
     };
     if body.is_empty() {
         return apply_inline_edits(source, block, leaf_edits);
     }
-    let (body_text, body_span) =
-        rewrite_body(source, body, body_outer, scope, leaf_edits, first_party);
+    let (body_text, body_span) = rewrite_body(
+        source,
+        body,
+        body_outer,
+        scope,
+        leaf_edits,
+        first_party,
+        defer_annotations,
+    );
     splice_bodies(source, block, [(body_text, body_span)], leaf_edits)
 }
 
@@ -993,6 +1149,19 @@ fn tier_levels(dep_sets: &[HashSet<usize>]) -> Option<Vec<usize>> {
     tiers.into_iter().collect()
 }
 
+/// Indexes each name to its position, or `None` when a name repeats. A
+/// duplicate makes an intra-run reference ambiguous, so the caller
+/// declines the reorder.
+fn unique_name_index<'a>(names: impl Iterator<Item = &'a str>) -> Option<HashMap<&'a str, usize>> {
+    let mut index = HashMap::new();
+    for (position, name) in names.enumerate() {
+        if index.insert(name, position).is_some() {
+            return None;
+        }
+    }
+    Some(index)
+}
+
 #[cfg(test)]
 mod tests {
     use indoc::indoc;
@@ -1001,6 +1170,13 @@ mod tests {
 
     use super::*;
     use crate::test_support::parse;
+
+    fn class_member(stmt: &Stmt) -> Option<(&str, &str)> {
+        stmt.as_class_def_stmt().map(|class| {
+            let name = class.name.as_str();
+            (name, name)
+        })
+    }
 
     #[test]
     fn ann_assign_with_named_field_filters_to_name_targets() {
@@ -1128,6 +1304,99 @@ mod tests {
         let f = s.ast().body[0].as_function_def_stmt().expect("def");
         let decorator = f.decorator_list.first().expect("one decorator");
         assert_eq!(decorator_simple_name(decorator), None);
+    }
+
+    #[test]
+    fn def_run_tier_keys_declines_a_duplicate_member_name() {
+        let source = parse("class Dup:\n    pass\n\n\nclass Dup:\n    pass\n");
+        assert!(def_run_tier_keys(&source.ast().body, false, class_member).is_none());
+    }
+
+    #[test]
+    fn def_run_tier_keys_declines_a_reference_cycle() {
+        let source = parse("class Alpha(Beta):\n    pass\n\n\nclass Beta(Alpha):\n    pass\n");
+        assert!(def_run_tier_keys(&source.ast().body, false, class_member).is_none());
+    }
+
+    #[test]
+    fn def_run_tier_keys_excludes_a_recursive_self_reference() {
+        let source = parse("class Node:\n    def child(self) -> Node: ...\n");
+        let body = &source.ast().body;
+        let keys =
+            def_run_tier_keys(body, false, class_member).expect("self-reference does not decline");
+        assert_eq!(keys[&body[0].range().start()].0, 0);
+    }
+
+    #[test]
+    fn def_run_tier_keys_tiers_a_backward_base_class_reference() {
+        let source = parse("class Beta:\n    pass\n\n\nclass Alpha(Beta):\n    pass\n");
+        let body = &source.ast().body;
+        let keys = def_run_tier_keys(body, false, class_member).expect("acyclic run tiers");
+        let tier = |i: usize| keys[&body[i].range().start()].0;
+        assert_eq!(tier(0), 0, "Beta has no dependency");
+        assert_eq!(tier(1), 1, "Alpha depends on Beta");
+    }
+
+    #[rstest]
+    #[case("from __future__ import annotations\n", true)]
+    #[case("from __future__ import annotations, division\n", true)]
+    #[case("from __future__ import division\n", false)]
+    #[case("from other import annotations\n", false)]
+    #[case("import __future__\n", false)]
+    #[case("x = 1\n", false)]
+    fn defers_annotations_detects_the_future_import(#[case] src: &str, #[case] expected: bool) {
+        let source = parse(src);
+        assert_eq!(defers_annotations(&source.ast().body), expected);
+    }
+
+    #[test]
+    fn eval_ref_visitor_collects_eval_surface_and_skips_bodies() {
+        let source = parse(indoc! {"
+            class Probe(BaseRef):
+                field: AnnotRef
+
+                def method(self, p: ParamRef = DefaultRef) -> ReturnRef:
+                    return BodyRef
+        "});
+        let mut visitor = EvalRefVisitor {
+            defer_annotations: false,
+            names: Vec::new(),
+        };
+        visitor.visit_stmt(&source.ast().body[0]);
+        let collected: HashSet<&str> = visitor.names.iter().copied().collect();
+        assert_eq!(
+            collected,
+            HashSet::from(["AnnotRef", "BaseRef", "DefaultRef", "ParamRef", "ReturnRef"]),
+        );
+    }
+
+    #[test]
+    fn eval_ref_visitor_prunes_a_lambda_body() {
+        let source = parse("class Probe:\n    factory = lambda seed=SeedRef: BodyRef\n");
+        let mut visitor = EvalRefVisitor {
+            defer_annotations: false,
+            names: Vec::new(),
+        };
+        visitor.visit_stmt(&source.ast().body[0]);
+        let collected: HashSet<&str> = visitor.names.iter().copied().collect();
+        assert_eq!(collected, HashSet::from(["SeedRef"]));
+    }
+
+    #[test]
+    fn eval_ref_visitor_skips_annotations_when_deferred() {
+        let source = parse(indoc! {"
+            class Probe(BaseRef):
+                field: AnnotRef
+
+                def method(self, p: ParamRef = DefaultRef) -> ReturnRef: ...
+        "});
+        let mut visitor = EvalRefVisitor {
+            defer_annotations: true,
+            names: Vec::new(),
+        };
+        visitor.visit_stmt(&source.ast().body[0]);
+        let collected: HashSet<&str> = visitor.names.iter().copied().collect();
+        assert_eq!(collected, HashSet::from(["BaseRef", "DefaultRef"]));
     }
 
     #[test]

--- a/src/rules/alphabetize.rs
+++ b/src/rules/alphabetize.rs
@@ -79,14 +79,17 @@ impl Rule for Alphabetize {
             leaf_edits.extend(collect_docstring_entry_edits(source));
             leaf_edits.sort_unstable();
         }
-        let (body_text, body_span) = rewrite_body(
+        let ctx = RewriteCtx {
+            defer_annotations: defers_annotations(body),
+            first_party: &self.first_party,
+            leaf_edits: &leaf_edits,
             source,
+        };
+        let (body_text, body_span) = rewrite_body(
+            ctx,
             body,
             TextRange::up_to(source.text().text_len()),
             BodyScope::Module,
-            &leaf_edits,
-            &self.first_party,
-            defers_annotations(body),
         );
         let edits = match body_text {
             Cow::Borrowed(_) => leaf_edits,
@@ -102,12 +105,8 @@ impl Rule for Alphabetize {
     }
 }
 
-/// Collects every `Name` load in a definition's evaluation-time
-/// surface: its decorators, base classes and class keywords, parameter
-/// defaults, non-deferred annotations, and the top level of a class
-/// body, descending into nested definitions but pruning every function
-/// and lambda body. Annotation positions are skipped when
-/// `defer_annotations` holds.
+/// Accumulates load-context names through `eval_time_refs`, pruning
+/// function and lambda bodies and skipping deferred annotations.
 struct EvalRefVisitor<'src> {
     defer_annotations: bool,
     names: Vec<&'src str>,
@@ -262,7 +261,7 @@ impl<'a> LeafCollector<'a> {
             return false;
         };
         // A call whose positional arguments are all positional-only has
-        // nothing to convert; the plain keyword reorder sorts it instead.
+        // nothing to convert, leaving the plain keyword reorder to sort it instead.
         if c.arguments.args.len() <= keywords.posonly_prefix {
             return false;
         }
@@ -313,6 +312,15 @@ impl<'a> AstVisitor<'a> for LeafCollector<'a> {
         }
         walk_stmt(self, stmt);
     }
+}
+
+/// Invariant context threaded through the body-rewrite recursion.
+#[derive(Clone, Copy)]
+struct RewriteCtx<'a> {
+    defer_annotations: bool,
+    first_party: &'a [String],
+    leaf_edits: &'a [Edit],
+    source: &'a Source,
 }
 
 #[derive(Default)]
@@ -592,27 +600,19 @@ fn def_run_tier_keys<'src, K: Copy>(
         .iter()
         .enumerate()
         .map(|(idx, &(stmt, _, _))| {
-            let mut visitor = EvalRefVisitor {
-                defer_annotations,
-                names: Vec::new(),
-            };
-            visitor.visit_stmt(stmt);
-            visitor
-                .names
-                .iter()
+            eval_time_refs(stmt, defer_annotations)
+                .into_iter()
                 .filter_map(|name| name_to_idx.get(name).copied())
                 // A recursive self-reference does not constrain sibling order.
                 .filter(|&dep| dep != idx)
                 .collect()
         })
         .collect();
-    let tiers = tier_levels(&dep_sets)?;
-    Some(
+    tier_key_map(
         members
-            .iter()
-            .zip(tiers)
-            .map(|(&(stmt, _, key), tier)| (stmt.range().start(), (tier, key)))
-            .collect(),
+            .into_iter()
+            .map(|(stmt, _, key)| (stmt.range().start(), key)),
+        &dep_sets,
     )
 }
 
@@ -632,6 +632,21 @@ fn dict_sort_key<'a>(source: &'a Source, item: &'a DictItem) -> Option<(u8, &'a 
     let key = item.key.as_ref()?;
     let group = u8::from(source.contains_line_break(item.range()));
     Some((group, source.slice(key)))
+}
+
+/// Collects the load-context names in a definition's evaluation-time
+/// surface: its decorators, base classes and class keywords, parameter
+/// defaults, non-deferred annotations, and the top level of a class
+/// body, descending into nested definitions but pruning every function
+/// and lambda body. Annotation positions are skipped when
+/// `defer_annotations` holds.
+fn eval_time_refs(stmt: &Stmt, defer_annotations: bool) -> Vec<&str> {
+    let mut visitor = EvalRefVisitor {
+        defer_annotations,
+        names: Vec::new(),
+    };
+    visitor.visit_stmt(stmt);
+    visitor.names
 }
 
 /// True when an annotated assignment carries a default, either
@@ -772,13 +787,11 @@ fn module_assign_tier_keys<'src>(
             )
         })
         .collect::<Option<Vec<_>>>()?;
-    let tiers = tier_levels(&dep_sets)?;
-    Some(
+    tier_key_map(
         run.iter()
-            .zip(tiers)
             .zip(&extracted)
-            .map(|((stmt, tier), &(name, _))| (stmt.range().start(), (tier, name)))
-            .collect(),
+            .map(|(stmt, &(name, _))| (stmt.range().start(), name)),
+        &dep_sets,
     )
 }
 
@@ -816,32 +829,24 @@ fn permute_defs<'src, K: Copy + Ord>(
 /// content, or any leaf edit lands inside, falling back to
 /// `Cow::Borrowed` over `source.slice(span)`. `scope` selects which
 /// family sorts apply.
-fn rewrite_body<'src>(
-    source: &'src Source,
+fn rewrite_body<'a>(
+    ctx: RewriteCtx<'a>,
     body: &[Stmt],
     outer: TextRange,
     scope: BodyScope,
-    leaf_edits: &[Edit],
-    first_party: &[String],
-    defer_annotations: bool,
-) -> (Cow<'src, str>, TextRange) {
-    let (blocks, rendered): (Vec<TextRange>, Vec<Cow<'src, str>>) = body
+) -> (Cow<'a, str>, TextRange) {
+    let RewriteCtx {
+        defer_annotations,
+        first_party,
+        source,
+        ..
+    } = ctx;
+    let (blocks, rendered): (Vec<TextRange>, Vec<Cow<'a, str>>) = body
         .iter()
         .enumerate()
         .map(|(i, stmt)| {
             let block = block_range(source, body, i, outer);
-            (
-                block,
-                rewrite_stmt(
-                    source,
-                    stmt,
-                    block,
-                    scope,
-                    leaf_edits,
-                    first_party,
-                    defer_annotations,
-                ),
-            )
+            (block, rewrite_stmt(ctx, stmt, block, scope))
         })
         .unzip();
     let body_span = blocks_span(&blocks);
@@ -905,30 +910,17 @@ fn rewrite_body<'src>(
 /// Recurses into each sub-body of a compound statement, splicing
 /// rewritten bodies back into the parent block while leaving header,
 /// keyword, and inter-arm regions to leaf-level edits.
-fn rewrite_compound<'src>(
-    source: &'src Source,
+fn rewrite_compound<'a>(
+    ctx: RewriteCtx<'a>,
     stmt: &Stmt,
     block: TextRange,
     scope: BodyScope,
-    leaf_edits: &[Edit],
-    first_party: &[String],
-    defer_annotations: bool,
-) -> Cow<'src, str> {
+) -> Cow<'a, str> {
     let bodies = compound_sub_bodies(stmt)
         .into_iter()
         .filter(|(body, _)| !body.is_empty())
-        .map(|(body, outer)| {
-            rewrite_body(
-                source,
-                body,
-                outer,
-                scope,
-                leaf_edits,
-                first_party,
-                defer_annotations,
-            )
-        });
-    splice_bodies(source, block, bodies, leaf_edits)
+        .map(|(body, outer)| rewrite_body(ctx, body, outer, scope));
+    splice_bodies(ctx.source, block, bodies, ctx.leaf_edits)
 }
 
 /// Rewrites a dict literal's items span. Returns `Some((span, text))`
@@ -1006,44 +998,25 @@ fn rewrite_item_block<'src>(
 /// sub-body with the inherited `parent_scope`, so module-level reorders
 /// (imports, classes, top-level functions) fire inside `if TYPE_CHECKING`
 /// and other body-bearing arms. Other shapes apply leaf edits in place.
-fn rewrite_stmt<'src>(
-    source: &'src Source,
+fn rewrite_stmt<'a>(
+    ctx: RewriteCtx<'a>,
     stmt: &Stmt,
     block: TextRange,
     parent_scope: BodyScope,
-    leaf_edits: &[Edit],
-    first_party: &[String],
-    defer_annotations: bool,
-) -> Cow<'src, str> {
+) -> Cow<'a, str> {
     let (body, body_outer, scope): (&[Stmt], TextRange, BodyScope) = match stmt {
         Stmt::ClassDef(c) => (&c.body, c.range(), BodyScope::Class),
         Stmt::FunctionDef(f) => (&f.body, f.range(), BodyScope::Function),
         s if is_compound_statement(s) => {
-            return rewrite_compound(
-                source,
-                stmt,
-                block,
-                parent_scope,
-                leaf_edits,
-                first_party,
-                defer_annotations,
-            );
+            return rewrite_compound(ctx, stmt, block, parent_scope);
         }
-        _ => return apply_inline_edits(source, block, leaf_edits),
+        _ => return apply_inline_edits(ctx.source, block, ctx.leaf_edits),
     };
     if body.is_empty() {
-        return apply_inline_edits(source, block, leaf_edits);
+        return apply_inline_edits(ctx.source, block, ctx.leaf_edits);
     }
-    let (body_text, body_span) = rewrite_body(
-        source,
-        body,
-        body_outer,
-        scope,
-        leaf_edits,
-        first_party,
-        defer_annotations,
-    );
-    splice_bodies(source, block, [(body_text, body_span)], leaf_edits)
+    let (body_text, body_span) = rewrite_body(ctx, body, body_outer, scope);
+    splice_bodies(ctx.source, block, [(body_text, body_span)], ctx.leaf_edits)
 }
 
 /// Returns the leftmost `Name` identifier of an `Attribute` or
@@ -1122,6 +1095,23 @@ fn statement_run_ranges(
     mut predicate: impl FnMut(&Stmt) -> bool,
 ) -> Vec<Range<usize>> {
     chunk_runs(body, |a, b| predicate(a) && predicate(b))
+}
+
+/// Tiers `dep_sets` and assembles a per-statement `(tier, key)` lookup
+/// keyed by start offset, or `None` when the dependency graph cycles.
+/// `offsets_keys` must yield one `(offset, key)` pair per dep set, in
+/// order.
+fn tier_key_map<K>(
+    offsets_keys: impl Iterator<Item = (TextSize, K)>,
+    dep_sets: &[HashSet<usize>],
+) -> Option<HashMap<TextSize, (usize, K)>> {
+    let tiers = tier_levels(dep_sets)?;
+    Some(
+        offsets_keys
+            .zip(tiers)
+            .map(|((offset, key), tier)| (offset, (tier, key)))
+            .collect(),
+    )
 }
 
 /// Assigns each binding a Kahn-style topological tier from its
@@ -1350,7 +1340,7 @@ mod tests {
     }
 
     #[test]
-    fn eval_ref_visitor_collects_eval_surface_and_skips_bodies() {
+    fn eval_time_refs_collects_eval_surface_and_skips_bodies() {
         let source = parse(indoc! {"
             class Probe(BaseRef):
                 field: AnnotRef
@@ -1358,12 +1348,9 @@ mod tests {
                 def method(self, p: ParamRef = DefaultRef) -> ReturnRef:
                     return BodyRef
         "});
-        let mut visitor = EvalRefVisitor {
-            defer_annotations: false,
-            names: Vec::new(),
-        };
-        visitor.visit_stmt(&source.ast().body[0]);
-        let collected: HashSet<&str> = visitor.names.iter().copied().collect();
+        let collected: HashSet<&str> = eval_time_refs(&source.ast().body[0], false)
+            .into_iter()
+            .collect();
         assert_eq!(
             collected,
             HashSet::from(["AnnotRef", "BaseRef", "DefaultRef", "ParamRef", "ReturnRef"]),
@@ -1371,31 +1358,25 @@ mod tests {
     }
 
     #[test]
-    fn eval_ref_visitor_prunes_a_lambda_body() {
+    fn eval_time_refs_prunes_a_lambda_body() {
         let source = parse("class Probe:\n    factory = lambda seed=SeedRef: BodyRef\n");
-        let mut visitor = EvalRefVisitor {
-            defer_annotations: false,
-            names: Vec::new(),
-        };
-        visitor.visit_stmt(&source.ast().body[0]);
-        let collected: HashSet<&str> = visitor.names.iter().copied().collect();
+        let collected: HashSet<&str> = eval_time_refs(&source.ast().body[0], false)
+            .into_iter()
+            .collect();
         assert_eq!(collected, HashSet::from(["SeedRef"]));
     }
 
     #[test]
-    fn eval_ref_visitor_skips_annotations_when_deferred() {
+    fn eval_time_refs_skips_annotations_when_deferred() {
         let source = parse(indoc! {"
             class Probe(BaseRef):
                 field: AnnotRef
 
                 def method(self, p: ParamRef = DefaultRef) -> ReturnRef: ...
         "});
-        let mut visitor = EvalRefVisitor {
-            defer_annotations: true,
-            names: Vec::new(),
-        };
-        visitor.visit_stmt(&source.ast().body[0]);
-        let collected: HashSet<&str> = visitor.names.iter().copied().collect();
+        let collected: HashSet<&str> = eval_time_refs(&source.ast().body[0], true)
+            .into_iter()
+            .collect();
         assert_eq!(collected, HashSet::from(["BaseRef", "DefaultRef"]));
     }
 

--- a/src/rules/unused_future_annotations.rs
+++ b/src/rules/unused_future_annotations.rs
@@ -15,13 +15,12 @@ use ruff_text_size::TextRange;
 
 use crate::{
     config::Config,
-    primitives::{binding::BindingAnalysis, edit::singleton_groups},
+    primitives::{
+        binding::BindingAnalysis, edit::singleton_groups, imports::future_annotations_alias,
+    },
     rule::{Rule, RuleId},
     source::Source,
 };
-
-const FUTURE_ANNOTATIONS: &str = "annotations";
-const FUTURE_MODULE: &str = "__future__";
 
 pub(crate) struct UnusedFutureAnnotations {
     target_version: Option<PythonVersion>,
@@ -43,7 +42,7 @@ impl Rule for UnusedFutureAnnotations {
             .iter()
             .filter_map(|stmt| {
                 let node = stmt.as_import_from_stmt()?;
-                Some((node, future_alias_index(node)?))
+                Some((node, future_annotations_alias(node)?))
             })
             .collect();
         if directives.is_empty() || !rule_fires(source, self.target_version) {
@@ -149,15 +148,6 @@ fn edit_for(source: &Source, node: &StmtImportFrom, alias_idx: usize) -> Edit {
     } else {
         Edit::range_deletion(source.text().full_lines_range(node.range))
     }
-}
-
-fn future_alias_index(node: &StmtImportFrom) -> Option<usize> {
-    if node.level != 0 || node.module.as_deref() != Some(FUTURE_MODULE) {
-        return None;
-    }
-    node.names
-        .iter()
-        .position(|alias| alias.name.id == FUTURE_ANNOTATIONS)
 }
 
 fn has_any_annotation(body: &[Stmt]) -> bool {

--- a/tests/fixtures/alphabetize/base_class_reference_pins_run/diagnostics.snap
+++ b/tests/fixtures/alphabetize/base_class_reference_pins_run/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/base_class_reference_pins_run/input.py
+---
+

--- a/tests/fixtures/alphabetize/base_class_reference_pins_run/input.py
+++ b/tests/fixtures/alphabetize/base_class_reference_pins_run/input.py
@@ -1,0 +1,6 @@
+class Beta:
+    pass
+
+
+class Alpha(Beta):
+    pass

--- a/tests/fixtures/alphabetize/base_class_reference_pins_run/input.py.snap
+++ b/tests/fixtures/alphabetize/base_class_reference_pins_run/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/base_class_reference_pins_run/input.py
+---
+class Beta:
+    pass
+
+
+class Alpha(Beta):
+    pass

--- a/tests/fixtures/alphabetize/base_class_reference_pins_run/meta.toml
+++ b/tests/fixtures/alphabetize/base_class_reference_pins_run/meta.toml
@@ -1,0 +1,9 @@
+[docs]
+previewable = true
+title       = "A Base Class Pins Its Subclass After It"
+
+description = '''
+`Alpha` names `Beta` as a base class, so the alphabetical sort holds `Beta`
+ahead of `Alpha` instead of moving the subclass above the name it inherits,
+leaving the module import-safe.
+'''

--- a/tests/fixtures/alphabetize/class_body_value_reference_pins_run/diagnostics.snap
+++ b/tests/fixtures/alphabetize/class_body_value_reference_pins_run/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/class_body_value_reference_pins_run/input.py
+---
+

--- a/tests/fixtures/alphabetize/class_body_value_reference_pins_run/input.py
+++ b/tests/fixtures/alphabetize/class_body_value_reference_pins_run/input.py
@@ -1,0 +1,6 @@
+class Defaults:
+    pass
+
+
+class Config:
+    settings = Defaults

--- a/tests/fixtures/alphabetize/class_body_value_reference_pins_run/input.py.snap
+++ b/tests/fixtures/alphabetize/class_body_value_reference_pins_run/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/class_body_value_reference_pins_run/input.py
+---
+class Defaults:
+    pass
+
+
+class Config:
+    settings = Defaults

--- a/tests/fixtures/alphabetize/class_body_value_reference_pins_run/meta.toml
+++ b/tests/fixtures/alphabetize/class_body_value_reference_pins_run/meta.toml
@@ -1,0 +1,9 @@
+[docs]
+previewable = false
+title       = "A Class-Body Value Pins the Named Class After It"
+
+description = '''
+`Config` binds `Defaults` as a class-body value, which runs while the class is
+being built, so the sort holds `Defaults` ahead of `Config` rather than moving
+it out of scope.
+'''

--- a/tests/fixtures/alphabetize/class_reference_cycle_skips_run/diagnostics.snap
+++ b/tests/fixtures/alphabetize/class_reference_cycle_skips_run/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/class_reference_cycle_skips_run/input.py
+---
+

--- a/tests/fixtures/alphabetize/class_reference_cycle_skips_run/input.py
+++ b/tests/fixtures/alphabetize/class_reference_cycle_skips_run/input.py
@@ -1,0 +1,6 @@
+class Alpha(Beta):
+    pass
+
+
+class Beta(Alpha):
+    pass

--- a/tests/fixtures/alphabetize/class_reference_cycle_skips_run/input.py.snap
+++ b/tests/fixtures/alphabetize/class_reference_cycle_skips_run/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/class_reference_cycle_skips_run/input.py
+---
+class Alpha(Beta):
+    pass
+
+
+class Beta(Alpha):
+    pass

--- a/tests/fixtures/alphabetize/class_reference_cycle_skips_run/meta.toml
+++ b/tests/fixtures/alphabetize/class_reference_cycle_skips_run/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "A Reference Cycle Skips the Whole Run"
+
+description = '''
+When the intra-run reference graph carries a cycle, **the run skips entirely**. `Alpha` names `Beta` as a base class and `Beta` names `Alpha`, so no topological tier exists and source order survives.
+'''

--- a/tests/fixtures/alphabetize/decorator_reference_pins_function_run/diagnostics.snap
+++ b/tests/fixtures/alphabetize/decorator_reference_pins_function_run/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/decorator_reference_pins_function_run/input.py
+---
+

--- a/tests/fixtures/alphabetize/decorator_reference_pins_function_run/input.py
+++ b/tests/fixtures/alphabetize/decorator_reference_pins_function_run/input.py
@@ -1,0 +1,7 @@
+def register(handler):
+    return handler
+
+
+@register
+def dispatch():
+    pass

--- a/tests/fixtures/alphabetize/decorator_reference_pins_function_run/input.py.snap
+++ b/tests/fixtures/alphabetize/decorator_reference_pins_function_run/input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/decorator_reference_pins_function_run/input.py
+---
+def register(handler):
+    return handler
+
+
+@register
+def dispatch():
+    pass

--- a/tests/fixtures/alphabetize/decorator_reference_pins_function_run/meta.toml
+++ b/tests/fixtures/alphabetize/decorator_reference_pins_function_run/meta.toml
@@ -1,0 +1,9 @@
+[docs]
+previewable = false
+title       = "A Decorator Pins the Decorated Function After It"
+
+description = '''
+`dispatch` is decorated with `@register`, applied at definition time, so the
+sort holds `register` ahead of `dispatch` rather than calling the decorator
+before it exists.
+'''

--- a/tests/fixtures/alphabetize/function_body_reference_does_not_pin/diagnostics.snap
+++ b/tests/fixtures/alphabetize/function_body_reference_does_not_pin/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/function_body_reference_does_not_pin/input.py
+---
+alphabetize@6..76

--- a/tests/fixtures/alphabetize/function_body_reference_does_not_pin/input.py
+++ b/tests/fixtures/alphabetize/function_body_reference_does_not_pin/input.py
@@ -1,0 +1,7 @@
+class Beta:
+    pass
+
+
+class Alpha:
+    def run(self):
+        return Beta()

--- a/tests/fixtures/alphabetize/function_body_reference_does_not_pin/input.py.snap
+++ b/tests/fixtures/alphabetize/function_body_reference_does_not_pin/input.py.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/function_body_reference_does_not_pin/input.py
+---
+class Alpha:
+    def run(self):
+        return Beta()
+
+
+class Beta:
+    pass

--- a/tests/fixtures/alphabetize/function_body_reference_does_not_pin/meta.toml
+++ b/tests/fixtures/alphabetize/function_body_reference_does_not_pin/meta.toml
@@ -1,0 +1,9 @@
+[docs]
+previewable = false
+title       = "A Method-Body Reference Does Not Pin the Order"
+
+description = '''
+`Alpha.run` names `Beta` only inside a method body, which runs when the method
+is called rather than when the class is defined, so the reference is deferred
+and `Alpha` still sorts ahead of `Beta`.
+'''

--- a/tests/fixtures/alphabetize/future_annotation_does_not_pin/diagnostics.snap
+++ b/tests/fixtures/alphabetize/future_annotation_does_not_pin/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/future_annotation_does_not_pin/input.py
+---
+alphabetize@43..110

--- a/tests/fixtures/alphabetize/future_annotation_does_not_pin/input.py
+++ b/tests/fixtures/alphabetize/future_annotation_does_not_pin/input.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class Helper:
+    pass
+
+
+class Builder:
+    def make(self) -> Helper: ...

--- a/tests/fixtures/alphabetize/future_annotation_does_not_pin/input.py.snap
+++ b/tests/fixtures/alphabetize/future_annotation_does_not_pin/input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/future_annotation_does_not_pin/input.py
+---
+from __future__ import annotations
+
+
+class Builder:
+    def make(self) -> Helper: ...
+
+
+class Helper:
+    pass

--- a/tests/fixtures/alphabetize/future_annotation_does_not_pin/meta.toml
+++ b/tests/fixtures/alphabetize/future_annotation_does_not_pin/meta.toml
@@ -1,0 +1,9 @@
+[docs]
+previewable = false
+title       = "A Deferred Annotation Does Not Pin the Order"
+
+description = '''
+Under `from __future__ import annotations` the `Helper` return annotation no
+longer evaluates at definition time, so it stops constraining the run and
+`Builder` sorts ahead of `Helper`.
+'''

--- a/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/diagnostics.snap
+++ b/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/input.py
+---
+

--- a/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/input.py
+++ b/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/input.py
@@ -1,0 +1,6 @@
+class Record:
+    pass
+
+
+class Loader:
+    def load(self, item: Record) -> None: ...

--- a/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/input.py.snap
+++ b/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/input.py
+---
+class Record:
+    pass
+
+
+class Loader:
+    def load(self, item: Record) -> None: ...

--- a/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/meta.toml
+++ b/tests/fixtures/alphabetize/parameter_annotation_reference_pins_run/meta.toml
@@ -1,0 +1,9 @@
+[docs]
+previewable = false
+title       = "A Parameter Annotation Pins the Annotated Class After Its Type"
+
+description = '''
+`Loader.load` annotates a parameter as `Record`, evaluated when the method is
+defined, so the sort holds `Record` ahead of `Loader` and the reorder stays
+import-safe.
+'''

--- a/tests/fixtures/alphabetize/return_annotation_reference_pins_run/diagnostics.snap
+++ b/tests/fixtures/alphabetize/return_annotation_reference_pins_run/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/return_annotation_reference_pins_run/input.py
+---
+

--- a/tests/fixtures/alphabetize/return_annotation_reference_pins_run/input.py
+++ b/tests/fixtures/alphabetize/return_annotation_reference_pins_run/input.py
@@ -1,0 +1,6 @@
+class Helper:
+    pass
+
+
+class Builder:
+    def make(self) -> Helper: ...

--- a/tests/fixtures/alphabetize/return_annotation_reference_pins_run/input.py.snap
+++ b/tests/fixtures/alphabetize/return_annotation_reference_pins_run/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/return_annotation_reference_pins_run/input.py
+---
+class Helper:
+    pass
+
+
+class Builder:
+    def make(self) -> Helper: ...

--- a/tests/fixtures/alphabetize/return_annotation_reference_pins_run/meta.toml
+++ b/tests/fixtures/alphabetize/return_annotation_reference_pins_run/meta.toml
@@ -1,0 +1,9 @@
+[docs]
+previewable = false
+title       = "A Return Annotation Pins the Annotated Class After Its Type"
+
+description = '''
+`Builder.make` returns `Helper`, an annotation that evaluates at definition
+time, so the sort holds `Helper` ahead of `Builder` rather than raising
+`NameError` on import.
+'''

--- a/tests/fixtures/alphabetize/unreferenced_classes_reorder/diagnostics.snap
+++ b/tests/fixtures/alphabetize/unreferenced_classes_reorder/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/alphabetize/unreferenced_classes_reorder/input.py
+---
+alphabetize@6..33

--- a/tests/fixtures/alphabetize/unreferenced_classes_reorder/input.py
+++ b/tests/fixtures/alphabetize/unreferenced_classes_reorder/input.py
@@ -1,0 +1,6 @@
+class Beta:
+    pass
+
+
+class Alpha:
+    pass

--- a/tests/fixtures/alphabetize/unreferenced_classes_reorder/input.py.snap
+++ b/tests/fixtures/alphabetize/unreferenced_classes_reorder/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/alphabetize/unreferenced_classes_reorder/input.py
+---
+class Alpha:
+    pass
+
+
+class Beta:
+    pass

--- a/tests/fixtures/alphabetize/unreferenced_classes_reorder/meta.toml
+++ b/tests/fixtures/alphabetize/unreferenced_classes_reorder/meta.toml
@@ -1,0 +1,8 @@
+[docs]
+previewable = false
+title       = "Classes With No Cross-Reference Still Sort"
+
+description = '''
+Neither class names the other, so the run collapses to a single tier and sorts
+by name exactly as before, moving `Alpha` ahead of `Beta`.
+'''

--- a/tests/fixtures/thematic/stacked_decorators_signature_align/diagnostics.snap
+++ b/tests/fixtures/thematic/stacked_decorators_signature_align/diagnostics.snap
@@ -3,9 +3,8 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/thematic/stacked_decorators_signature_align/input.py
 ---
-alphabetize@19..303
 bare-imports@7..16
-blank-lines@252..253
-blank-lines@283..285
-docstring-frame@135..224
-docstring-wrap@184..216
+blank-lines@49..50
+blank-lines@78..80
+docstring-frame@196..285
+docstring-wrap@248..280

--- a/tests/fixtures/thematic/stacked_decorators_signature_align/input.py.snap
+++ b/tests/fixtures/thematic/stacked_decorators_signature_align/input.py.snap
@@ -1,10 +1,17 @@
 ---
 source: tests/integration.rs
-assertion_line: 28
 expression: output
 input_file: tests/fixtures/thematic/stacked_decorators_signature_align/input.py
 ---
 import functools
+
+
+def memoize(fn):
+    return fn
+
+
+def trace(fn):
+    return fn
 
 
 @memoize
@@ -16,11 +23,3 @@ def lookup(key: str, default: int = 0, ttl: float = 60.0):
     the default.
     """
     return key
-
-
-def memoize(fn):
-    return fn
-
-
-def trace(fn):
-    return fn


### PR DESCRIPTION
### 🪻 Quick Summary

Pins a run of sibling class and function definitions in place behind any sibling it names at evaluation time, so `alphabetize` can no longer reorder a definition above a name it references and raise `NameError` when the module imports. The rule already routed module-level assignment runs through a topological-tier guard that declines any run it cannot prove safe, and this change extends that guard to class and function runs, building each run's intra-run reference graph from its evaluation-time surface (*base classes and class keywords, decorators, parameter defaults, non-deferred annotations, and class-body values*) and ordering by the resulting tier with the existing name sort breaking ties within a tier.

A reference inside a function or lambda body is deferred and does not pin, an annotation stops pinning under `from __future__ import annotations`, and a run whose references cycle or whose members collide on a name stays in source order untouched.

---

### 🗞️ Key Changes

- Extends the topological-tier guard from module-level assignment runs to class and function definition runs, keying the run's order on a Kahn-style tier from `tier_levels` so a definition never sorts ahead of a sibling it names at evaluation time, with the existing name sort breaking ties within a tier.

- Collects each definition's evaluation-time surface through an `EvalRefVisitor` (*its base classes and class keywords, decorators, parameter defaults, non-deferred annotations, and the top level of a class body*), descending into nested definitions while pruning every function and lambda body so a deferred reference never constrains the order.

- Skips annotation references when the module carries `from __future__ import annotations`, where the annotation no longer evaluates at definition time, while a base class, decorator, class-body value, or parameter default pins the order whatever the annotation mode.

- Declines a run whose reference graph carries a cycle or whose members share a name, leaving it in source order rather than risk an unsafe reorder, matching how the assignment-run path already bails on a run it cannot prove.

- Lifts `from __future__ import annotations` detection into a shared `future_annotations_alias` in `src/primitives/imports.rs`, consumed by both the new guard and `unused-future-annotations`, which drops its local copy.

- Covers the four reference surfaces, the deferred-body and future-annotation controls, the unreferenced-reorder baseline, and the cycle decline with fixtures, and corrects the `stacked_decorators_signature_align` fixture, whose prior expected output reordered a function ahead of its own decorators and would have raised `NameError` on import.

---

### ☕ Implementation Notes

#### Tiering on Intra-Run Names Rather Than `is_defined_before`

The spec framed the guard as reusing the `BindingAnalysis::is_defined_before` wiring the module-assignment path relies on, but a definition run cannot tier on that check. The assignment run is contiguous, so its access-root check can prove an external reference is bound before the run begins. A definition run is not contiguous, and its evaluation-time references are dominated by builtins and imports (*a base class like `Exception`, a framework decorator*) that carry no module-scope write to resolve against, so that proof would decline almost every real class.

The guard instead builds the reference graph from bare name matches against the run's own members and orders by the resulting tier, excluding a definition's self-reference so a recursive type hint (*`def child(self) -> Node` inside `class Node`*) constrains nothing rather than self-looping the whole run into a decline.

---

### 🧵 Related Issues

- Closes #210