### PR TITLE
[242] Drop the trailing comma from `signature-layout`'s exploded emission

### DIFF
--- a/site/rules/signature-layout.md
+++ b/site/rules/signature-layout.md
@@ -12,7 +12,7 @@ layout   : doc
 
 A function signature reads as either a one-line declaration or a stacked column of parameters. Mixed shapes (*part on the `def` line, the rest indented underneath*) force the reader to track two layout idioms at once. `signature-layout` collapses every signature to the binary canonical form, deciding the shape from `code-line-length` and `max-inline-params`.
 
-The rule expands a signature when its inline form overflows the configured `code-line-length`, or when its parameter count exceeds `max-inline-params`. Otherwise the signature collapses to a single line. A comment inside the parameter list pins the existing shape, because moving the parameters would orphan the comment from its anchor. The expanded form lays each parameter on its own line, indented one step past the `def`, with the closing `)` flush left and the return annotation trailing on the same line.
+The rule expands a signature when its inline form overflows the configured `code-line-length`, or when its parameter count exceeds `max-inline-params`. Otherwise the signature collapses to a single line. A comment inside the parameter list pins the existing shape, because moving the parameters would orphan the comment from its anchor. The expanded form lays each parameter on its own line, indented one step past the `def`, with the closing `)` flush left, the return annotation trailing on the same line, and the final parameter ending bare, the shape [[strip-trailing-commas]] accepts.
 
 <template #configuration>
 

--- a/site/rules/strip-trailing-commas.md
+++ b/site/rules/strip-trailing-commas.md
@@ -1,7 +1,7 @@
 ---
 category : auto-fix
 family   : formatting
-caption  : "removes trailing commas from inside single-line collections."
+caption  : "removes trailing commas from collections, signatures, calls, and every other bracketed container."
 related  : [collection-layout, align-colons]
 layout   : doc
 ---

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -20,14 +20,13 @@ pub use records::{CacheEntry, CacheInfo, CleanReport, Rewrite};
 
 #[cfg(test)]
 mod tests {
-    use ruff_diagnostics::{Edit, Fix};
     use tempfile::TempDir;
 
     use super::key::CACHE_FORMAT_VERSION;
     use super::*;
-    use crate::diagnostics::{Diagnostic, Severity};
+    use crate::diagnostics::Diagnostic;
     use crate::rule::RuleId;
-    use crate::testing::range;
+    use crate::testing::{format_diagnostic, range};
 
     const CONFIG_A: &str = "code-line-length = 88\n";
     const CONFIG_B: &str = "code-line-length = 100\n";
@@ -41,25 +40,16 @@ mod tests {
         }
     }
 
