### PR TITLE
[239] Re-sort the release-note changelog categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,8 @@
 changelog:
   categories:
+    - title: 🐞 Bugs
+      labels:
+        - 🐞 bug
     - title: ✨ Features
       labels:
         - 🦉 engine
@@ -7,22 +10,18 @@ changelog:
         - 🪉 ordering
         - 🪶 formatting
         - 🧶 lint
-    - title: 🐞 Bugs
-      labels:
-        - 🐞 bug
     - title: 🪄 CLI
       labels:
         - 🪄 cli
-    - title: 📰 Docs
+    - title: 📻 FYI
       labels:
         - 📰 docs
-    - title: 🗜️ Build
-      labels:
-        - 🗜️ build
+        - 🗝️ site
     - title: 🧱 Internals
       labels:
         - ⚖️ tests
         - 🗺️ architecture
+        - 🗜️ build
     - title: Other
       labels:
         - "*"


### PR DESCRIPTION
### 🪻 Quick Summary

Re-sorts the changelog categories GitHub reads from `.github/release.yml` when it generates a release's notes, so a bug-fix PR lands under Bugs rather than Features. GitHub drops each merged PR into the first category whose labels it matches, and because a regression fix carries a rule label *(`🦉 engine`, `🪉 ordering`, `🪜 alignment`, or `🪶 formatting`)* beside `🐞 bug`, the old order let Features claim it ahead of the lower-sitting Bugs section. Lifting `🐞 Bugs` to the head of the list keeps a tagged fix in Bugs, and the same pass tidies the surrounding categories, fusing `📰 docs` and `🗝️ site` into one `📻 FYI` heading and folding `🗜️ build` into Internals.

---

### 🗞️ Key Changes

- Moves `🐞 Bugs` to the head of the category list so a PR carrying `🐞 bug` sorts into Bugs ahead of the rule label it also carries, where the previous order routed every regression fix into Features under GitHub's first-match-wins bucketing.

- Fuses `📰 docs` and `🗝️ site` into a single `📻 FYI` category, replacing the standalone Docs heading and giving site-labeled PRs a home rather than dropping them into the `*` catch-all.

- Folds `🗜️ build` into Internals beside `⚖️ tests` and `🗺️ architecture`, retiring the standalone Build category so release plumbing sits with the rest of the internal-facing work.

---

### 🧵 Related Issues

- Closes #239