### PR TITLE
[237] Finalize `0.4.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.96"
-version      = "0.3.0"
+version      = "0.4.0"
 
 [dependencies]
 annotate-snippets  = "=0.12.13"


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes the fourth *Prose* release. Bumps `Cargo.toml` from `0.3.0` to `0.4.0` and regenerates `Cargo.lock` against the new version. The `0.4` cycle brings *Prose* into the editor through a `prose server` language server, adds the `import-layout` and `call-layout` rules, makes an `alphabetize` signature reorder safe by rewriting positional call sites to keyword form, hoists module-level constants into dependency-ordered bands, teaches `align-colons` to align commented dicts, and lands a run of layout and edit-assembly fixes.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` from `0.3.0` to `0.4.0` and regenerates `Cargo.lock` against the new version

---

### 🧵 Related Issues

- Closes #237