-    fn entry(formatted: Option<&str>) -> CacheEntry {
+    fn entry(formatted: &str) -> CacheEntry {
         CacheEntry {
             // The rule must be a registered slug, because `RuleId`
             // deserializes through the registry and an unknown slug
             // fails the entry's round-trip.
             diagnostics: vec![Diagnostic {
-                fix: Some(Fix::safe_edit(Edit::range_replacement(
-                    "y".into(),
-                    range(0, 1),
-                ))),
-                message: "rewrite".into(),
-                range: range(0, 1),
                 rule: RuleId::from("align-equals"),
-                severity: Severity::Format,
+                ..format_diagnostic(range(0, 1))
             }],
-            rewrite: match formatted {
-                Some(text) => Rewrite::Changed(text.to_owned()),
-                None => Rewrite::Unchanged,
-            },
+            rewrite: Rewrite::Changed(formatted.to_owned()),
         }
     }
 
@@ -121,7 +111,7 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
         let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        cache.insert(&key, &entry(Some("y = 1\n")));
+        cache.insert(&key, &entry("y = 1\n"));
         let report = cache.clean().expect("cleans");
         assert_eq!(report.entries, 1);
         assert!(report.bytes > 0);
@@ -143,9 +133,9 @@ mod tests {
         let cache = cache_in(&tmp, 100);
         let key_old = CacheKey::compute(b"x = 1\n", CONFIG_A);
         let key_new = CacheKey::compute(b"y = 2\n", CONFIG_A);
-        cache.insert(&key_old, &entry(Some("a = 1\n")));
+        cache.insert(&key_old, &entry("a = 1\n"));
         std::thread::sleep(std::time::Duration::from_millis(20));
-        cache.insert(&key_new, &entry(Some("b = 2\n")));
+        cache.insert(&key_new, &entry("b = 2\n"));
 
         let tightened = Cache {
             max_size_bytes: 0,
@@ -162,7 +152,7 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
         let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        cache.insert(&key, &entry(Some("y = 1\n")));
+        cache.insert(&key, &entry("y = 1\n"));
         let report = cache.compact();
         assert_eq!(report.entries, 0);
         assert_eq!(report.bytes, 0);
@@ -172,14 +162,8 @@ mod tests {
     fn info_counts_entries_and_byte_total() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        cache.insert(
-            &CacheKey::compute(b"x = 1\n", CONFIG_A),
-            &entry(Some("y = 1\n")),
-        );
-        cache.insert(
-            &CacheKey::compute(b"x = 2\n", CONFIG_A),
-            &entry(Some("y = 2\n")),
-        );
+        cache.insert(&CacheKey::compute(b"x = 1\n", CONFIG_A), &entry("y = 1\n"));
+        cache.insert(&CacheKey::compute(b"x = 2\n", CONFIG_A), &entry("y = 2\n"));
         let info = cache.info();
         assert_eq!(info.entries, 2);
         assert!(info.bytes > 0);
@@ -214,9 +198,9 @@ mod tests {
         let cache = cache_in(&tmp, 0);
         let key_old = CacheKey::compute(b"x = 1\n", CONFIG_A);
         let key_new = CacheKey::compute(b"y = 2\n", CONFIG_A);
-        cache.insert(&key_old, &entry(Some("a = 1\n")));
+        cache.insert(&key_old, &entry("a = 1\n"));
         std::thread::sleep(std::time::Duration::from_millis(20));
-        cache.insert(&key_new, &entry(Some("b = 2\n")));
+        cache.insert(&key_new, &entry("b = 2\n"));
         assert!(cache.lookup(&key_old).is_none());
     }
 
@@ -225,7 +209,7 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
         let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        cache.insert(&key, &entry(Some("y = 1\n")));
+        cache.insert(&key, &entry("y = 1\n"));
         let tmp_count = fs_err::read_dir(&cache.root)
             .expect("read_dir")
             .flatten()
@@ -252,7 +236,7 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
         let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        let original = entry(Some("y = 1\n"));
+        let original = entry("y = 1\n");
         cache.insert(&key, &original);
         let recovered = cache.lookup(&key).expect("hit");
         assert_eq!(recovered, original);

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -21,13 +21,13 @@ pub use records::{CacheEntry, CacheInfo, CleanReport, Rewrite};
 #[cfg(test)]
 mod tests {
     use ruff_diagnostics::{Edit, Fix};
-    use ruff_text_size::TextRange;
     use tempfile::TempDir;
 
     use super::key::CACHE_FORMAT_VERSION;
     use super::*;
     use crate::diagnostics::{Diagnostic, Severity};
     use crate::rule::RuleId;
+    use crate::testing::range;
 
     const CONFIG_A: &str = "code-line-length = 88\n";
     const CONFIG_B: &str = "code-line-length = 100\n";
@@ -43,6 +43,9 @@ mod tests {
 
     fn entry(formatted: Option<&str>) -> CacheEntry {
         CacheEntry {
+            // The rule must be a registered slug, because `RuleId`
+            // deserializes through the registry and an unknown slug
+            // fails the entry's round-trip.
             diagnostics: vec![Diagnostic {
                 fix: Some(Fix::safe_edit(Edit::range_replacement(
                     "y".into(),
@@ -58,10 +61,6 @@ mod tests {
                 None => Rewrite::Unchanged,
             },
         }
-    }
-
-    fn range(start: u32, end: u32) -> TextRange {
-        TextRange::new(start.into(), end.into())
     }
 
     #[test]

--- a/src/cache/records.rs
+++ b/src/cache/records.rs
@@ -8,7 +8,7 @@ use crate::diagnostics::Diagnostic;
 
 /// Post-pipeline state cached per `(source, config, version)` key. The
 /// diagnostics are always anchored to the source as written, leaving any
-/// mode free to render them. The rewrite is present only when the writing
+/// mode free to render them. The rewrite is `Skipped` unless the writing
 /// mode ran [`Pipeline::run`](crate::pipeline::Pipeline::run).
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CacheEntry {
@@ -33,10 +33,10 @@ pub struct CleanReport {
     pub entries: usize,
 }
 
-/// What a cached entry holds for the file's rewrite. `Skipped` marks an
-/// entry a `check` run wrote without computing the rewrite, whereas the
-/// other two record a completed `run`.
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+/// What a mode knows about the file's rewrite. `Skipped` marks a mode
+/// that never computed the rewrite, whereas the other two record a
+/// completed `run`.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Rewrite {
     /// `run` produced text differing from the original.
     Changed(String),

--- a/src/cli/runner/diff.rs
+++ b/src/cli/runner/diff.rs
@@ -27,3 +27,47 @@ pub(super) fn write_diff<W: Write>(
     unified.to_writer(writer).context("writing diff")?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_diff_decorates_with_thread_anchor() {
+        let mut buf = Vec::new();
+        {
+            let mut writer = anstream::AutoStream::never(&mut buf);
+            write_diff(
+                &mut writer,
+                "sample.py",
+                "ab = 1\nx = 2\n",
+                "ab = 1\nx  = 2\n",
+                true,
+            )
+            .expect("writes");
+        }
+        let out = String::from_utf8(buf).expect("utf-8");
+        assert!(out.contains("🧵 sample.py"), "anchor missing: {out:?}");
+        assert!(!out.contains("--- "), "plain header leaked: {out:?}");
+        assert!(out.contains("@@"), "hunks missing: {out:?}");
+    }
+
+    #[test]
+    fn write_diff_plain_keeps_the_patch_header() {
+        let mut buf = Vec::new();
+        write_diff(
+            &mut buf,
+            "sample.py",
+            "ab = 1\nx = 2\n",
+            "ab = 1\nx  = 2\n",
+            false,
+        )
+        .expect("writes");
+        let out = String::from_utf8(buf).expect("utf-8");
+        assert!(
+            out.contains("--- sample.py"),
+            "patch header missing: {out:?}"
+        );
+        assert!(!out.contains('🧵'), "decoration leaked: {out:?}");
+    }
+}

--- a/src/cli/runner/mod.rs
+++ b/src/cli/runner/mod.rs
@@ -14,7 +14,7 @@ use super::{
     output::Presentation,
 };
 use crate::{
-    cache::Cache,
+    cache::{Cache, Rewrite},
     config::Config,
     diagnostics::{Diagnostic, Severity},
     pipeline::Pipeline,
@@ -37,7 +37,7 @@ enum FileOutcome {
         cached: bool,
         diagnostics: Vec<Diagnostic>,
         file: SourceFile,
-        formatted_text: Option<String>,
+        rewrite: Rewrite,
     },
     Failed(ExitStatus),
 }
@@ -182,7 +182,7 @@ fn format_paths_diff<O: Write, E: Write>(
     for outcome in &outcomes {
         if let FileOutcome::Done {
             file,
-            formatted_text: Some(formatted),
+            rewrite: Rewrite::Changed(formatted),
             ..
         } = outcome
         {
@@ -243,14 +243,9 @@ fn format_stdin<R: Read, O: Write, E: Write>(
     let outcome = process_stdin(stdin, pipeline, format_pass(diff, format));
     let outcomes = std::slice::from_ref(&outcome);
     let summary = emitter_summary(outcomes);
-    if let FileOutcome::Done {
-        file,
-        formatted_text,
-        ..
-    } = &outcome
-    {
+    if let FileOutcome::Done { file, rewrite, .. } = &outcome {
         if diff {
-            if let Some(formatted) = formatted_text {
+            if let Rewrite::Changed(formatted) = rewrite {
                 write_diff(
                     writer,
                     "<stdin>",
@@ -260,7 +255,11 @@ fn format_stdin<R: Read, O: Write, E: Write>(
                 )?;
             }
         } else if format.is_text() {
-            let to_write = formatted_text.as_deref().unwrap_or(file.source_text());
+            let to_write = match rewrite {
+                Rewrite::Changed(formatted) => formatted.as_str(),
+                Rewrite::Skipped => unreachable!("format passes compute the rewrite"),
+                Rewrite::Unchanged => file.source_text(),
+            };
             writer
                 .write_all(to_write.as_bytes())
                 .context("writing stdout")?;
@@ -299,35 +298,15 @@ mod tests {
     use ruff_text_size::TextRange;
     use tempfile::TempDir;
 
-    use super::process::{cache_rewrite, rehydrate, run_pipeline, walk_error};
+    use super::process::{rehydrate, run_pipeline, walk_error};
     use super::report::{file_changed, report_verbose};
     use super::*;
     use crate::cache::{CacheEntry, Rewrite};
     use crate::cli::output::Summary;
     use crate::diagnostics::{EmitterSummary, Severity};
-    use crate::rule::{Rule, RuleId};
+    use crate::rule::RuleId;
     use crate::source::Source;
-
-    /// Test-only rule whose single edit rewrites the leading statement
-    /// into unparseable source, exercising the reparse guard.
-    struct BreaksParse;
-
-    impl Rule for BreaksParse {
-        fn apply(&self, _source: &Source) -> Vec<Vec<Edit>> {
-            vec![vec![Edit::range_replacement(
-                "def foo(".to_owned(),
-                TextRange::new(0.into(), 5.into()),
-            )]]
-        }
-
-        fn id(&self) -> RuleId {
-            RuleId::from("breaks-parse")
-        }
-
-        fn message(&self) -> &'static str {
-            "breaks parse"
-        }
-    }
+    use crate::testing::{GroupSentinelRule, breaks_parse, parse, range};
 
     struct ErrorReader;
 
@@ -384,7 +363,7 @@ mod tests {
             cached: false,
             diagnostics,
             file: source.source_file().clone(),
-            formatted_text: None,
+            rewrite: Rewrite::Skipped,
         }
     }
 
@@ -393,16 +372,6 @@ mod tests {
             quiet: false,
             stdout_tty: false,
         }
-    }
-
-    #[test]
-    fn cache_rewrite_marks_skipped_unless_run_supplied_text() {
-        assert_matches!(cache_rewrite(false, None), Rewrite::Skipped);
-        assert_matches!(cache_rewrite(true, None), Rewrite::Unchanged);
-        assert_matches!(
-            cache_rewrite(true, Some("y = 1\n")),
-            Rewrite::Changed(text) if text == "y = 1\n"
-        );
     }
 
     #[test]
@@ -426,8 +395,8 @@ mod tests {
 
     #[test]
     fn check_outcomes_with_failed_parse_takes_higher_status() {
-        let source = "x = 1\n".parse::<Source>().expect("parses");
-        let range = TextRange::new(0.into(), 1.into());
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
         let outcomes = vec![
             outcome_with(
                 source,
@@ -443,8 +412,8 @@ mod tests {
 
     #[test]
     fn check_outcomes_with_lint_and_format_returns_lint_violation() {
-        let source = "x = 1\n".parse::<Source>().expect("parses");
-        let range = TextRange::new(0.into(), 1.into());
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
         let diagnostics = vec![
             diagnostic(Severity::Format, range, "synthetic-format"),
             diagnostic(Severity::Lint, range, "synthetic-lint"),
@@ -458,12 +427,8 @@ mod tests {
 
     #[test]
     fn check_outcomes_with_synthetic_lint_returns_lint_violation() {
-        let source = "x = 1\n".parse::<Source>().expect("parses");
-        let diagnostics = vec![diagnostic(
-            Severity::Lint,
-            TextRange::new(0.into(), 1.into()),
-            "synthetic-lint",
-        )];
+        let source = parse("x = 1\n");
+        let diagnostics = vec![diagnostic(Severity::Lint, range(0, 1), "synthetic-lint")];
         let outcomes = vec![outcome_with(source, diagnostics)];
 
         let status = status_from_outcomes(&outcomes, false);
@@ -555,8 +520,8 @@ mod tests {
 
     #[test]
     fn check_validate_fails_on_unparseable_rule_output() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(BreaksParse)]);
-        let source = "x = 1\n".parse::<Source>().expect("parses");
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
+        let source = parse("x = 1\n");
 
         let outcome = run_pipeline(source, &pipeline, Pass::Diagnose { validate: true });
 
@@ -565,20 +530,26 @@ mod tests {
 
     #[test]
     fn check_without_validate_ignores_unparseable_rule_output() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(BreaksParse)]);
-        let source = "x = 1\n".parse::<Source>().expect("parses");
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
+        let source = parse("x = 1\n");
 
         let outcome = run_pipeline(source, &pipeline, Pass::Diagnose { validate: false });
 
-        assert_matches!(outcome, FileOutcome::Done { .. });
+        assert_matches!(
+            outcome,
+            FileOutcome::Done {
+                rewrite: Rewrite::Skipped,
+                ..
+            }
+        );
     }
 
     #[test]
     fn emit_outcomes_propagates_writer_failure() {
-        let source = "x = 1\n".parse::<Source>().expect("parses");
+        let source = parse("x = 1\n");
         let diags = vec![diagnostic(
             Severity::Format,
-            TextRange::new(0.into(), 1.into()),
+            range(0, 1),
             "synthetic-format",
         )];
         let outcomes = vec![outcome_with(source, diags)];
@@ -601,7 +572,7 @@ mod tests {
         )]
         format: OutputFormat,
     ) {
-        let source = "x = 1\n".parse::<Source>().expect("parses");
+        let source = parse("x = 1\n");
         let outcomes = vec![outcome_with(source, Vec::new())];
         let mut buf = Vec::new();
         emit_outcomes(&outcomes, format, &mut buf, &EmitterSummary::default()).expect("emits");
@@ -609,18 +580,18 @@ mod tests {
 
     #[test]
     fn emitter_summary_counts_visited_changed_diagnostics_and_rules() {
-        let range = TextRange::new(0.into(), 1.into());
+        let range = range(0, 1);
         let mut changed = outcome_with(
-            "x = 1\n".parse::<Source>().expect("parses"),
+            parse("x = 1\n"),
             vec![
                 diagnostic(Severity::Format, range, "align-equals"),
                 diagnostic(Severity::Lint, range, "reassigned-constants"),
             ],
         );
-        if let FileOutcome::Done { formatted_text, .. } = &mut changed {
-            *formatted_text = Some("x   = 1\n".to_owned());
+        if let FileOutcome::Done { rewrite, .. } = &mut changed {
+            *rewrite = Rewrite::Changed("x   = 1\n".to_owned());
         }
-        let clean = outcome_with("y = 2\n".parse::<Source>().expect("parses"), Vec::new());
+        let clean = outcome_with(parse("y = 2\n"), Vec::new());
         let outcomes = vec![changed, clean, FileOutcome::Failed(ExitStatus::ParseError)];
 
         let summary = emitter_summary(&outcomes);
@@ -638,9 +609,9 @@ mod tests {
 
     #[test]
     fn emitter_summary_tallies_repeated_rule_occurrences() {
-        let range = TextRange::new(0.into(), 1.into());
+        let range = range(0, 1);
         let outcome = outcome_with(
-            "x = 1\n".parse::<Source>().expect("parses"),
+            parse("x = 1\n"),
             vec![
                 diagnostic(Severity::Format, range, "align-equals"),
                 diagnostic(Severity::Format, range, "align-equals"),
@@ -653,15 +624,16 @@ mod tests {
     }
 
     #[test]
-    fn file_changed_counts_a_rewrite_or_a_format_diagnostic() {
-        let range = TextRange::new(0.into(), 1.into());
+    fn file_changed_counts_a_changed_rewrite_or_a_skipped_format_diagnostic() {
+        let range = range(0, 1);
         let format = vec![diagnostic(Severity::Format, range, "synthetic-format")];
         let lint = vec![diagnostic(Severity::Lint, range, "synthetic-lint")];
 
-        assert!(file_changed(&[], Some("x = 1\n")));
-        assert!(file_changed(&format, None));
-        assert!(!file_changed(&lint, None));
-        assert!(!file_changed(&[], None));
+        assert!(file_changed(&[], &Rewrite::Changed("x = 1\n".to_owned())));
+        assert!(file_changed(&format, &Rewrite::Skipped));
+        assert!(!file_changed(&format, &Rewrite::Unchanged));
+        assert!(!file_changed(&lint, &Rewrite::Skipped));
+        assert!(!file_changed(&[], &Rewrite::Skipped));
     }
 
     #[test]
@@ -913,6 +885,22 @@ mod tests {
     }
 
     #[test]
+    fn rehydrate_marks_a_check_mode_outcome_skipped() {
+        let entry = CacheEntry {
+            diagnostics: Vec::new(),
+            rewrite: Rewrite::Changed("y = 1\n".to_owned()),
+        };
+        let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, false);
+        assert_matches!(
+            outcome,
+            Some(FileOutcome::Done {
+                rewrite: Rewrite::Skipped,
+                ..
+            })
+        );
+    }
+
+    #[test]
     fn rehydrate_returns_none_for_a_skipped_entry() {
         let entry = CacheEntry {
             diagnostics: Vec::new(),
@@ -930,7 +918,7 @@ mod tests {
         let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, true);
         assert_matches!(
             outcome,
-            Some(FileOutcome::Done { formatted_text: Some(text), .. }) if text == "y = 1\n"
+            Some(FileOutcome::Done { rewrite: Rewrite::Changed(text), .. }) if text == "y = 1\n"
         );
     }
 
@@ -944,7 +932,7 @@ mod tests {
         assert_matches!(
             outcome,
             Some(FileOutcome::Done {
-                formatted_text: None,
+                rewrite: Rewrite::Unchanged,
                 ..
             })
         );
@@ -960,7 +948,7 @@ mod tests {
     #[test]
     fn report_verbose_prints_hit_and_miss_counts() {
         let make = |cached: bool| {
-            let source: Source = "x = 1\n".parse().expect("parses");
+            let source = parse("x = 1\n");
             let mut o = outcome_with(source, Vec::new());
             if let FileOutcome::Done { cached: c, .. } = &mut o {
                 *c = cached;
@@ -983,8 +971,8 @@ mod tests {
 
     #[test]
     fn rewrite_pass_fails_on_unparseable_rule_output() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(BreaksParse)]);
-        let source = "x = 1\n".parse::<Source>().expect("parses");
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
+        let source = parse("x = 1\n");
 
         let outcome = run_pipeline(source, &pipeline, Pass::Rewrite);
 
@@ -992,13 +980,66 @@ mod tests {
     }
 
     #[test]
+    fn run_pipeline_reports_unchanged_when_edits_cancel() {
+        let range = range(0, 1);
+        let pipeline = Pipeline::from_rules(vec![
+            Box::new(GroupSentinelRule {
+                groups: vec![vec![Edit::range_replacement("y".to_owned(), range)]],
+                id: RuleId::from("x-to-y"),
+            }),
+            Box::new(GroupSentinelRule {
+                groups: vec![vec![Edit::range_replacement("x".to_owned(), range)]],
+                id: RuleId::from("y-to-x"),
+            }),
+        ]);
+        let source = parse("x = 1\n");
+
+        let outcome = run_pipeline(source, &pipeline, Pass::Rewrite);
+
+        assert_matches!(
+            &outcome,
+            FileOutcome::Done {
+                diagnostics,
+                rewrite: Rewrite::Unchanged,
+                ..
+            } if diagnostics.len() == 2
+        );
+        assert_eq!(
+            status_from_outcomes(std::slice::from_ref(&outcome), false),
+            ExitStatus::Clean,
+        );
+    }
+
+    #[test]
+    fn status_from_outcomes_clears_format_change_for_an_unchanged_rewrite() {
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
+        let mut outcome = outcome_with(
+            source,
+            vec![
+                diagnostic(Severity::Format, range, "synthetic-format"),
+                diagnostic(Severity::Lint, range, "synthetic-lint"),
+            ],
+        );
+        if let FileOutcome::Done { rewrite, .. } = &mut outcome {
+            *rewrite = Rewrite::Unchanged;
+        }
+        let outcomes = vec![outcome];
+
+        assert_eq!(
+            status_from_outcomes(&outcomes, false),
+            ExitStatus::LintViolation,
+        );
+    }
+
+    #[test]
     fn status_from_outcomes_demotes_format_change_when_demoted() {
-        let source = "x = 1\n".parse::<Source>().expect("parses");
+        let source = parse("x = 1\n");
         let outcomes = vec![outcome_with(
             source,
             vec![diagnostic(
                 Severity::Format,
-                TextRange::new(0.into(), 1.into()),
+                range(0, 1),
                 "synthetic-format",
             )],
         )];
@@ -1011,15 +1052,11 @@ mod tests {
 
     #[test]
     fn summarize_reports_diagnostics_alongside_a_failure() {
-        let source = "x = 1\n".parse::<Source>().expect("parses");
+        let source = parse("x = 1\n");
         let outcomes = vec![
             outcome_with(
                 source,
-                vec![diagnostic(
-                    Severity::Lint,
-                    TextRange::new(0.into(), 1.into()),
-                    "synthetic-lint",
-                )],
+                vec![diagnostic(Severity::Lint, range(0, 1), "synthetic-lint")],
             ),
             FileOutcome::Failed(ExitStatus::ParseError),
         ];

--- a/src/cli/runner/mod.rs
+++ b/src/cli/runner/mod.rs
@@ -290,41 +290,17 @@ fn open_cache(config: &Config, no_cache: bool) -> Option<Cache> {
 #[cfg(test)]
 mod tests {
     use std::io::{self, Cursor};
-    use std::path::Path;
 
     use assert_matches::assert_matches;
-    use rstest::rstest;
-    use ruff_diagnostics::{Edit, Fix};
-    use ruff_text_size::TextRange;
     use tempfile::TempDir;
 
-    use super::process::{rehydrate, run_pipeline, walk_error};
-    use super::report::{file_changed, report_verbose};
     use super::*;
-    use crate::cache::{CacheEntry, Rewrite};
-    use crate::cli::output::Summary;
-    use crate::diagnostics::{EmitterSummary, Severity};
-    use crate::rule::RuleId;
-    use crate::source::Source;
-    use crate::testing::{GroupSentinelRule, breaks_parse, parse, range};
 
     struct ErrorReader;
 
     impl Read for ErrorReader {
         fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
             Err(io::Error::other("simulated stdin failure"))
-        }
-    }
-
-    struct FailingWriter;
-
-    impl Write for FailingWriter {
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-
-        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
-            Err(io::Error::other("simulated write failure"))
         }
     }
 
@@ -337,17 +313,6 @@ mod tests {
         }
     }
 
-    fn diagnostic(severity: Severity, range: TextRange, slug: &'static str) -> Diagnostic {
-        Diagnostic {
-            fix: matches!(severity, Severity::Format)
-                .then(|| Fix::safe_edit(Edit::range_replacement("y".into(), range))),
-            message: "test".into(),
-            range,
-            rule: RuleId::from(slug),
-            severity,
-        }
-    }
-
     fn format_args(paths: Vec<PathBuf>, stdin: bool, diff: bool) -> FormatArgs {
         FormatArgs {
             diff,
@@ -355,15 +320,6 @@ mod tests {
             paths,
             stdin,
             ..Default::default()
-        }
-    }
-
-    fn outcome_with(source: Source, diagnostics: Vec<Diagnostic>) -> FileOutcome {
-        FileOutcome::Done {
-            cached: false,
-            diagnostics,
-            file: source.source_file().clone(),
-            rewrite: Rewrite::Skipped,
         }
     }
 
@@ -391,49 +347,6 @@ mod tests {
         .expect("runs successfully");
 
         assert_eq!(status, ExitStatus::Clean);
-    }
-
-    #[test]
-    fn check_outcomes_with_failed_parse_takes_higher_status() {
-        let source = parse("x = 1\n");
-        let range = range(0, 1);
-        let outcomes = vec![
-            outcome_with(
-                source,
-                vec![diagnostic(Severity::Format, range, "synthetic-format")],
-            ),
-            FileOutcome::Failed(ExitStatus::ParseError),
-        ];
-
-        let status = status_from_outcomes(&outcomes, false);
-
-        assert_eq!(status, ExitStatus::ParseError);
-    }
-
-    #[test]
-    fn check_outcomes_with_lint_and_format_returns_lint_violation() {
-        let source = parse("x = 1\n");
-        let range = range(0, 1);
-        let diagnostics = vec![
-            diagnostic(Severity::Format, range, "synthetic-format"),
-            diagnostic(Severity::Lint, range, "synthetic-lint"),
-        ];
-        let outcomes = vec![outcome_with(source, diagnostics)];
-
-        let status = status_from_outcomes(&outcomes, false);
-
-        assert_eq!(status, ExitStatus::LintViolation);
-    }
-
-    #[test]
-    fn check_outcomes_with_synthetic_lint_returns_lint_violation() {
-        let source = parse("x = 1\n");
-        let diagnostics = vec![diagnostic(Severity::Lint, range(0, 1), "synthetic-lint")];
-        let outcomes = vec![outcome_with(source, diagnostics)];
-
-        let status = status_from_outcomes(&outcomes, false);
-
-        assert_eq!(status, ExitStatus::LintViolation);
     }
 
     #[test]
@@ -516,124 +429,6 @@ mod tests {
         )
         .expect("runs without anyhow");
         assert_eq!(status, ExitStatus::ParseError);
-    }
-
-    #[test]
-    fn check_validate_fails_on_unparseable_rule_output() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
-        let source = parse("x = 1\n");
-
-        let outcome = run_pipeline(source, &pipeline, Pass::Diagnose { validate: true });
-
-        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
-    }
-
-    #[test]
-    fn check_without_validate_ignores_unparseable_rule_output() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
-        let source = parse("x = 1\n");
-
-        let outcome = run_pipeline(source, &pipeline, Pass::Diagnose { validate: false });
-
-        assert_matches!(
-            outcome,
-            FileOutcome::Done {
-                rewrite: Rewrite::Skipped,
-                ..
-            }
-        );
-    }
-
-    #[test]
-    fn emit_outcomes_propagates_writer_failure() {
-        let source = parse("x = 1\n");
-        let diags = vec![diagnostic(
-            Severity::Format,
-            range(0, 1),
-            "synthetic-format",
-        )];
-        let outcomes = vec![outcome_with(source, diags)];
-        let result = emit_outcomes(
-            &outcomes,
-            OutputFormat::Json,
-            &mut FailingWriter,
-            &EmitterSummary::default(),
-        );
-        assert!(result.is_err());
-    }
-
-    #[rstest]
-    fn emit_outcomes_renders_each_output_format(
-        #[values(
-            OutputFormat::Github,
-            OutputFormat::Json,
-            OutputFormat::Sarif,
-            OutputFormat::Text
-        )]
-        format: OutputFormat,
-    ) {
-        let source = parse("x = 1\n");
-        let outcomes = vec![outcome_with(source, Vec::new())];
-        let mut buf = Vec::new();
-        emit_outcomes(&outcomes, format, &mut buf, &EmitterSummary::default()).expect("emits");
-    }
-
-    #[test]
-    fn emitter_summary_counts_visited_changed_diagnostics_and_rules() {
-        let range = range(0, 1);
-        let mut changed = outcome_with(
-            parse("x = 1\n"),
-            vec![
-                diagnostic(Severity::Format, range, "align-equals"),
-                diagnostic(Severity::Lint, range, "reassigned-constants"),
-            ],
-        );
-        if let FileOutcome::Done { rewrite, .. } = &mut changed {
-            *rewrite = Rewrite::Changed("x   = 1\n".to_owned());
-        }
-        let clean = outcome_with(parse("y = 2\n"), Vec::new());
-        let outcomes = vec![changed, clean, FileOutcome::Failed(ExitStatus::ParseError)];
-
-        let summary = emitter_summary(&outcomes);
-
-        assert_eq!(summary.files_visited, 2);
-        assert_eq!(summary.files_changed, 1);
-        assert_eq!(summary.files_with_diagnostics, 1);
-        assert_eq!(summary.diagnostics_total, 2);
-        assert_eq!(summary.rules_fired[&RuleId::from("align-equals")], 1);
-        assert_eq!(
-            summary.rules_fired[&RuleId::from("reassigned-constants")],
-            1
-        );
-    }
-
-    #[test]
-    fn emitter_summary_tallies_repeated_rule_occurrences() {
-        let range = range(0, 1);
-        let outcome = outcome_with(
-            parse("x = 1\n"),
-            vec![
-                diagnostic(Severity::Format, range, "align-equals"),
-                diagnostic(Severity::Format, range, "align-equals"),
-            ],
-        );
-
-        let summary = emitter_summary(std::slice::from_ref(&outcome));
-
-        assert_eq!(summary.rules_fired[&RuleId::from("align-equals")], 2);
-    }
-
-    #[test]
-    fn file_changed_counts_a_changed_rewrite_or_a_skipped_format_diagnostic() {
-        let range = range(0, 1);
-        let format = vec![diagnostic(Severity::Format, range, "synthetic-format")];
-        let lint = vec![diagnostic(Severity::Lint, range, "synthetic-lint")];
-
-        assert!(file_changed(&[], &Rewrite::Changed("x = 1\n".to_owned())));
-        assert!(file_changed(&format, &Rewrite::Skipped));
-        assert!(!file_changed(&format, &Rewrite::Unchanged));
-        assert!(!file_changed(&lint, &Rewrite::Skipped));
-        assert!(!file_changed(&[], &Rewrite::Skipped));
     }
 
     #[test]
@@ -865,255 +660,5 @@ mod tests {
         .expect("runs successfully");
 
         assert_eq!(status, ExitStatus::ConfigError);
-    }
-
-    #[test]
-    fn process_path_returns_config_error_on_missing_file() {
-        let tmp = TempDir::new().expect("tempdir");
-        let config = Config::default();
-        let setup = RunSetup {
-            cache: None,
-            config_toml: String::new(),
-            pipeline: Pipeline::with_filters(&config, &[], &[]),
-        };
-        let outcome = process_path(
-            &tmp.path().join("does_not_exist.py"),
-            &setup,
-            Pass::Diagnose { validate: false },
-        );
-        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
-    }
-
-    #[test]
-    fn rehydrate_marks_a_check_mode_outcome_skipped() {
-        let entry = CacheEntry {
-            diagnostics: Vec::new(),
-            rewrite: Rewrite::Changed("y = 1\n".to_owned()),
-        };
-        let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, false);
-        assert_matches!(
-            outcome,
-            Some(FileOutcome::Done {
-                rewrite: Rewrite::Skipped,
-                ..
-            })
-        );
-    }
-
-    #[test]
-    fn rehydrate_returns_none_for_a_skipped_entry() {
-        let entry = CacheEntry {
-            diagnostics: Vec::new(),
-            rewrite: Rewrite::Skipped,
-        };
-        assert!(rehydrate(Path::new("a.py"), b"x = 1\n", entry, true).is_none());
-    }
-
-    #[test]
-    fn rehydrate_serves_a_changed_rewrite_to_a_format_mode() {
-        let entry = CacheEntry {
-            diagnostics: Vec::new(),
-            rewrite: Rewrite::Changed("y = 1\n".to_owned()),
-        };
-        let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, true);
-        assert_matches!(
-            outcome,
-            Some(FileOutcome::Done { rewrite: Rewrite::Changed(text), .. }) if text == "y = 1\n"
-        );
-    }
-
-    #[test]
-    fn rehydrate_serves_an_unchanged_rewrite_as_no_edit() {
-        let entry = CacheEntry {
-            diagnostics: Vec::new(),
-            rewrite: Rewrite::Unchanged,
-        };
-        let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, true);
-        assert_matches!(
-            outcome,
-            Some(FileOutcome::Done {
-                rewrite: Rewrite::Unchanged,
-                ..
-            })
-        );
-    }
-
-    #[test]
-    fn report_verbose_prints_bypassed_when_cache_disabled() {
-        let mut buf = Vec::new();
-        report_verbose(&[], false, &mut buf);
-        assert_eq!(String::from_utf8(buf).expect("utf-8"), "cache: bypassed\n");
-    }
-
-    #[test]
-    fn report_verbose_prints_hit_and_miss_counts() {
-        let make = |cached: bool| {
-            let source = parse("x = 1\n");
-            let mut o = outcome_with(source, Vec::new());
-            if let FileOutcome::Done { cached: c, .. } = &mut o {
-                *c = cached;
-            }
-            o
-        };
-        let outcomes = vec![
-            make(true),
-            make(true),
-            make(false),
-            FileOutcome::Failed(ExitStatus::Clean),
-        ];
-        let mut buf = Vec::new();
-        report_verbose(&outcomes, true, &mut buf);
-        assert_eq!(
-            String::from_utf8(buf).expect("utf-8"),
-            "cache: 2 hits, 1 misses, 3 files\n",
-        );
-    }
-
-    #[test]
-    fn rewrite_pass_fails_on_unparseable_rule_output() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
-        let source = parse("x = 1\n");
-
-        let outcome = run_pipeline(source, &pipeline, Pass::Rewrite);
-
-        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
-    }
-
-    #[test]
-    fn run_pipeline_reports_unchanged_when_edits_cancel() {
-        let range = range(0, 1);
-        let pipeline = Pipeline::from_rules(vec![
-            Box::new(GroupSentinelRule {
-                groups: vec![vec![Edit::range_replacement("y".to_owned(), range)]],
-                id: RuleId::from("x-to-y"),
-            }),
-            Box::new(GroupSentinelRule {
-                groups: vec![vec![Edit::range_replacement("x".to_owned(), range)]],
-                id: RuleId::from("y-to-x"),
-            }),
-        ]);
-        let source = parse("x = 1\n");
-
-        let outcome = run_pipeline(source, &pipeline, Pass::Rewrite);
-
-        assert_matches!(
-            &outcome,
-            FileOutcome::Done {
-                diagnostics,
-                rewrite: Rewrite::Unchanged,
-                ..
-            } if diagnostics.len() == 2
-        );
-        assert_eq!(
-            status_from_outcomes(std::slice::from_ref(&outcome), false),
-            ExitStatus::Clean,
-        );
-    }
-
-    #[test]
-    fn status_from_outcomes_clears_format_change_for_an_unchanged_rewrite() {
-        let source = parse("x = 1\n");
-        let range = range(0, 1);
-        let mut outcome = outcome_with(
-            source,
-            vec![
-                diagnostic(Severity::Format, range, "synthetic-format"),
-                diagnostic(Severity::Lint, range, "synthetic-lint"),
-            ],
-        );
-        if let FileOutcome::Done { rewrite, .. } = &mut outcome {
-            *rewrite = Rewrite::Unchanged;
-        }
-        let outcomes = vec![outcome];
-
-        assert_eq!(
-            status_from_outcomes(&outcomes, false),
-            ExitStatus::LintViolation,
-        );
-    }
-
-    #[test]
-    fn status_from_outcomes_demotes_format_change_when_demoted() {
-        let source = parse("x = 1\n");
-        let outcomes = vec![outcome_with(
-            source,
-            vec![diagnostic(
-                Severity::Format,
-                range(0, 1),
-                "synthetic-format",
-            )],
-        )];
-        assert_eq!(status_from_outcomes(&outcomes, true), ExitStatus::Clean);
-        assert_eq!(
-            status_from_outcomes(&outcomes, false),
-            ExitStatus::FormatChange,
-        );
-    }
-
-    #[test]
-    fn summarize_reports_diagnostics_alongside_a_failure() {
-        let source = parse("x = 1\n");
-        let outcomes = vec![
-            outcome_with(
-                source,
-                vec![diagnostic(Severity::Lint, range(0, 1), "synthetic-lint")],
-            ),
-            FileOutcome::Failed(ExitStatus::ParseError),
-        ];
-        assert_matches!(
-            summarize(&outcomes, &emitter_summary(&outcomes), Mode::Check),
-            Some(Summary::Diagnostics { files: 1, total: 1 })
-        );
-    }
-
-    #[test]
-    fn summarize_suppresses_clean_summary_when_a_file_failed() {
-        let outcomes = vec![FileOutcome::Failed(ExitStatus::ParseError)];
-        assert!(summarize(&outcomes, &emitter_summary(&outcomes), Mode::Check).is_none());
-    }
-
-    #[test]
-    fn walk_error_returns_failed_with_config_error() {
-        let outcome = walk_error("synthetic walk failure");
-        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
-    }
-
-    #[test]
-    fn write_diff_decorates_with_thread_anchor() {
-        let mut buf = Vec::new();
-        {
-            let mut writer = anstream::AutoStream::never(&mut buf);
-            write_diff(
-                &mut writer,
-                "sample.py",
-                "ab = 1\nx = 2\n",
-                "ab = 1\nx  = 2\n",
-                true,
-            )
-            .expect("writes");
-        }
-        let out = String::from_utf8(buf).expect("utf-8");
-        assert!(out.contains("🧵 sample.py"), "anchor missing: {out:?}");
-        assert!(!out.contains("--- "), "plain header leaked: {out:?}");
-        assert!(out.contains("@@"), "hunks missing: {out:?}");
-    }
-
-    #[test]
-    fn write_diff_plain_keeps_the_patch_header() {
-        let mut buf = Vec::new();
-        write_diff(
-            &mut buf,
-            "sample.py",
-            "ab = 1\nx = 2\n",
-            "ab = 1\nx  = 2\n",
-            false,
-        )
-        .expect("writes");
-        let out = String::from_utf8(buf).expect("utf-8");
-        assert!(
-            out.contains("--- sample.py"),
-            "patch header missing: {out:?}"
-        );
-        assert!(!out.contains('🧵'), "decoration leaked: {out:?}");
     }
 }

--- a/src/cli/runner/process.rs
+++ b/src/cli/runner/process.rs
@@ -10,16 +10,16 @@ use rayon::iter::{ParallelBridge, ParallelIterator};
 use ruff_source_file::SourceFileBuilder;
 
 use super::{FileOutcome, Pass, RunSetup, has_format_change};
-use crate::cli::exit_status::ExitStatus;
 use crate::{
     cache::{CacheEntry, CacheKey, Rewrite},
+    cli::exit_status::ExitStatus,
     pipeline::Pipeline,
     source::Source,
     walker,
 };
 pub(super) fn apply_rewrite(path: &Path, outcome: FileOutcome) -> FileOutcome {
     let FileOutcome::Done {
-        formatted_text: Some(text),
+        rewrite: Rewrite::Changed(text),
         ..
     } = &outcome
     else {
@@ -29,19 +29,6 @@ pub(super) fn apply_rewrite(path: &Path, outcome: FileOutcome) -> FileOutcome {
         return config_error(e);
     }
     outcome
-}
-
-/// Records what a cached entry knows about the rewrite. A mode that
-/// skipped `run` stores `Skipped`, whereas one that ran it records
-/// whether the text changed.
-pub(super) fn cache_rewrite(needs_rewrite: bool, formatted_text: Option<&str>) -> Rewrite {
-    if !needs_rewrite {
-        return Rewrite::Skipped;
-    }
-    match formatted_text {
-        Some(text) => Rewrite::Changed(text.to_owned()),
-        None => Rewrite::Unchanged,
-    }
 }
 
 pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOutcome {
@@ -86,7 +73,7 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
         Some((c, k)),
         FileOutcome::Done {
             diagnostics,
-            formatted_text,
+            rewrite,
             ..
         },
     ) = (&keyed, &outcome)
@@ -95,7 +82,7 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
             k,
             &CacheEntry {
                 diagnostics: diagnostics.clone(),
-                rewrite: cache_rewrite(needs_rewrite, formatted_text.as_deref()),
+                rewrite: rewrite.clone(),
             },
         );
     }
@@ -132,15 +119,14 @@ pub(super) fn rehydrate(
     entry: CacheEntry,
     needs_rewrite: bool,
 ) -> Option<FileOutcome> {
-    let formatted_text = if needs_rewrite {
+    let rewrite = if needs_rewrite {
         match entry.rewrite {
-            Rewrite::Changed(text) => Some(text),
             // A `check` entry skipped the rewrite this mode needs.
             Rewrite::Skipped => return None,
-            Rewrite::Unchanged => None,
+            rewrite => rewrite,
         }
     } else {
-        None
+        Rewrite::Skipped
     };
     let original_text = std::str::from_utf8(original_bytes).ok()?.to_owned();
     let file = SourceFileBuilder::new(path.display().to_string(), original_text).finish();
@@ -148,7 +134,7 @@ pub(super) fn rehydrate(
         cached: true,
         diagnostics: entry.diagnostics,
         file,
-        formatted_text,
+        rewrite,
     })
 }
 
@@ -172,20 +158,20 @@ pub(super) fn run_pipeline(source: Source, pipeline: &Pipeline, pass: Pass) -> F
             cached: false,
             diagnostics,
             file,
-            formatted_text: None,
+            rewrite: Rewrite::Skipped,
         };
     }
     let diagnosed = matches!(pass, Pass::Both).then(|| pipeline.diagnose(&source));
     match pipeline.run(source) {
         Ok((formatted, run_diagnostics)) => {
-            let formatted_text = formatted
+            let rewrite = formatted
                 .changed_from(file.source_text())
-                .map(str::to_owned);
+                .map_or(Rewrite::Unchanged, |text| Rewrite::Changed(text.to_owned()));
             FileOutcome::Done {
                 cached: false,
                 diagnostics: diagnosed.unwrap_or(run_diagnostics),
                 file,
-                formatted_text,
+                rewrite,
             }
         }
         Err(e) => config_error(e),

--- a/src/cli/runner/process.rs
+++ b/src/cli/runner/process.rs
@@ -17,6 +17,7 @@ use crate::{
     source::Source,
     walker,
 };
+
 pub(super) fn apply_rewrite(path: &Path, outcome: FileOutcome) -> FileOutcome {
     let FileOutcome::Done {
         rewrite: Rewrite::Changed(text),
@@ -57,8 +58,7 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
     let text = match String::from_utf8(bytes) {
         Ok(t) => t,
         Err(e) => {
-            eprintln!("error: {} is not valid UTF-8: {e}", path.display());
-            return FileOutcome::Failed(ExitStatus::ConfigError);
+            return config_error(format_args!("{} is not valid UTF-8: {e}", path.display()));
         }
     };
     let source = match Source::build(text, path.display().to_string()) {
@@ -100,10 +100,9 @@ where
 }
 
 pub(super) fn process_stdin<R: Read>(stdin: R, pipeline: &Pipeline, pass: Pass) -> FileOutcome {
-    let Ok(text) =
-        io::read_to_string(stdin).inspect_err(|e| eprintln!("error: reading stdin: {e}"))
-    else {
-        return FileOutcome::Failed(ExitStatus::ConfigError);
+    let text = match io::read_to_string(stdin) {
+        Ok(t) => t,
+        Err(e) => return config_error(format_args!("reading stdin: {e}")),
     };
     text.parse::<Source>()
         .inspect_err(|e| eprintln!("error: parse error in stdin: {e}"))
@@ -179,8 +178,7 @@ pub(super) fn run_pipeline(source: Source, pipeline: &Pipeline, pass: Pass) -> F
 }
 
 pub(super) fn walk_error<E: std::fmt::Display>(err: E) -> FileOutcome {
-    eprintln!("error: cannot walk: {err}");
-    FileOutcome::Failed(ExitStatus::ConfigError)
+    config_error(format_args!("cannot walk: {err}"))
 }
 
 fn config_error(e: impl std::fmt::Display) -> FileOutcome {

--- a/src/cli/runner/process.rs
+++ b/src/cli/runner/process.rs
@@ -27,7 +27,7 @@ pub(super) fn apply_rewrite(path: &Path, outcome: FileOutcome) -> FileOutcome {
         return outcome;
     };
     if let Err(e) = fs_err::write(path, text) {
-        return config_error(e);
+        return failed(ExitStatus::ConfigError, e);
     }
     outcome
 }
@@ -35,7 +35,7 @@ pub(super) fn apply_rewrite(path: &Path, outcome: FileOutcome) -> FileOutcome {
 pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOutcome {
     let bytes = match fs_err::read(path) {
         Ok(b) => b,
-        Err(e) => return config_error(e),
+        Err(e) => return failed(ExitStatus::ConfigError, e),
     };
     // Plain `format` would persist only `run`'s post-edit diagnostics, and
     // a `--validate` check must re-confirm the rewrite parses rather than
@@ -58,14 +58,19 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
     let text = match String::from_utf8(bytes) {
         Ok(t) => t,
         Err(e) => {
-            return config_error(format_args!("{} is not valid UTF-8: {e}", path.display()));
+            return failed(
+                ExitStatus::ConfigError,
+                format_args!("{} is not valid UTF-8: {e}", path.display()),
+            );
         }
     };
     let source = match Source::build(text, path.display().to_string()) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("error: parse error in `{}`: {e}", path.display());
-            return FileOutcome::Failed(ExitStatus::ParseError);
+            return failed(
+                ExitStatus::ParseError,
+                format_args!("parse error in `{}`: {e}", path.display()),
+            );
         }
     };
     let outcome = run_pipeline(source, &setup.pipeline, pass);
@@ -102,14 +107,15 @@ where
 pub(super) fn process_stdin<R: Read>(stdin: R, pipeline: &Pipeline, pass: Pass) -> FileOutcome {
     let text = match io::read_to_string(stdin) {
         Ok(t) => t,
-        Err(e) => return config_error(format_args!("reading stdin: {e}")),
+        Err(e) => return failed(ExitStatus::ConfigError, format_args!("reading stdin: {e}")),
     };
-    text.parse::<Source>()
-        .inspect_err(|e| eprintln!("error: parse error in stdin: {e}"))
-        .map_or_else(
-            |_| FileOutcome::Failed(ExitStatus::ParseError),
-            |source| run_pipeline(source, pipeline, pass),
-        )
+    match text.parse::<Source>() {
+        Ok(source) => run_pipeline(source, pipeline, pass),
+        Err(e) => failed(
+            ExitStatus::ParseError,
+            format_args!("parse error in stdin: {e}"),
+        ),
+    }
 }
 
 pub(super) fn rehydrate(
@@ -151,7 +157,7 @@ pub(super) fn run_pipeline(source: Source, pipeline: &Pipeline, pass: Pass) -> F
             && has_format_change(&diagnostics)
             && let Err(e) = pipeline.validate(source)
         {
-            return config_error(e);
+            return failed(ExitStatus::ConfigError, e);
         }
         return FileOutcome::Done {
             cached: false,
@@ -173,15 +179,172 @@ pub(super) fn run_pipeline(source: Source, pipeline: &Pipeline, pass: Pass) -> F
                 rewrite,
             }
         }
-        Err(e) => config_error(e),
+        Err(e) => failed(ExitStatus::ConfigError, e),
     }
 }
 
 pub(super) fn walk_error<E: std::fmt::Display>(err: E) -> FileOutcome {
-    config_error(format_args!("cannot walk: {err}"))
+    failed(ExitStatus::ConfigError, format_args!("cannot walk: {err}"))
 }
 
-fn config_error(e: impl std::fmt::Display) -> FileOutcome {
+fn failed(status: ExitStatus, e: impl std::fmt::Display) -> FileOutcome {
     eprintln!("error: {e}");
-    FileOutcome::Failed(ExitStatus::ConfigError)
+    FileOutcome::Failed(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use ruff_diagnostics::Edit;
+    use tempfile::TempDir;
+
+    use super::super::report::status_from_outcomes;
+    use super::*;
+    use crate::config::Config;
+    use crate::rule::RuleId;
+    use crate::testing::{GroupSentinelRule, breaks_parse, parse, range};
+
+    #[test]
+    fn check_validate_fails_on_unparseable_rule_output() {
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
+        let source = parse("x = 1\n");
+
+        let outcome = run_pipeline(source, &pipeline, Pass::Diagnose { validate: true });
+
+        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
+    }
+
+    #[test]
+    fn check_without_validate_ignores_unparseable_rule_output() {
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
+        let source = parse("x = 1\n");
+
+        let outcome = run_pipeline(source, &pipeline, Pass::Diagnose { validate: false });
+
+        assert_matches!(
+            outcome,
+            FileOutcome::Done {
+                rewrite: Rewrite::Skipped,
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn process_path_returns_config_error_on_missing_file() {
+        let tmp = TempDir::new().expect("tempdir");
+        let config = Config::default();
+        let setup = RunSetup {
+            cache: None,
+            config_toml: String::new(),
+            pipeline: Pipeline::with_filters(&config, &[], &[]),
+        };
+        let outcome = process_path(
+            &tmp.path().join("does_not_exist.py"),
+            &setup,
+            Pass::Diagnose { validate: false },
+        );
+        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
+    }
+
+    #[test]
+    fn rehydrate_marks_a_check_mode_outcome_skipped() {
+        let entry = CacheEntry {
+            diagnostics: Vec::new(),
+            rewrite: Rewrite::Changed("y = 1\n".to_owned()),
+        };
+        let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, false);
+        assert_matches!(
+            outcome,
+            Some(FileOutcome::Done {
+                rewrite: Rewrite::Skipped,
+                ..
+            })
+        );
+    }
+
+    #[test]
+    fn rehydrate_returns_none_for_a_skipped_entry() {
+        let entry = CacheEntry {
+            diagnostics: Vec::new(),
+            rewrite: Rewrite::Skipped,
+        };
+        assert!(rehydrate(Path::new("a.py"), b"x = 1\n", entry, true).is_none());
+    }
+
+    #[test]
+    fn rehydrate_serves_a_changed_rewrite_to_a_format_mode() {
+        let entry = CacheEntry {
+            diagnostics: Vec::new(),
+            rewrite: Rewrite::Changed("y = 1\n".to_owned()),
+        };
+        let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, true);
+        assert_matches!(
+            outcome,
+            Some(FileOutcome::Done { rewrite: Rewrite::Changed(text), .. }) if text == "y = 1\n"
+        );
+    }
+
+    #[test]
+    fn rehydrate_serves_an_unchanged_rewrite_as_no_edit() {
+        let entry = CacheEntry {
+            diagnostics: Vec::new(),
+            rewrite: Rewrite::Unchanged,
+        };
+        let outcome = rehydrate(Path::new("a.py"), b"x = 1\n", entry, true);
+        assert_matches!(
+            outcome,
+            Some(FileOutcome::Done {
+                rewrite: Rewrite::Unchanged,
+                ..
+            })
+        );
+    }
+
+    #[test]
+    fn rewrite_pass_fails_on_unparseable_rule_output() {
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
+        let source = parse("x = 1\n");
+
+        let outcome = run_pipeline(source, &pipeline, Pass::Rewrite);
+
+        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
+    }
+
+    #[test]
+    fn run_pipeline_reports_unchanged_when_edits_cancel() {
+        let range = range(0, 1);
+        let pipeline = Pipeline::from_rules(vec![
+            Box::new(GroupSentinelRule {
+                groups: vec![vec![Edit::range_replacement("y".to_owned(), range)]],
+                id: RuleId::from("x-to-y"),
+            }),
+            Box::new(GroupSentinelRule {
+                groups: vec![vec![Edit::range_replacement("x".to_owned(), range)]],
+                id: RuleId::from("y-to-x"),
+            }),
+        ]);
+        let source = parse("x = 1\n");
+
+        let outcome = run_pipeline(source, &pipeline, Pass::Rewrite);
+
+        assert_matches!(
+            &outcome,
+            FileOutcome::Done {
+                diagnostics,
+                rewrite: Rewrite::Unchanged,
+                ..
+            } if diagnostics.len() == 2
+        );
+        assert_eq!(
+            status_from_outcomes(std::slice::from_ref(&outcome), false),
+            ExitStatus::Clean,
+        );
+    }
+
+    #[test]
+    fn walk_error_returns_failed_with_config_error() {
+        let outcome = walk_error("synthetic walk failure");
+        assert_matches!(outcome, FileOutcome::Failed(ExitStatus::ConfigError));
+    }
 }

--- a/src/cli/runner/report.rs
+++ b/src/cli/runner/report.rs
@@ -185,3 +185,277 @@ pub(super) fn summarize(
         resolved => Some(resolved),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use rstest::rstest;
+    use ruff_diagnostics::{Edit, Fix};
+    use ruff_text_size::TextRange;
+
+    use super::*;
+    use crate::diagnostics::Severity;
+    use crate::rule::RuleId;
+    use crate::source::Source;
+    use crate::testing::{parse, range};
+
+    struct FailingWriter;
+
+    impl Write for FailingWriter {
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("simulated write failure"))
+        }
+    }
+
+    fn diagnostic(severity: Severity, range: TextRange, slug: &'static str) -> Diagnostic {
+        Diagnostic {
+            fix: matches!(severity, Severity::Format)
+                .then(|| Fix::safe_edit(Edit::range_replacement("y".into(), range))),
+            message: "test".into(),
+            range,
+            rule: RuleId::from(slug),
+            severity,
+        }
+    }
+
+    fn outcome_with(source: Source, diagnostics: Vec<Diagnostic>) -> FileOutcome {
+        FileOutcome::Done {
+            cached: false,
+            diagnostics,
+            file: source.source_file().clone(),
+            rewrite: Rewrite::Skipped,
+        }
+    }
+
+    #[test]
+    fn check_outcomes_with_failed_parse_takes_higher_status() {
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
+        let outcomes = vec![
+            outcome_with(
+                source,
+                vec![diagnostic(Severity::Format, range, "synthetic-format")],
+            ),
+            FileOutcome::Failed(ExitStatus::ParseError),
+        ];
+
+        let status = status_from_outcomes(&outcomes, false);
+
+        assert_eq!(status, ExitStatus::ParseError);
+    }
+
+    #[test]
+    fn check_outcomes_with_lint_and_format_returns_lint_violation() {
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
+        let diagnostics = vec![
+            diagnostic(Severity::Format, range, "synthetic-format"),
+            diagnostic(Severity::Lint, range, "synthetic-lint"),
+        ];
+        let outcomes = vec![outcome_with(source, diagnostics)];
+
+        let status = status_from_outcomes(&outcomes, false);
+
+        assert_eq!(status, ExitStatus::LintViolation);
+    }
+
+    #[test]
+    fn check_outcomes_with_synthetic_lint_returns_lint_violation() {
+        let source = parse("x = 1\n");
+        let diagnostics = vec![diagnostic(Severity::Lint, range(0, 1), "synthetic-lint")];
+        let outcomes = vec![outcome_with(source, diagnostics)];
+
+        let status = status_from_outcomes(&outcomes, false);
+
+        assert_eq!(status, ExitStatus::LintViolation);
+    }
+
+    #[test]
+    fn emit_outcomes_propagates_writer_failure() {
+        let source = parse("x = 1\n");
+        let diags = vec![diagnostic(
+            Severity::Format,
+            range(0, 1),
+            "synthetic-format",
+        )];
+        let outcomes = vec![outcome_with(source, diags)];
+        let result = emit_outcomes(
+            &outcomes,
+            OutputFormat::Json,
+            &mut FailingWriter,
+            &EmitterSummary::default(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[rstest]
+    fn emit_outcomes_renders_each_output_format(
+        #[values(
+            OutputFormat::Github,
+            OutputFormat::Json,
+            OutputFormat::Sarif,
+            OutputFormat::Text
+        )]
+        format: OutputFormat,
+    ) {
+        let source = parse("x = 1\n");
+        let outcomes = vec![outcome_with(source, Vec::new())];
+        let mut buf = Vec::new();
+        emit_outcomes(&outcomes, format, &mut buf, &EmitterSummary::default()).expect("emits");
+    }
+
+    #[test]
+    fn emitter_summary_counts_visited_changed_diagnostics_and_rules() {
+        let range = range(0, 1);
+        let mut changed = outcome_with(
+            parse("x = 1\n"),
+            vec![
+                diagnostic(Severity::Format, range, "align-equals"),
+                diagnostic(Severity::Lint, range, "reassigned-constants"),
+            ],
+        );
+        if let FileOutcome::Done { rewrite, .. } = &mut changed {
+            *rewrite = Rewrite::Changed("x   = 1\n".to_owned());
+        }
+        let clean = outcome_with(parse("y = 2\n"), Vec::new());
+        let outcomes = vec![changed, clean, FileOutcome::Failed(ExitStatus::ParseError)];
+
+        let summary = emitter_summary(&outcomes);
+
+        assert_eq!(summary.files_visited, 2);
+        assert_eq!(summary.files_changed, 1);
+        assert_eq!(summary.files_with_diagnostics, 1);
+        assert_eq!(summary.diagnostics_total, 2);
+        assert_eq!(summary.rules_fired[&RuleId::from("align-equals")], 1);
+        assert_eq!(
+            summary.rules_fired[&RuleId::from("reassigned-constants")],
+            1
+        );
+    }
+
+    #[test]
+    fn emitter_summary_tallies_repeated_rule_occurrences() {
+        let range = range(0, 1);
+        let outcome = outcome_with(
+            parse("x = 1\n"),
+            vec![
+                diagnostic(Severity::Format, range, "align-equals"),
+                diagnostic(Severity::Format, range, "align-equals"),
+            ],
+        );
+
+        let summary = emitter_summary(std::slice::from_ref(&outcome));
+
+        assert_eq!(summary.rules_fired[&RuleId::from("align-equals")], 2);
+    }
+
+    #[test]
+    fn file_changed_counts_a_changed_rewrite_or_a_skipped_format_diagnostic() {
+        let range = range(0, 1);
+        let format = vec![diagnostic(Severity::Format, range, "synthetic-format")];
+        let lint = vec![diagnostic(Severity::Lint, range, "synthetic-lint")];
+
+        assert!(file_changed(&[], &Rewrite::Changed("x = 1\n".to_owned())));
+        assert!(file_changed(&format, &Rewrite::Skipped));
+        assert!(!file_changed(&format, &Rewrite::Unchanged));
+        assert!(!file_changed(&lint, &Rewrite::Skipped));
+        assert!(!file_changed(&[], &Rewrite::Skipped));
+    }
+
+    #[test]
+    fn report_verbose_prints_bypassed_when_cache_disabled() {
+        let mut buf = Vec::new();
+        report_verbose(&[], false, &mut buf);
+        assert_eq!(String::from_utf8(buf).expect("utf-8"), "cache: bypassed\n");
+    }
+
+    #[test]
+    fn report_verbose_prints_hit_and_miss_counts() {
+        let make = |cached: bool| {
+            let source = parse("x = 1\n");
+            let mut o = outcome_with(source, Vec::new());
+            if let FileOutcome::Done { cached: c, .. } = &mut o {
+                *c = cached;
+            }
+            o
+        };
+        let outcomes = vec![
+            make(true),
+            make(true),
+            make(false),
+            FileOutcome::Failed(ExitStatus::Clean),
+        ];
+        let mut buf = Vec::new();
+        report_verbose(&outcomes, true, &mut buf);
+        assert_eq!(
+            String::from_utf8(buf).expect("utf-8"),
+            "cache: 2 hits, 1 misses, 3 files\n",
+        );
+    }
+
+    #[test]
+    fn status_from_outcomes_clears_format_change_for_an_unchanged_rewrite() {
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
+        let mut outcome = outcome_with(
+            source,
+            vec![
+                diagnostic(Severity::Format, range, "synthetic-format"),
+                diagnostic(Severity::Lint, range, "synthetic-lint"),
+            ],
+        );
+        if let FileOutcome::Done { rewrite, .. } = &mut outcome {
+            *rewrite = Rewrite::Unchanged;
+        }
+        let outcomes = vec![outcome];
+
+        assert_eq!(
+            status_from_outcomes(&outcomes, false),
+            ExitStatus::LintViolation,
+        );
+    }
+
+    #[test]
+    fn status_from_outcomes_demotes_format_change_when_demoted() {
+        let source = parse("x = 1\n");
+        let outcomes = vec![outcome_with(
+            source,
+            vec![diagnostic(
+                Severity::Format,
+                range(0, 1),
+                "synthetic-format",
+            )],
+        )];
+        assert_eq!(status_from_outcomes(&outcomes, true), ExitStatus::Clean);
+        assert_eq!(
+            status_from_outcomes(&outcomes, false),
+            ExitStatus::FormatChange,
+        );
+    }
+
+    #[test]
+    fn summarize_reports_diagnostics_alongside_a_failure() {
+        let source = parse("x = 1\n");
+        let outcomes = vec![
+            outcome_with(
+                source,
+                vec![diagnostic(Severity::Lint, range(0, 1), "synthetic-lint")],
+            ),
+            FileOutcome::Failed(ExitStatus::ParseError),
+        ];
+        assert_matches!(
+            summarize(&outcomes, &emitter_summary(&outcomes), Mode::Check),
+            Some(Summary::Diagnostics { files: 1, total: 1 })
+        );
+    }
+
+    #[test]
+    fn summarize_suppresses_clean_summary_when_a_file_failed() {
+        let outcomes = vec![FileOutcome::Failed(ExitStatus::ParseError)];
+        assert!(summarize(&outcomes, &emitter_summary(&outcomes), Mode::Check).is_none());
+    }
+}

--- a/src/cli/runner/report.rs
+++ b/src/cli/runner/report.rs
@@ -6,10 +6,15 @@ use std::io::{self, Write};
 use anyhow::Context;
 
 use super::{FileOutcome, Mode, RunSetup, has_format_change};
-use crate::cli::args::OutputFormat;
-use crate::cli::exit_status::ExitStatus;
-use crate::cli::output::{self, Presentation, Summary};
-use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Github, Json, Run, Sarif, Text};
+use crate::{
+    cache::Rewrite,
+    cli::{
+        args::OutputFormat,
+        exit_status::ExitStatus,
+        output::{self, Presentation, Summary},
+    },
+    diagnostics::{Diagnostic, Emitter, EmitterSummary, Github, Json, Run, Sarif, Text},
+};
 
 pub(super) fn emit_outcomes<W: Write>(
     outcomes: &[FileOutcome],
@@ -42,17 +47,16 @@ pub(super) fn emitter_summary(outcomes: &[FileOutcome]) -> EmitterSummary {
         .filter_map(|o| match o {
             FileOutcome::Done {
                 diagnostics,
-                formatted_text,
+                rewrite,
                 ..
-            } => Some((diagnostics, formatted_text)),
+            } => Some((diagnostics, rewrite)),
             FileOutcome::Failed(_) => None,
         })
         .fold(
             EmitterSummary::default(),
-            |mut summary, (diagnostics, formatted_text)| {
+            |mut summary, (diagnostics, rewrite)| {
                 summary.files_visited += 1;
-                summary.files_changed +=
-                    usize::from(file_changed(diagnostics, formatted_text.as_deref()));
+                summary.files_changed += usize::from(file_changed(diagnostics, rewrite));
                 summary.files_with_diagnostics += usize::from(!diagnostics.is_empty());
                 summary.diagnostics_total += diagnostics.len();
                 for diag in diagnostics {
@@ -63,11 +67,15 @@ pub(super) fn emitter_summary(outcomes: &[FileOutcome]) -> EmitterSummary {
         )
 }
 
-/// A file counts as changed when `run` produced a rewrite, or, on the
-/// `check` path that skips the rewrite, when `diagnose` emitted a format
-/// diagnostic.
-pub(super) fn file_changed(diagnostics: &[Diagnostic], formatted_text: Option<&str>) -> bool {
-    formatted_text.is_some() || has_format_change(diagnostics)
+/// A file counts as changed when `run` produced text differing from the
+/// original. A mode that skipped the rewrite falls back to whether
+/// `diagnose` emitted a format diagnostic.
+pub(super) fn file_changed(diagnostics: &[Diagnostic], rewrite: &Rewrite) -> bool {
+    match rewrite {
+        Rewrite::Changed(_) => true,
+        Rewrite::Skipped => has_format_change(diagnostics),
+        Rewrite::Unchanged => false,
+    }
 }
 
 pub(super) fn finish(
@@ -125,12 +133,21 @@ pub(super) fn status_from_outcomes(
     outcomes
         .iter()
         .map(|outcome| match outcome {
-            FileOutcome::Done { diagnostics, .. } => diagnostics
-                .iter()
-                .map(|d| ExitStatus::from(d.severity))
-                .filter(|s| !demote_format_change || *s != ExitStatus::FormatChange)
-                .max()
-                .unwrap_or_default(),
+            FileOutcome::Done {
+                diagnostics,
+                rewrite,
+                ..
+            } => {
+                // A rewrite that settled back to the input byte-for-byte
+                // reports clean, its cancelling edits notwithstanding.
+                let demote = demote_format_change || matches!(rewrite, Rewrite::Unchanged);
+                diagnostics
+                    .iter()
+                    .map(|d| ExitStatus::from(d.severity))
+                    .filter(|s| !demote || *s != ExitStatus::FormatChange)
+                    .max()
+                    .unwrap_or_default()
+            }
             FileOutcome::Failed(s) => *s,
         })
         .max()

--- a/src/diagnostics/github.rs
+++ b/src/diagnostics/github.rs
@@ -49,26 +49,8 @@ fn emit_one(writer: &mut dyn Write, file: &SourceFile, diag: &Diagnostic) -> io:
 
 #[cfg(test)]
 mod tests {
-    use ruff_diagnostics::{Edit, Fix};
-    use ruff_text_size::TextRange;
-
     use super::*;
-    use crate::diagnostics::Severity;
-    use crate::rule::RuleId;
-    use crate::testing::{parse, range};
-
-    fn diag(range: TextRange) -> Diagnostic {
-        Diagnostic {
-            fix: Some(Fix::safe_edit(Edit::range_replacement(
-                "y".to_owned(),
-                range,
-            ))),
-            message: "rewrite x to y".to_owned(),
-            range,
-            rule: RuleId::from("rewrite-x"),
-            severity: Severity::Format,
-        }
-    }
+    use crate::testing::{format_diagnostic, parse, range};
 
     fn emit_to_string(file: &SourceFile, diag: &Diagnostic) -> String {
         let mut buf = Vec::<u8>::new();
@@ -85,7 +67,7 @@ mod tests {
     #[test]
     fn drops_endline_and_endcolumn_for_multi_line_ranges() {
         let source = parse("x = (\n  1\n)\n");
-        let diag = diag(range(0, 11));
+        let diag = format_diagnostic(range(0, 11));
         assert_eq!(
             emit_to_string(source.source_file(), &diag),
             "::warning file=<source>,line=1,col=1::rewrite x to y\n",
@@ -95,7 +77,7 @@ mod tests {
     #[test]
     fn emits_endline_and_endcolumn_when_range_stays_on_one_line() {
         let source = parse("x = 1\n");
-        let diag = diag(range(0, 1));
+        let diag = format_diagnostic(range(0, 1));
         assert_eq!(
             emit_to_string(source.source_file(), &diag),
             "::warning file=<source>,line=1,col=1,endLine=1,endColumn=2::rewrite x to y\n",

--- a/src/diagnostics/github.rs
+++ b/src/diagnostics/github.rs
@@ -55,7 +55,7 @@ mod tests {
     use super::*;
     use crate::diagnostics::Severity;
     use crate::rule::RuleId;
-    use crate::source::Source;
+    use crate::testing::{parse, range};
 
     fn diag(range: TextRange) -> Diagnostic {
         Diagnostic {
@@ -84,8 +84,8 @@ mod tests {
 
     #[test]
     fn drops_endline_and_endcolumn_for_multi_line_ranges() {
-        let source: Source = "x = (\n  1\n)\n".parse().expect("parses");
-        let diag = diag(TextRange::new(0.into(), 11.into()));
+        let source = parse("x = (\n  1\n)\n");
+        let diag = diag(range(0, 11));
         assert_eq!(
             emit_to_string(source.source_file(), &diag),
             "::warning file=<source>,line=1,col=1::rewrite x to y\n",
@@ -94,8 +94,8 @@ mod tests {
 
     #[test]
     fn emits_endline_and_endcolumn_when_range_stays_on_one_line() {
-        let source: Source = "x = 1\n".parse().expect("parses");
-        let diag = diag(TextRange::new(0.into(), 1.into()));
+        let source = parse("x = 1\n");
+        let diag = diag(range(0, 1));
         assert_eq!(
             emit_to_string(source.source_file(), &diag),
             "::warning file=<source>,line=1,col=1,endLine=1,endColumn=2::rewrite x to y\n",

--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -173,15 +173,15 @@ pub fn lint_records_json(file: &SourceFile, diagnostics: &[Diagnostic]) -> Optio
 
 #[cfg(test)]
 mod tests {
-    use ruff_text_size::TextRange;
     use serde_json::{Value, json};
 
     use super::*;
     use crate::diagnostics::Severity;
     use crate::source::Source;
+    use crate::testing::{parse, range};
 
     fn diag() -> Diagnostic {
-        let range = TextRange::new(0.into(), 1.into());
+        let range = range(0, 1);
         Diagnostic {
             fix: Some(Fix::safe_edit(Edit::range_replacement(
                 "y".to_owned(),
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn closes_stream_with_a_summary_record_after_each_diagnostic() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let records = emit_records(
             &source,
             std::slice::from_ref(&diag()),
@@ -230,8 +230,8 @@ mod tests {
 
     #[test]
     fn edit_before_carries_original_multi_line_substring() {
-        let source: Source = "x = 1\ny = 2\n".parse().expect("parses");
-        let range = TextRange::new(0.into(), 11.into());
+        let source = parse("x = 1\ny = 2\n");
+        let range = range(0, 11);
         let diag = Diagnostic {
             fix: Some(Fix::safe_edit(Edit::range_replacement(
                 "z = 3".to_owned(),
@@ -252,17 +252,14 @@ mod tests {
 
     #[test]
     fn fix_carries_one_edit_entry_per_group_member() {
-        let source: Source = "x = 1\ny = 2\n".parse().expect("parses");
+        let source = parse("x = 1\ny = 2\n");
         let diag = Diagnostic {
             fix: Some(Fix::safe_edits(
-                Edit::range_replacement("a".to_owned(), TextRange::new(0.into(), 1.into())),
-                [Edit::range_replacement(
-                    "b".to_owned(),
-                    TextRange::new(6.into(), 7.into()),
-                )],
+                Edit::range_replacement("a".to_owned(), range(0, 1)),
+                [Edit::range_replacement("b".to_owned(), range(6, 7))],
             )),
             message: "align".to_owned(),
-            range: TextRange::new(0.into(), 7.into()),
+            range: range(0, 7),
             rule: RuleId::from("align-equals"),
             severity: Severity::Format,
         };
@@ -279,7 +276,7 @@ mod tests {
 
     #[test]
     fn kind_leads_every_serialized_object() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let text = emit_text(
             &source,
             std::slice::from_ref(&diag()),
@@ -302,7 +299,7 @@ mod tests {
 
     #[test]
     fn populates_fix_payload_with_safe_applicability_and_edit() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let records = emit_records(
             &source,
             std::slice::from_ref(&diag()),
@@ -320,8 +317,8 @@ mod tests {
 
     #[test]
     fn roundtrips_full_stream_with_deterministic_per_rule_counts() {
-        let source: Source = "x = 1\n".parse().expect("parses");
-        let range = TextRange::new(0.into(), 1.into());
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
         let diagnostics = vec![
             diag(),
             Diagnostic::lint(RuleId::from("align-equals"), range, "name it".to_owned()),
@@ -362,7 +359,7 @@ mod tests {
 
     #[test]
     fn summary_closes_zero_diagnostic_stream_with_zero_counts() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let summary = EmitterSummary {
             files_visited: 1,
             ..Default::default()

--- a/src/diagnostics/json.rs
+++ b/src/diagnostics/json.rs
@@ -176,22 +176,11 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::*;
-    use crate::diagnostics::Severity;
     use crate::source::Source;
-    use crate::testing::{parse, range};
+    use crate::testing::{format_diagnostic, parse, range};
 
     fn diag() -> Diagnostic {
-        let range = range(0, 1);
-        Diagnostic {
-            fix: Some(Fix::safe_edit(Edit::range_replacement(
-                "y".to_owned(),
-                range,
-            ))),
-            message: "rewrite x to y".to_owned(),
-            range,
-            rule: RuleId::from("rewrite-x"),
-            severity: Severity::Format,
-        }
+        format_diagnostic(range(0, 1))
     }
 
     fn emit_records(
@@ -237,10 +226,7 @@ mod tests {
                 "z = 3".to_owned(),
                 range,
             ))),
-            message: "collapse".to_owned(),
-            range,
-            rule: RuleId::from("rewrite-x"),
-            severity: Severity::Format,
+            ..format_diagnostic(range)
         };
         let records = emit_records(
             &source,
@@ -258,10 +244,7 @@ mod tests {
                 Edit::range_replacement("a".to_owned(), range(0, 1)),
                 [Edit::range_replacement("b".to_owned(), range(6, 7))],
             )),
-            message: "align".to_owned(),
-            range: range(0, 7),
-            rule: RuleId::from("align-equals"),
-            severity: Severity::Format,
+            ..format_diagnostic(range(0, 7))
         };
         let records = emit_records(
             &source,

--- a/src/diagnostics/sarif.rs
+++ b/src/diagnostics/sarif.rs
@@ -133,21 +133,10 @@ mod tests {
     use serde_json::Value;
 
     use super::*;
-    use crate::diagnostics::Severity;
-    use crate::testing::{parse, range};
+    use crate::testing::{format_diagnostic, parse, range};
 
     fn diag() -> Diagnostic {
-        let range = range(0, 1);
-        Diagnostic {
-            fix: Some(Fix::safe_edit(Edit::range_replacement(
-                "y".to_owned(),
-                range,
-            ))),
-            message: "rewrite x to y".to_owned(),
-            range,
-            rule: RuleId::from("rewrite-x"),
-            severity: Severity::Format,
-        }
+        format_diagnostic(range(0, 1))
     }
 
     fn emit_value(file: &SourceFile, diagnostics: &[Diagnostic]) -> Value {
@@ -195,6 +184,15 @@ mod tests {
     }
 
     #[test]
+    fn emits_an_absolute_path_unchanged() {
+        let file = SourceFileBuilder::new("/tmp/My Project/mod.py", "x = 1\n").finish();
+        let v = emit_value(&file, std::slice::from_ref(&diag()));
+        let uri = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
+            ["uri"];
+        assert_eq!(uri, "/tmp/My Project/mod.py");
+    }
+
+    #[test]
     fn fix_carries_one_replacement_per_group_edit() {
         let source = parse("x = 1\ny = 2\n");
         let diag = Diagnostic {
@@ -202,10 +200,7 @@ mod tests {
                 Edit::range_replacement("a".to_owned(), range(0, 1)),
                 [Edit::range_replacement("b".to_owned(), range(6, 7))],
             )),
-            message: "align".to_owned(),
-            range: range(0, 7),
-            rule: RuleId::from("align-equals"),
-            severity: Severity::Format,
+            ..format_diagnostic(range(0, 7))
         };
         let v = emit_value(source.source_file(), std::slice::from_ref(&diag));
         let replacements =
@@ -226,15 +221,6 @@ mod tests {
         };
         let v = emit_value(source.source_file(), std::slice::from_ref(&diag));
         assert!(v["runs"][0]["results"][0]["fixes"].is_null());
-    }
-
-    #[test]
-    fn emits_an_absolute_path_unchanged() {
-        let file = SourceFileBuilder::new("/tmp/My Project/mod.py", "x = 1\n").finish();
-        let v = emit_value(&file, std::slice::from_ref(&diag()));
-        let uri = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
-            ["uri"];
-        assert_eq!(uri, "/tmp/My Project/mod.py");
     }
 
     #[test]

--- a/src/diagnostics/sarif.rs
+++ b/src/diagnostics/sarif.rs
@@ -130,15 +130,14 @@ fn sarif_run(runs: &[Run<'_>]) -> SarifRun {
 mod tests {
     use ruff_diagnostics::{Edit, Fix};
     use ruff_source_file::SourceFileBuilder;
-    use ruff_text_size::TextRange;
     use serde_json::Value;
 
     use super::*;
     use crate::diagnostics::Severity;
-    use crate::source::Source;
+    use crate::testing::{parse, range};
 
     fn diag() -> Diagnostic {
-        let range = TextRange::new(0.into(), 1.into());
+        let range = range(0, 1);
         Diagnostic {
             fix: Some(Fix::safe_edit(Edit::range_replacement(
                 "y".to_owned(),
@@ -161,7 +160,7 @@ mod tests {
 
     #[test]
     fn deduplicates_rule_descriptors_across_diagnostics() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let diags = vec![diag(), diag()];
         let v = emit_value(source.source_file(), &diags);
         let rules = v["runs"][0]["tool"]["driver"]["rules"]
@@ -176,7 +175,7 @@ mod tests {
 
     #[test]
     fn emits_a_single_sarif_run_per_invocation() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let diag = diag();
         let v = emit_value(source.source_file(), std::slice::from_ref(&diag));
         assert_eq!(v["version"], "2.1.0");
@@ -197,17 +196,14 @@ mod tests {
 
     #[test]
     fn fix_carries_one_replacement_per_group_edit() {
-        let source: Source = "x = 1\ny = 2\n".parse().expect("parses");
+        let source = parse("x = 1\ny = 2\n");
         let diag = Diagnostic {
             fix: Some(Fix::safe_edits(
-                Edit::range_replacement("a".to_owned(), TextRange::new(0.into(), 1.into())),
-                [Edit::range_replacement(
-                    "b".to_owned(),
-                    TextRange::new(6.into(), 7.into()),
-                )],
+                Edit::range_replacement("a".to_owned(), range(0, 1)),
+                [Edit::range_replacement("b".to_owned(), range(6, 7))],
             )),
             message: "align".to_owned(),
-            range: TextRange::new(0.into(), 7.into()),
+            range: range(0, 7),
             rule: RuleId::from("align-equals"),
             severity: Severity::Format,
         };
@@ -223,7 +219,7 @@ mod tests {
 
     #[test]
     fn omits_fixes_payload_when_diagnostic_has_no_edit() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let diag = Diagnostic {
             fix: None,
             ..diag()
@@ -243,7 +239,7 @@ mod tests {
 
     #[test]
     fn passes_the_stdin_placeholder_name_through_unchanged() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let v = emit_value(source.source_file(), std::slice::from_ref(&diag()));
         let uri = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
             ["uri"];
@@ -252,7 +248,7 @@ mod tests {
 
     #[test]
     fn populates_fixes_payload_when_diagnostic_carries_an_edit() {
-        let source: Source = "x = 1\n".parse().expect("parses");
+        let source = parse("x = 1\n");
         let diag = diag();
         let v = emit_value(source.source_file(), std::slice::from_ref(&diag));
         let fix = &v["runs"][0]["results"][0]["fixes"][0];

--- a/src/diagnostics/text.rs
+++ b/src/diagnostics/text.rs
@@ -66,6 +66,7 @@ mod tests {
     use crate::diagnostics::{Diagnostic, Severity};
     use crate::rule::RuleId;
     use crate::source::Source;
+    use crate::testing::{parse, range};
 
     fn diag(range: TextRange, fix: Option<Fix>) -> Diagnostic {
         Diagnostic {
@@ -94,8 +95,8 @@ mod tests {
 
     #[test]
     fn appends_help_block_when_fix_is_available() {
-        let source: Source = "x = 1\n".parse().expect("parses");
-        let range = TextRange::new(0.into(), 1.into());
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
         let rendered = render_to_string(
             &source,
             &diag(
@@ -113,17 +114,14 @@ mod tests {
 
     #[test]
     fn help_block_renders_every_edit_in_a_group() {
-        let source: Source = "x = 1\ny = 2\n".parse().expect("parses");
+        let source = parse("x = 1\ny = 2\n");
         let rendered = render_to_string(
             &source,
             &diag(
-                TextRange::new(0.into(), 7.into()),
+                range(0, 7),
                 Some(Fix::safe_edits(
-                    Edit::range_replacement("aaa".to_owned(), TextRange::new(0.into(), 1.into())),
-                    [Edit::range_replacement(
-                        "bbb".to_owned(),
-                        TextRange::new(6.into(), 7.into()),
-                    )],
+                    Edit::range_replacement("aaa".to_owned(), range(0, 1)),
+                    [Edit::range_replacement("bbb".to_owned(), range(6, 7))],
                 )),
             ),
         );
@@ -134,8 +132,8 @@ mod tests {
 
     #[test]
     fn renders_path_line_column_message_and_caret() {
-        let source: Source = "x = 1\n".parse().expect("parses");
-        let range = TextRange::new(0.into(), 1.into());
+        let source = parse("x = 1\n");
+        let range = range(0, 1);
         let rendered = render_to_string(&source, &diag(range, None));
         assert!(rendered.contains("warning: rewrite x to y"));
         assert!(rendered.contains("--> <source>:1:1"));

--- a/src/diagnostics/text.rs
+++ b/src/diagnostics/text.rs
@@ -60,23 +60,11 @@ impl Emitter for Text {
 #[cfg(test)]
 mod tests {
     use ruff_diagnostics::{Edit, Fix};
-    use ruff_text_size::TextRange;
 
     use super::*;
-    use crate::diagnostics::{Diagnostic, Severity};
-    use crate::rule::RuleId;
+    use crate::diagnostics::Diagnostic;
     use crate::source::Source;
-    use crate::testing::{parse, range};
-
-    fn diag(range: TextRange, fix: Option<Fix>) -> Diagnostic {
-        Diagnostic {
-            fix,
-            message: "rewrite x to y".to_owned(),
-            range,
-            rule: RuleId::from("rewrite-x"),
-            severity: Severity::Format,
-        }
-    }
+    use crate::testing::{format_diagnostic, parse, range};
 
     fn render_to_string(source: &Source, diag: &Diagnostic) -> String {
         let mut buf = Vec::<u8>::new();
@@ -96,17 +84,7 @@ mod tests {
     #[test]
     fn appends_help_block_when_fix_is_available() {
         let source = parse("x = 1\n");
-        let range = range(0, 1);
-        let rendered = render_to_string(
-            &source,
-            &diag(
-                range,
-                Some(Fix::safe_edit(Edit::range_replacement(
-                    "y".to_owned(),
-                    range,
-                ))),
-            ),
-        );
+        let rendered = render_to_string(&source, &format_diagnostic(range(0, 1)));
         assert!(rendered.contains("warning: rewrite x to y"));
         assert!(rendered.contains("help: replace with"));
         assert!(rendered.contains('y'));
@@ -117,13 +95,13 @@ mod tests {
         let source = parse("x = 1\ny = 2\n");
         let rendered = render_to_string(
             &source,
-            &diag(
-                range(0, 7),
-                Some(Fix::safe_edits(
+            &Diagnostic {
+                fix: Some(Fix::safe_edits(
                     Edit::range_replacement("aaa".to_owned(), range(0, 1)),
                     [Edit::range_replacement("bbb".to_owned(), range(6, 7))],
                 )),
-            ),
+                ..format_diagnostic(range(0, 7))
+            },
         );
         assert!(rendered.contains("help: replace with"));
         assert!(rendered.contains("aaa"));
@@ -133,8 +111,13 @@ mod tests {
     #[test]
     fn renders_path_line_column_message_and_caret() {
         let source = parse("x = 1\n");
-        let range = range(0, 1);
-        let rendered = render_to_string(&source, &diag(range, None));
+        let rendered = render_to_string(
+            &source,
+            &Diagnostic {
+                fix: None,
+                ..format_diagnostic(range(0, 1))
+            },
+        );
         assert!(rendered.contains("warning: rewrite x to y"));
         assert!(rendered.contains("--> <source>:1:1"));
         assert!(rendered.contains("rewrite-x"));

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -201,9 +201,8 @@ mod tests {
     }
 
     /// Test-only rule that records its own id into a shared log and
-    /// returns the edit list supplied at construction time.
+    /// never produces edits.
     struct SentinelRule {
-        edits: Vec<Edit>,
         id: RuleId,
         log: Arc<Mutex<Vec<&'static str>>>,
     }
@@ -211,7 +210,7 @@ mod tests {
     impl Rule for SentinelRule {
         fn apply(&self, _source: &Source) -> Vec<Vec<Edit>> {
             self.log.lock().expect("log mutex").push(self.id.as_str());
-            singleton_groups(self.edits.clone())
+            Vec::new()
         }
 
         fn id(&self) -> RuleId {
@@ -377,17 +376,14 @@ mod tests {
         let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
         let pipeline = Pipeline::from_rules(vec![
             Box::new(SentinelRule {
-                edits: Vec::new(),
                 id: RuleId::from("first"),
                 log: log.clone(),
             }),
             Box::new(SentinelRule {
-                edits: Vec::new(),
                 id: RuleId::from("second"),
                 log: log.clone(),
             }),
             Box::new(SentinelRule {
-                edits: Vec::new(),
                 id: RuleId::from("third"),
                 log: log.clone(),
             }),
@@ -537,7 +533,6 @@ mod tests {
     fn run_short_circuits_when_file_is_suppressed() {
         let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
         let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
-            edits: vec![Edit::range_replacement("y".to_owned(), range(13, 14))],
             id: RuleId::from("never-called"),
             log: log.clone(),
         })]);

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -168,7 +168,7 @@ mod tests {
     use crate::config::Config;
     use crate::diagnostics::Severity;
     use crate::primitives::edit::singleton_groups;
-    use crate::testing::{assert_send_sync, parse, range};
+    use crate::testing::{GroupSentinelRule, assert_send_sync, breaks_parse, parse, range};
 
     /// Test-only lint-only rule that returns the range list supplied
     /// at construction and never produces edits.
@@ -246,28 +246,6 @@ mod tests {
         }
     }
 
-    /// Test-only rule that returns the fix groups supplied at
-    /// construction, exercising the multi-edit groups the singleton
-    /// wrappers cannot produce.
-    struct GroupSentinelRule {
-        groups: Vec<Vec<Edit>>,
-        id: RuleId,
-    }
-
-    impl Rule for GroupSentinelRule {
-        fn apply(&self, _source: &Source) -> Vec<Vec<Edit>> {
-            self.groups.clone()
-        }
-
-        fn id(&self) -> RuleId {
-            self.id
-        }
-
-        fn message(&self) -> &'static str {
-            "group test rule"
-        }
-    }
-
     fn registered_slugs(pipeline: &Pipeline) -> Vec<&'static str> {
         pipeline.rules.iter().map(|r| r.id().as_str()).collect()
     }
@@ -279,10 +257,9 @@ mod tests {
         // rule's edit, so the lint range stays valid against the
         // untouched buffer and both findings surface together.
         let pipeline = Pipeline::from_rules(vec![
-            Box::new(SentinelRule {
-                edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+            Box::new(GroupSentinelRule {
+                groups: vec![vec![Edit::range_replacement("y".to_owned(), range(0, 1))]],
                 id: RuleId::from("rewrite-x-to-y"),
-                log: Arc::new(Mutex::new(Vec::new())),
             }),
             Box::new(LintSentinelRule {
                 id: RuleId::from("flag-x"),
@@ -385,12 +362,7 @@ mod tests {
 
     #[test]
     fn reparse_failure_surfaces_rule_id() {
-        let log = Arc::new(Mutex::new(Vec::<&'static str>::new()));
-        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
-            edits: vec![Edit::range_replacement("def foo(".to_owned(), range(0, 5))],
-            id: RuleId::from("breaks-parse"),
-            log: log.clone(),
-        })]);
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
         let source = parse("x = 1\n");
 
         let err = pipeline.run(source).expect_err("reparse should fail");
@@ -453,13 +425,12 @@ mod tests {
         // Edit at 11..16 (`x = 1`) sits inside the suppressed
         // [0..17) span and must be dropped, leaving the unsuppressed
         // edit at 27..32 (`z = 9`) to apply.
-        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
-            edits: vec![
+        let pipeline = Pipeline::from_rules(vec![Box::new(GroupSentinelRule {
+            groups: singleton_groups(vec![
                 Edit::range_replacement("y".to_owned(), range(11, 16)),
                 Edit::range_replacement("Z".to_owned(), range(27, 32)),
-            ],
+            ]),
             id: RuleId::from("rewrite-x-and-z"),
-            log: Arc::new(Mutex::new(Vec::new())),
         })]);
         let source = parse("# fmt: off\nx = 1\n# fmt: on\nz = 9\n");
 
@@ -547,10 +518,9 @@ mod tests {
 
     #[test]
     fn run_emits_one_diagnostic_per_surviving_edit() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
-            edits: vec![Edit::range_replacement("y".to_owned(), range(0, 1))],
+        let pipeline = Pipeline::from_rules(vec![Box::new(GroupSentinelRule {
+            groups: vec![vec![Edit::range_replacement("y".to_owned(), range(0, 1))]],
             id: RuleId::from("rewrite-x-to-y"),
-            log: Arc::new(Mutex::new(Vec::new())),
         })]);
         let source = parse("x = 1\n");
 
@@ -596,10 +566,9 @@ mod tests {
 
     #[test]
     fn run_skips_reparse_when_every_edit_is_suppressed() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(SentinelRule {
-            edits: vec![Edit::range_replacement("y".to_owned(), range(11, 16))],
+        let pipeline = Pipeline::from_rules(vec![Box::new(GroupSentinelRule {
+            groups: vec![vec![Edit::range_replacement("y".to_owned(), range(11, 16))]],
             id: RuleId::from("rewrite-x-to-y"),
-            log: Arc::new(Mutex::new(Vec::new())),
         })]);
         let source = parse("# fmt: off\nx = 1\n# fmt: on\n");
 
@@ -633,13 +602,7 @@ mod tests {
 
     #[test]
     fn validate_surfaces_unparseable_rule_output() {
-        let pipeline = Pipeline::from_rules(vec![Box::new(GroupSentinelRule {
-            groups: vec![vec![Edit::range_replacement(
-                "def foo(".to_owned(),
-                range(0, 5),
-            )]],
-            id: RuleId::from("breaks-parse"),
-        })]);
+        let pipeline = Pipeline::from_rules(vec![Box::new(breaks_parse())]);
         let source = parse("x = 1\n");
 
         assert_matches!(

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -350,7 +350,7 @@ mod tests {
             pipeline.rules.iter().map(|r| r.id().as_str()).collect();
         registered.sort_unstable();
         let mut known: Vec<&'static str> =
-            Pipeline::known_ids().iter().map(|id| id.as_str()).collect();
+            Pipeline::known_ids().iter().map(RuleId::as_str).collect();
         known.sort_unstable();
         assert_eq!(registered, known);
     }
@@ -670,23 +670,7 @@ mod tests {
     #[test]
     fn with_filters_select_overrides_disabled_config() {
         let mut config = Config::default();
-        config.rules.align_colons.enabled = false;
-        config.rules.align_comparisons.enabled = false;
         config.rules.align_equals.enabled = false;
-        config.rules.align_imports.enabled = false;
-        config.rules.align_match_case.enabled = false;
-        config.rules.alphabetize.enabled = false;
-        config.rules.bare_imports.enabled = false;
-        config.rules.blank_lines.enabled = false;
-        config.rules.collection_layout.enabled = false;
-        config.rules.legacy_union_syntax.enabled = false;
-        config.rules.reassigned_constants.enabled = false;
-        config.rules.signature_layout.enabled = false;
-        config.rules.single_use_variables.enabled = false;
-        config.rules.step_narration.enabled = false;
-        config.rules.strip_align_padding.enabled = false;
-        config.rules.strip_trailing_commas.enabled = false;
-        config.rules.unused_future_annotations.enabled = false;
 
         let pipeline = Pipeline::with_filters(&config, &[RuleId::from("align-equals")], &[]);
         assert_eq!(registered_slugs(&pipeline), ["align-equals"]);

--- a/src/primitives/aligner/emit.rs
+++ b/src/primitives/aligner/emit.rs
@@ -156,7 +156,7 @@ mod tests {
     use ruff_text_size::{Ranged, TextSize};
 
     use super::*;
-    use crate::testing::parse;
+    use crate::testing::{parse, range};
 
     /// Builds the expected summary tuple for an `Edit::range_deletion`
     /// over a member's gap.
@@ -197,7 +197,7 @@ mod tests {
             let gap_end = u32::try_from(text.len()).expect("test source fits in u32");
             text.push_str("= 0\n");
             members.push(Member {
-                gap: TextRange::new(TextSize::new(gap_start), TextSize::new(gap_end)),
+                gap: range(gap_start, gap_end),
                 line_start: TextSize::new(line_start),
                 op_width: 0,
                 width,
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn space_padding_edit_inserts_when_range_empty_and_n_positive() {
         let source = parse("xy\n");
-        let range = TextRange::new(TextSize::new(1), TextSize::new(1));
+        let range = range(1, 1);
         let edit = space_padding_edit(&source, range, 2).expect("0-vs-2 spaces emits");
         assert_eq!(summary(&edit), (1, 1, "  ".to_owned()));
     }
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     fn space_padding_edit_replaces_when_text_has_non_space_chars() {
         let source = parse("a:b\n");
-        let range = TextRange::new(TextSize::new(1), TextSize::new(2));
+        let range = range(1, 2);
         let edit = space_padding_edit(&source, range, 1).expect("non-space content emits");
         assert_eq!(summary(&edit), (1, 2, " ".to_owned()));
     }
@@ -461,7 +461,7 @@ mod tests {
     #[test]
     fn space_padding_edit_returns_none_for_empty_range_at_zero() {
         let source = parse("xy\n");
-        let range = TextRange::new(TextSize::new(1), TextSize::new(1));
+        let range = range(1, 1);
         assert!(space_padding_edit(&source, range, 0).is_none());
     }
 }

--- a/src/rules/signature_layout.rs
+++ b/src/rules/signature_layout.rs
@@ -78,7 +78,7 @@ impl Layout<'_> {
             indent,
             parts.len(),
             |out, i| out.push_str(parts[i]),
-            |_| true,
+            |i| i < parts.len() - 1,
         );
         self.push_return_and_colon(&mut out, fd);
         out

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,9 +1,10 @@
 //! Helpers shared across `#[cfg(test)] mod tests` blocks.
 
-use ruff_diagnostics::Edit;
+use ruff_diagnostics::{Edit, Fix};
 use ruff_text_size::TextRange;
 
 use crate::{
+    diagnostics::{Diagnostic, Severity},
     rule::{Rule, RuleId},
     source::Source,
 };
@@ -40,6 +41,21 @@ pub(crate) fn breaks_parse() -> GroupSentinelRule {
             range(0, 5),
         )]],
         id: RuleId::from("breaks-parse"),
+    }
+}
+
+/// Format diagnostic with a safe single-edit fix, the shape emitter
+/// tests render.
+pub(crate) fn format_diagnostic(range: TextRange) -> Diagnostic {
+    Diagnostic {
+        fix: Some(Fix::safe_edit(Edit::range_replacement(
+            "y".to_owned(),
+            range,
+        ))),
+        message: "rewrite x to y".to_owned(),
+        range,
+        rule: RuleId::from("rewrite-x"),
+        severity: Severity::Format,
     }
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,10 +1,47 @@
 //! Helpers shared across `#[cfg(test)] mod tests` blocks.
 
+use ruff_diagnostics::Edit;
 use ruff_text_size::TextRange;
 
-use crate::source::Source;
+use crate::{
+    rule::{Rule, RuleId},
+    source::Source,
+};
+
+/// Test-only rule that returns the fix groups supplied at
+/// construction.
+pub(crate) struct GroupSentinelRule {
+    pub(crate) groups: Vec<Vec<Edit>>,
+    pub(crate) id: RuleId,
+}
+
+impl Rule for GroupSentinelRule {
+    fn apply(&self, _source: &Source) -> Vec<Vec<Edit>> {
+        self.groups.clone()
+    }
+
+    fn id(&self) -> RuleId {
+        self.id
+    }
+
+    fn message(&self) -> &'static str {
+        "group test rule"
+    }
+}
 
 pub(crate) fn assert_send_sync<T: Send + Sync>() {}
+
+/// Returns a rule whose single edit rewrites the leading statement
+/// into unparseable source, exercising the reparse guard.
+pub(crate) fn breaks_parse() -> GroupSentinelRule {
+    GroupSentinelRule {
+        groups: vec![vec![Edit::range_replacement(
+            "def foo(".to_owned(),
+            range(0, 5),
+        )]],
+        id: RuleId::from("breaks-parse"),
+    }
+}
 
 pub(crate) fn parse(src: &str) -> Source {
     src.parse().expect("test source parses")

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,10 +1,10 @@
 //! Helpers shared across `#[cfg(test)] mod tests` blocks.
 
-use ruff_diagnostics::{Edit, Fix};
+use ruff_diagnostics::Edit;
 use ruff_text_size::TextRange;
 
 use crate::{
-    diagnostics::{Diagnostic, Severity},
+    diagnostics::Diagnostic,
     rule::{Rule, RuleId},
     source::Source,
 };
@@ -33,7 +33,7 @@ impl Rule for GroupSentinelRule {
 pub(crate) fn assert_send_sync<T: Send + Sync>() {}
 
 /// Returns a rule whose single edit rewrites the leading statement
-/// into unparseable source, exercising the reparse guard.
+/// into unparseable source.
 pub(crate) fn breaks_parse() -> GroupSentinelRule {
     GroupSentinelRule {
         groups: vec![vec![Edit::range_replacement(
@@ -44,19 +44,13 @@ pub(crate) fn breaks_parse() -> GroupSentinelRule {
     }
 }
 
-/// Format diagnostic with a safe single-edit fix, the shape emitter
-/// tests render.
+/// Format diagnostic with a safe single-edit fix.
 pub(crate) fn format_diagnostic(range: TextRange) -> Diagnostic {
-    Diagnostic {
-        fix: Some(Fix::safe_edit(Edit::range_replacement(
-            "y".to_owned(),
-            range,
-        ))),
-        message: "rewrite x to y".to_owned(),
-        range,
-        rule: RuleId::from("rewrite-x"),
-        severity: Severity::Format,
-    }
+    Diagnostic::format(
+        RuleId::from("rewrite-x"),
+        vec![Edit::range_replacement("y".to_owned(), range)],
+        "rewrite x to y".to_owned(),
+    )
 }
 
 pub(crate) fn parse(src: &str) -> Source {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -412,6 +412,16 @@ fn emitters_render_shrinking_literals_without_aborting(
 }
 
 #[test]
+fn format_dash_rewrites_unaligned_stdin_to_stdout() {
+    prose()
+        .args(["format", "-"])
+        .write_stdin("ab = 1\nx = 2\n")
+        .assert()
+        .success()
+        .stdout("ab = 1\nx  = 2\n");
+}
+
+#[test]
 fn format_dash_writes_rewrite_to_stdout() {
     prose()
         .args(["format", "-"])

--- a/tests/fixtures/composition/exploded_signature_reaches_fixed_point/config.toml
+++ b/tests/fixtures/composition/exploded_signature_reaches_fixed_point/config.toml
@@ -1,0 +1,2 @@
+[harness]
+rules = ["strip-trailing-commas", "signature-layout"]

--- a/tests/fixtures/composition/exploded_signature_reaches_fixed_point/diagnostics.snap
+++ b/tests/fixtures/composition/exploded_signature_reaches_fixed_point/diagnostics.snap
@@ -1,0 +1,7 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/composition/exploded_signature_reaches_fixed_point/input.py
+---
+signature-layout@114..115
+strip-trailing-commas@114..115

--- a/tests/fixtures/composition/exploded_signature_reaches_fixed_point/input.py
+++ b/tests/fixtures/composition/exploded_signature_reaches_fixed_point/input.py
@@ -1,0 +1,8 @@
+def compose(
+    channel: str,
+    layout: tuple[int, int],
+    palette: str,
+    spread: float,
+    verbose: bool,
+):
+    return (channel, layout, palette, spread, verbose)

--- a/tests/fixtures/composition/exploded_signature_reaches_fixed_point/input.py.snap
+++ b/tests/fixtures/composition/exploded_signature_reaches_fixed_point/input.py.snap
@@ -1,0 +1,13 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/composition/exploded_signature_reaches_fixed_point/input.py
+---
+def compose(
+    channel: str,
+    layout: tuple[int, int],
+    palette: str,
+    spread: float,
+    verbose: bool
+):
+    return (channel, layout, palette, spread, verbose)

--- a/tests/fixtures/composition/exploded_signature_reaches_fixed_point/meta.toml
+++ b/tests/fixtures/composition/exploded_signature_reaches_fixed_point/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = true
+title       = "An Exploded Signature Settles at Its Fixed Point"
+
+description = '''
+An exploded signature carrying a trailing `,` **strips to a shape both rules accept**. `strip-trailing-commas` removes the comma and `signature-layout` recognizes the bare emission as canonical, so a second pass leaves the output byte-identical.
+'''

--- a/tests/fixtures/composition/params_regroup_expand_align/input.py.snap
+++ b/tests/fixtures/composition/params_regroup_expand_align/input.py.snap
@@ -8,6 +8,6 @@ def configure(
     beta  : float,
     zebra : str,
     delta : float = 0.5,
-    mango : bool  = False,
+    mango : bool  = False
 ):
     return (zebra, alpha, beta, mango, delta)

--- a/tests/fixtures/signature_layout/both_canonical_shapes_untouched/input.py
+++ b/tests/fixtures/signature_layout/both_canonical_shapes_untouched/input.py
@@ -7,6 +7,6 @@ def already_expanded(
     palette: str,
     spread: float,
     target: int,
-    verbose: bool,
+    verbose: bool
 ):
     return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/both_canonical_shapes_untouched/input.py.snap
+++ b/tests/fixtures/signature_layout/both_canonical_shapes_untouched/input.py.snap
@@ -12,6 +12,6 @@ def already_expanded(
     palette: str,
     spread: float,
     target: int,
-    verbose: bool,
+    verbose: bool
 ):
     return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/comment_after_colon_not_pinning/input.py.snap
+++ b/tests/fixtures/signature_layout/comment_after_colon_not_pinning/input.py.snap
@@ -8,6 +8,6 @@ def render(
     palette: str,
     spread: float,
     target: int,
-    verbose: bool,
+    verbose: bool
 ):  # entry point
     return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/custom_line_length_expands/input.py.snap
+++ b/tests/fixtures/signature_layout/custom_line_length_expands/input.py.snap
@@ -6,6 +6,6 @@ input_file: tests/fixtures/signature_layout/custom_line_length_expands/input.py
 def render(
     left: LayoutLayer,
     palette: PaletteSpec,
-    right: LayoutLayer,
+    right: LayoutLayer
 ):
     return (left, palette, right)

--- a/tests/fixtures/signature_layout/decorator_surface_untouched/input.py.snap
+++ b/tests/fixtures/signature_layout/decorator_surface_untouched/input.py.snap
@@ -12,6 +12,6 @@ def render(
     palette: str,
     spread: float,
     target: int,
-    verbose: bool,
+    verbose: bool
 ):
     return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/diagnostics.snap
+++ b/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/expanded_trailing_comma_dropped/input.py
+---
+signature-layout@112..113

--- a/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/input.py
+++ b/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/input.py
@@ -3,6 +3,6 @@ def render(
     palette: str,
     spread: float,
     target: int,
-    verbose: bool
+    verbose: bool,
 ):
     return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/input.py.snap
+++ b/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/input.py.snap
@@ -1,13 +1,13 @@
 ---
 source: tests/integration.rs
 expression: output
-input_file: tests/fixtures/signature_layout/missing_trailing_comma_added/input.py
+input_file: tests/fixtures/signature_layout/expanded_trailing_comma_dropped/input.py
 ---
 def render(
     layout: tuple[int, int],
     palette: str,
     spread: float,
     target: int,
-    verbose: bool,
+    verbose: bool
 ):
     return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/meta.toml
+++ b/tests/fixtures/signature_layout/expanded_trailing_comma_dropped/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "Expansion Drops the Trailing Comma"
+
+description = '''
+A multi-line signature whose last parameter carries a trailing `,` **loses it in the canonical expansion**. The exploded emission ends its final parameter bare, the shape `strip-trailing-commas` accepts.
+'''

--- a/tests/fixtures/signature_layout/line_length_alone_expands/input.py.snap
+++ b/tests/fixtures/signature_layout/line_length_alone_expands/input.py.snap
@@ -6,6 +6,6 @@ input_file: tests/fixtures/signature_layout/line_length_alone_expands/input.py
 def render(
     left_descriptor: LayoutLayer,
     palette_descriptor: PaletteSpec,
-    right_descriptor: LayoutLayer,
+    right_descriptor: LayoutLayer
 ):
     return (left_descriptor, palette_descriptor, right_descriptor)

--- a/tests/fixtures/signature_layout/lone_param_expands_bare/diagnostics.snap
+++ b/tests/fixtures/signature_layout/lone_param_expands_bare/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/lone_param_expands_bare/input.py
+---
+signature-layout@11..87

--- a/tests/fixtures/signature_layout/lone_param_expands_bare/input.py
+++ b/tests/fixtures/signature_layout/lone_param_expands_bare/input.py
@@ -1,0 +1,2 @@
+def render(palette_descriptor_inventories: tuple[PaletteSpec, PaletteSpec, PaletteSpec]):
+    return palette_descriptor_inventories

--- a/tests/fixtures/signature_layout/lone_param_expands_bare/input.py.snap
+++ b/tests/fixtures/signature_layout/lone_param_expands_bare/input.py.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/lone_param_expands_bare/input.py
+---
+def render(
+    palette_descriptor_inventories: tuple[PaletteSpec, PaletteSpec, PaletteSpec]
+):
+    return palette_descriptor_inventories

--- a/tests/fixtures/signature_layout/lone_param_expands_bare/meta.toml
+++ b/tests/fixtures/signature_layout/lone_param_expands_bare/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "A Lone Parameter Expands Bare"
+
+description = '''
+A single parameter that overflows `code-line-length` **expands to one bare line**. With the only parameter also the last, the canonical emission carries no comma at all.
+'''

--- a/tests/fixtures/signature_layout/method_expands_at_class_indent/input.py.snap
+++ b/tests/fixtures/signature_layout/method_expands_at_class_indent/input.py.snap
@@ -9,6 +9,6 @@ class Renderer:
         layout: tuple[int, int],
         palette: str,
         spread: float,
-        target: int,
+        target: int
     ):
         return (self, layout, palette, spread, target)

--- a/tests/fixtures/signature_layout/missing_trailing_comma_added/diagnostics.snap
+++ b/tests/fixtures/signature_layout/missing_trailing_comma_added/diagnostics.snap
@@ -1,6 +1,0 @@
----
-source: tests/diagnostics.rs
-expression: render(&diagnostics)
-input_file: tests/fixtures/signature_layout/missing_trailing_comma_added/input.py
----
-signature-layout@112..112

--- a/tests/fixtures/signature_layout/missing_trailing_comma_added/meta.toml
+++ b/tests/fixtures/signature_layout/missing_trailing_comma_added/meta.toml
@@ -1,7 +1,0 @@
-[docs]
-previewable = false
-title       = "Expansion Adds the Missing Trailing Comma"
-
-description = '''
-A multi-line signature whose last parameter lacks a trailing `,` **gets one added in the canonical expansion**. The rewrite holds its trailing-comma invariant against source variants that omit it.
-'''

--- a/tests/fixtures/signature_layout/param_count_alone_expands/input.py.snap
+++ b/tests/fixtures/signature_layout/param_count_alone_expands/input.py.snap
@@ -8,6 +8,6 @@ def render(
     height: int,
     depth: int,
     scale: int,
-    fast: bool,
+    fast: bool
 ):
     return (width, height, depth, scale, fast)

--- a/tests/fixtures/signature_layout/pep695_type_params_survive/input.py.snap
+++ b/tests/fixtures/signature_layout/pep695_type_params_survive/input.py.snap
@@ -8,6 +8,6 @@ def render[T](
     beta: T,
     delta: T,
     gamma: T,
-    target: T,
+    target: T
 ) -> tuple[T, T]:
     return (alpha, beta)

--- a/tests/fixtures/signature_layout/posonly_slash_ends_bare/diagnostics.snap
+++ b/tests/fixtures/signature_layout/posonly_slash_ends_bare/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/signature_layout/posonly_slash_ends_bare/input.py
+---
+signature-layout@11..54

--- a/tests/fixtures/signature_layout/posonly_slash_ends_bare/input.py
+++ b/tests/fixtures/signature_layout/posonly_slash_ends_bare/input.py
@@ -1,0 +1,2 @@
+def render(layout, palette, spread, target, verbose, /):
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/posonly_slash_ends_bare/input.py.snap
+++ b/tests/fixtures/signature_layout/posonly_slash_ends_bare/input.py.snap
@@ -1,0 +1,14 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/signature_layout/posonly_slash_ends_bare/input.py
+---
+def render(
+    layout,
+    palette,
+    spread,
+    target,
+    verbose,
+    /
+):
+    return (layout, palette, spread, target, verbose)

--- a/tests/fixtures/signature_layout/posonly_slash_ends_bare/meta.toml
+++ b/tests/fixtures/signature_layout/posonly_slash_ends_bare/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "A Trailing Positional-Only Slash Ends Bare"
+
+description = '''
+A signature whose parameter list ends on the positional-only `/` separator **leaves the separator bare** as the final exploded line, so the emission re-parses cleanly.
+'''

--- a/tests/fixtures/signature_layout/return_string_concat_survives_expand/input.py.snap
+++ b/tests/fixtures/signature_layout/return_string_concat_survives_expand/input.py.snap
@@ -7,7 +7,7 @@ def assemble_result(
     primary_candidate,
     secondary_candidate,
     fallback_candidate,
-    retry_budget,
+    retry_budget
 ) -> (
     "module.PrimaryEnvelope"
     "[str]"

--- a/tests/fixtures/signature_layout/return_union_parens_survive_expand/input.py.snap
+++ b/tests/fixtures/signature_layout/return_union_parens_survive_expand/input.py.snap
@@ -7,7 +7,7 @@ def assemble_result(
     primary_candidate,
     secondary_candidate,
     fallback_candidate,
-    retry_budget,
+    retry_budget
 ) -> (
     PrimaryEnvelope
     | SecondaryEnvelope

--- a/tests/fixtures/signature_layout/rich_annotations_sliced_verbatim/input.py.snap
+++ b/tests/fixtures/signature_layout/rich_annotations_sliced_verbatim/input.py.snap
@@ -12,6 +12,6 @@ def configure(
     config: Mapping[str, Any],
     metadata: Annotated[dict[str, int], "extra"],
     tags: tuple[str, ...],
-    timeout: Optional[float] = None,
+    timeout: Optional[float] = None
 ) -> tuple[bool, str]:
     return (True, "ok")

--- a/tests/fixtures/signature_layout/separators_preserved_verbatim/input.py.snap
+++ b/tests/fixtures/signature_layout/separators_preserved_verbatim/input.py.snap
@@ -10,6 +10,6 @@ def render(
     *,
     layout: tuple[int, int],
     spread: float,
-    verbose: bool = False,
+    verbose: bool = False
 ) -> tuple[int, str]:
     return (palette, target, layout, spread, verbose)

--- a/tests/fixtures/signature_layout/star_prefixes_carry_through/input.py.snap
+++ b/tests/fixtures/signature_layout/star_prefixes_carry_through/input.py.snap
@@ -9,6 +9,6 @@ def dispatch(
     *args: int,
     layout: tuple[int, int],
     spread: float = 0.0,
-    **kwargs: object,
+    **kwargs: object
 ):
     return (palette, target, layout, spread, args, kwargs)

--- a/tests/fixtures/signature_layout/walker_descends_nested_defs/input.py.snap
+++ b/tests/fixtures/signature_layout/walker_descends_nested_defs/input.py.snap
@@ -8,14 +8,14 @@ async def outer(
     palette: str,
     spread: float,
     target: int,
-    verbose: bool,
+    verbose: bool
 ):
     def inner(
         host: str,
         port: int,
         retries: int,
         timeout: float,
-        verbose: bool,
+        verbose: bool
     ):
         return (host, port, retries, timeout, verbose)
     return await inner(palette, 8080, 3, 10.0, verbose)


### PR DESCRIPTION
### 🪻 Quick Summary

Drops the trailing comma from `signature-layout`'s one-parameter-per-line emission, the comma `strip-trailing-commas` exists to remove. The two default-enabled rules previously accepted no common state, in that `check` raised a diagnostic on an exploded signature with the comma and without it, and because the layout rule runs after the strip rule, every `format` run re-added the comma the strip had just removed, leaving output that failed its own `check` and a byte-stable file reporting `Reformatted 1 file` on every run. The emission now ends its final parameter bare, matching the shape `collection-layout` already emits, and the runner carries each file's rewrite as a tri-state so a run whose edits cancel byte-for-byte reports the file unchanged in both summary counts and exit status. A polish pass is folded in, colocating the runner's unit tests with the files they pin and consolidating hand-rolled test scaffolding into shared `testing` helpers.

---

### 🗞️ Key Changes

- Ends `build_expanded`'s final parameter bare, so the canonical one-per-line emission passes `strip-trailing-commas` and `format` output passes `check` under the default rule set.

- Replaces `FileOutcome`'s `Option<String>` rewrite field with the cache's `Rewrite` tri-state, letting a `format` run whose edits cancel byte-for-byte report the file unchanged in summary counts and exit status rather than counting as a reformat.

- Pins the fixed point with the composition fixture `exploded_signature_reaches_fixed_point`, where both rules run over an exploded signature, the output draws no diagnostic, and a second pass leaves it byte-identical.

- Inverts the `missing_trailing_comma_added` rule fixture into `expanded_trailing_comma_dropped`, adds the `lone_param_expands_bare` and `posonly_slash_ends_bare` edge fixtures, and regenerates every exploded-emission snapshot bare.

- Colocates the runner's unit tests with the files they pin, relocating the per-file processing, outcome reporting, and diff rendering blocks from `src/cli/runner/mod.rs` into `process.rs`, `report.rs`, and `diff.rs`.

- Consolidates test scaffolding into the shared `testing` module, wherein `GroupSentinelRule`, `breaks_parse`, and a `format_diagnostic` delegating to the existing `Diagnostic::format` constructor replace per-module hand-rolled copies.

- Routes every runner failure path through one `failed` helper carrying the exit status, absorbing the `ParseError` reporting sites the prior `ConfigError`-only shape left inline.

- Adds a `format -` CLI pin asserting the formatted rewrite reaches stdout for changing stdin input, and corrects the `strip-trailing-commas` docs caption to the rule's full bracketed-container coverage.

---

### 🧵 Related Issues

- Closes #242
