### PR TITLE
[243] Resolve config per input file from its own ancestors

### DIFF
--- a/site/.vitepress/data/exit-codes.data.ts
+++ b/site/.vitepress/data/exit-codes.data.ts
@@ -63,7 +63,8 @@ const SOURCES: readonly ExitCodeSource[] = [
     detail : [
       'Surfaces from config-file parse errors, malformed `--select` / '
       + '`--ignore` flags, or unknown CLI options.',
-      'Pre-empts every other code (the run never reaches the pipeline).'
+      'A malformed flag pre-empts the whole run, whereas a broken ancestor '
+      + 'config fails only the files it governs while the rest proceed.'
     ],
     label  : 'Config error',
     summary: 'Config file or argument validation failed.'

--- a/site/integrations/github-actions.md
+++ b/site/integrations/github-actions.md
@@ -71,7 +71,7 @@ Repeat runs hit the user-level [**cache**](/reference/cache) on by default, but 
 - run: prose check .
 ```
 
-Keying off the config files invalidates the cache whenever configuration changes, since the key already digests the active config and an upstream change to it produces a fresh set of entries. macOS runners use `~/Library/Caches/prose` and Windows runners use `%LOCALAPPDATA%\prose\cache`, both [documented on the cache page](/reference/cache#location).
+Keying off the config files invalidates the cache whenever configuration changes, since the key already digests each file's governing config and an upstream change to it produces a fresh set of entries. macOS runners use `~/Library/Caches/prose` and Windows runners use `%LOCALAPPDATA%\prose\cache`, both [documented on the cache page](/reference/cache#location).
 
 ## Pairing With Ruff in CI
 

--- a/site/primitives/pipeline.md
+++ b/site/primitives/pipeline.md
@@ -15,7 +15,7 @@ stability: public
 ### Constructors
 
 1. `Pipeline::empty() -> Self` returns a pipeline with no rules registered, for tests or callers building a custom rule set.
-2. `Pipeline::with_defaults(config: &Config) -> Self` builds the canonical pipeline from every rule whose `enabled` flag is set in `[tool.prose]`. The `prose format` and `prose check` paths both reach for this.
+2. `Pipeline::with_defaults(config: &Config) -> Self` builds the canonical pipeline from every rule whose `enabled` flag is set in `[tool.prose]`. The `prose server` formatting and diagnostics paths reach for this, and the CLI reaches the same set through `with_filters` with no flags.
 3. `Pipeline::with_filters(config: &Config, select: &[RuleId], ignore: &[RuleId]) -> Self` applies the CLI's `--select` and `--ignore` semantics. A non-empty `select` replaces the configured-enabled set, an empty `select` falls back to it, and `ignore` subtracts from the base to yield `select - ignore`.
 4. `Pipeline::for_rule(name: &str, config: &Config) -> Option<Self>` builds a single-rule pipeline for diagnostic isolation and `prose check --select <rule>` exact-rule paths. Returns `None` for an unrecognized slug.
 

--- a/site/reference/cache.md
+++ b/site/reference/cache.md
@@ -1,6 +1,6 @@
 # Cache
 
-*Prose* caches per-file pipeline output keyed on the source bytes, the active configuration, and the *Prose* version. A repeat `prose check` or `prose format` against an unchanged file collapses to a stat, a hash, and a deserialize, since the cache hit re-emits diagnostics from the cached entry without entering the pipeline.
+*Prose* caches per-file pipeline output keyed on the source bytes, the configuration governing the file, and the *Prose* version. A repeat `prose check` or `prose format` against an unchanged file collapses to a stat, a hash, and a deserialize, since the cache hit re-emits diagnostics from the cached entry without entering the pipeline.
 
 The cache is enabled by default. The `[cache]` table tunes it, `--no-cache` bypasses it for one invocation, and `prose cache clean` clears it.
 
@@ -23,7 +23,7 @@ Resolution chains through `PROSE_CACHE_DIR` → the platform default. `PROSE_CAC
 The cache key is the **BLAKE3** digest of `(source_bytes ++ config_toml ++ prose_version ++ cache_format_version)`. The inputs:
 
 - the source bytes of the file under formatting
-- the canonical TOML serialization of the active `Config`, so a semantically-equivalent re-shuffling of the user's config file produces the same key
+- the canonical TOML serialization of the `Config` governing the file, so a semantically-equivalent re-shuffling of the user's config file produces the same key
 - the *Prose* version from `CARGO_PKG_VERSION`, so a version bump invalidates the cache wholesale
 - a private `CACHE_FORMAT_VERSION` constant that bumps independently when the on-disk entry shape changes, leaving the user-facing version free to ship semver-meaningful bumps without unrelated cache turnover
 

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-*Prose* loads its configuration from a `prose.toml` file or the `[tool.prose]` table of a `pyproject.toml`, walking upward from the working directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically.
+*Prose* loads its configuration from a `prose.toml` file or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically.
 
 A `prose.toml` keeps its keys at the document root, the form this page shows throughout. A `pyproject.toml` carries the same keys under a `[tool.prose]` prefix so the manifest can house other tools too, leaving every key below a `[tool.prose.<…>]` equivalent for projects that prefer one file.
 
@@ -21,7 +21,7 @@ A bare `false` disables a rule, an inline table sets its knobs while leaving the
 
 ## Where *Prose* Looks
 
-*Prose* walks upward from the working directory toward the filesystem root. In each directory a `prose.toml` outranks a `pyproject.toml`, and the nearest directory carrying either wins, in that *Prose* reads only that one file and never merges across matches up the tree. A `pyproject.toml` lacking a `[tool.prose]` table is passed over, leaving the walk to continue upward. When no ancestor carries either, every default applies as if the config were empty.
+*Prose* walks upward from each input file's own directory toward the filesystem root, so a file answers to its own project's config even when one invocation names files across several projects. Stdin input walks from the working directory, the one input with no path of its own. In each directory a `prose.toml` outranks a `pyproject.toml`, and the nearest directory carrying either wins, in that *Prose* reads only that one file and never merges across matches up the tree. A `pyproject.toml` lacking a `[tool.prose]` table is passed over, leaving the walk to continue upward. When no ancestor carries either, every default applies as if the config were empty.
 
 When a `prose.toml` and a `pyproject.toml` `[tool.prose]` table share a directory, the `prose.toml` wins and *Prose* notes the precedence to stderr, so the file that took effect is never ambiguous.
 

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -22,7 +22,7 @@ pub(crate) fn clean<W: Write>(stdout: W) -> anyhow::Result<ExitStatus> {
 
 pub(crate) fn compact<W: Write>(stdout: W) -> anyhow::Result<ExitStatus> {
     let config = match load_config_or_status() {
-        Ok(c) => c,
+        Ok((_, c)) => c,
         Err(s) => return Ok(s),
     };
     let cache = match open_or_status() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -115,18 +115,16 @@ fn is_broken_pipe(err: &anyhow::Error) -> bool {
 
 /// Loads the cwd's own config, returning the cwd beside it.
 fn load_config_or_status() -> Result<(PathBuf, Config), ExitStatus> {
+    let fail = |e: anyhow::Error| {
+        log_error_chain(&e);
+        ExitStatus::ConfigError
+    };
     let cwd = std::env::current_dir()
         .context("reading current working directory")
-        .map_err(|e| {
-            log_error_chain(&e);
-            ExitStatus::ConfigError
-        })?;
+        .map_err(fail)?;
     let config = Config::load(&cwd)
         .context("loading [tool.prose] config")
-        .map_err(|e| {
-            log_error_chain(&e);
-            ExitStatus::ConfigError
-        })?;
+        .map_err(fail)?;
     Ok((cwd, config))
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,6 +20,7 @@
 
 use std::{
     io::{self, IsTerminal, Write},
+    path::PathBuf,
     process::ExitCode,
 };
 
@@ -112,19 +113,21 @@ fn is_broken_pipe(err: &anyhow::Error) -> bool {
         .is_some_and(|e| e.kind() == io::ErrorKind::BrokenPipe)
 }
 
-fn load_config_or_status() -> Result<Config, ExitStatus> {
+/// Loads the cwd's own config, returning the cwd beside it.
+fn load_config_or_status() -> Result<(PathBuf, Config), ExitStatus> {
     let cwd = std::env::current_dir()
         .context("reading current working directory")
         .map_err(|e| {
             log_error_chain(&e);
             ExitStatus::ConfigError
         })?;
-    Config::load(&cwd)
+    let config = Config::load(&cwd)
         .context("loading [tool.prose] config")
         .map_err(|e| {
             log_error_chain(&e);
             ExitStatus::ConfigError
-        })
+        })?;
+    Ok((cwd, config))
 }
 
 fn log_error_chain(err: &anyhow::Error) {

--- a/src/cli/runner/mod.rs
+++ b/src/cli/runner/mod.rs
@@ -3,6 +3,7 @@
 use std::{
     io::{Read, Write},
     path::PathBuf,
+    sync::Arc,
 };
 
 use anyhow::Context;
@@ -23,12 +24,14 @@ use crate::{
 mod diff;
 mod process;
 mod report;
+mod resolve;
 
 use diff::write_diff;
 use process::{apply_rewrite, process_path, process_paths, process_stdin};
 use report::{
     emit_outcomes, emitter_summary, finish, render_summary, status_from_outcomes, summarize,
 };
+use resolve::{ConfigResolver, Resolved};
 
 /// One file's contribution to the run.
 #[derive(Debug)]
@@ -66,8 +69,8 @@ enum Pass {
 /// Per-run setup shared across every path the walker yields.
 struct RunSetup {
     cache: Option<Cache>,
-    config_toml: String,
-    pipeline: Pipeline,
+    cwd: Arc<Resolved>,
+    resolver: ConfigResolver,
 }
 
 pub(crate) fn check_with_io<R: Read, O: Write, E: Write>(
@@ -86,7 +89,7 @@ pub(crate) fn check_with_io<R: Read, O: Write, E: Write>(
         validate: args.validate,
     };
     let outcomes = if args.stdin {
-        vec![process_stdin(stdin, &setup.pipeline, pass)]
+        vec![process_stdin(stdin, &setup.cwd.pipeline, pass)]
     } else {
         process_paths(&args.paths, |path| process_path(path, &setup, pass))
     };
@@ -119,7 +122,7 @@ pub(crate) fn format_with_io<R: Read, O: Write, E: Write>(
             args.diff,
             args.output_format,
             present,
-            &setup.pipeline,
+            &setup.cwd.pipeline,
             &mut stdout,
             &mut stderr,
         );
@@ -146,15 +149,18 @@ pub(crate) fn format_with_io<R: Read, O: Write, E: Write>(
     }
 }
 
+/// Builds the run-level setup. The cwd's own config governs stdin
+/// input and the cache settings, while each path input re-resolves
+/// from its own ancestors through the seeded resolver.
 fn build_run(rules: &RuleFilter, no_cache: bool) -> Result<RunSetup, ExitStatus> {
-    let config = super::load_config_or_status()?;
-    let pipeline = Pipeline::with_filters(&config, &rules.select, &rules.ignore);
+    let (cwd_dir, config) = super::load_config_or_status()?;
     let cache = open_cache(&config, no_cache);
-    let config_toml = toml::to_string(&config).unwrap_or_default();
+    let resolver = ConfigResolver::new(rules.select.clone(), rules.ignore.clone());
+    let cwd = resolver.seed(cwd_dir, &config);
     Ok(RunSetup {
         cache,
-        config_toml,
-        pipeline,
+        cwd,
+        resolver,
     })
 }
 
@@ -307,6 +313,7 @@ mod tests {
     use crate::diagnostics::{EmitterSummary, Severity};
     use crate::rule::{Rule, RuleId};
     use crate::source::Source;
+    use crate::testing::write_pyproject;
 
     /// Test-only rule whose single edit rewrites the leading statement
     /// into unparseable source, exercising the reparse guard.
@@ -406,6 +413,37 @@ mod tests {
     }
 
     #[test]
+    fn check_broken_ancestor_config_fails_the_file_and_continues() {
+        let tmp = TempDir::new().expect("tempdir");
+        let broken = tmp.path().join("broken");
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir_all(&broken).expect("dirs create");
+        std::fs::create_dir_all(&plain).expect("dirs create");
+        write_pyproject(&broken, "[this is not valid TOML");
+        std::fs::write(broken.join("a.py"), "x = 1\n").expect("writes");
+        std::fs::write(plain.join("b.py"), "x = 1\n").expect("writes");
+
+        let mut args = check_args(vec![broken.join("a.py"), plain.join("b.py")], false);
+        args.output_format = OutputFormat::Json;
+        let mut stdout = Vec::new();
+        let status = check_with_io(
+            args,
+            false,
+            &windowed(),
+            io::empty(),
+            &mut stdout,
+            io::sink(),
+        )
+        .expect("runs without anyhow");
+
+        assert_eq!(status, ExitStatus::ConfigError);
+        let out = String::from_utf8(stdout).expect("utf-8");
+        let summary: serde_json::Value =
+            serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses");
+        assert_eq!(summary["files_visited"], 1);
+    }
+
+    #[test]
     fn check_clean_returns_clean() {
         let tmp = TempDir::new().expect("tempdir");
         let file = tmp.path().join("a.py");
@@ -479,6 +517,48 @@ mod tests {
 
         let status = check_with_io(
             check_args(vec![tmp.path().to_path_buf()], false),
+            false,
+            &windowed(),
+            io::empty(),
+            Vec::<u8>::new(),
+            io::sink(),
+        )
+        .expect("runs successfully");
+
+        assert_eq!(status, ExitStatus::FormatChange);
+    }
+
+    #[test]
+    fn check_resolves_config_from_the_files_own_ancestors() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+
+        let status = check_with_io(
+            check_args(vec![file], false),
+            false,
+            &windowed(),
+            io::empty(),
+            Vec::<u8>::new(),
+            io::sink(),
+        )
+        .expect("runs successfully");
+
+        assert_eq!(status, ExitStatus::Clean);
+    }
+
+    #[test]
+    fn check_select_overrides_the_files_own_config() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+
+        let mut args = check_args(vec![file], false);
+        args.rules.select = vec![RuleId::from("align-equals")];
+        let status = check_with_io(
+            args,
             false,
             &windowed(),
             io::empty(),
@@ -662,6 +742,26 @@ mod tests {
         assert!(file_changed(&format, None));
         assert!(!file_changed(&lint, None));
         assert!(!file_changed(&[], None));
+    }
+
+    #[test]
+    fn format_diff_resolves_config_from_the_files_own_ancestors() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+
+        let status = format_with_io(
+            format_args(vec![file], false, true),
+            false,
+            &windowed(),
+            io::empty(),
+            Vec::<u8>::new(),
+            io::sink(),
+        )
+        .expect("runs successfully");
+
+        assert_eq!(status, ExitStatus::Clean);
     }
 
     #[test]
@@ -898,11 +998,12 @@ mod tests {
     #[test]
     fn process_path_returns_config_error_on_missing_file() {
         let tmp = TempDir::new().expect("tempdir");
-        let config = Config::default();
+        let resolver = ConfigResolver::new(Vec::new(), Vec::new());
+        let cwd = resolver.seed(tmp.path().to_path_buf(), &Config::default());
         let setup = RunSetup {
             cache: None,
-            config_toml: String::new(),
-            pipeline: Pipeline::with_filters(&config, &[], &[]),
+            cwd,
+            resolver,
         };
         let outcome = process_path(
             &tmp.path().join("does_not_exist.py"),

--- a/src/cli/runner/mod.rs
+++ b/src/cli/runner/mod.rs
@@ -463,6 +463,27 @@ mod tests {
     }
 
     #[test]
+    fn check_ignore_overrides_the_files_own_config() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+
+        let mut args = check_args(vec![file], false);
+        args.rules.ignore = vec![RuleId::from("align-equals")];
+        let status = check_with_io(
+            args,
+            false,
+            &windowed(),
+            io::empty(),
+            Vec::<u8>::new(),
+            io::sink(),
+        )
+        .expect("runs successfully");
+
+        assert_eq!(status, ExitStatus::Clean);
+    }
+
+    #[test]
     fn check_outcomes_with_failed_parse_takes_higher_status() {
         let source = "x = 1\n".parse::<Source>().expect("parses");
         let range = TextRange::new(0.into(), 1.into());

--- a/src/cli/runner/mod.rs
+++ b/src/cli/runner/mod.rs
@@ -81,7 +81,7 @@ pub(crate) fn check_with_io<R: Read, O: Write, E: Write>(
     mut stdout: O,
     mut stderr: E,
 ) -> anyhow::Result<ExitStatus> {
-    let setup = match build_run(&args.rules, args.no_cache) {
+    let setup = match build_run(args.rules, args.no_cache) {
         Ok(s) => s,
         Err(s) => return Ok(s),
     };
@@ -95,7 +95,7 @@ pub(crate) fn check_with_io<R: Read, O: Write, E: Write>(
     };
     let summary = emitter_summary(&outcomes);
     emit_outcomes(&outcomes, args.output_format, &mut stdout, &summary)?;
-    let status = finish(&outcomes, &setup, verbose, false);
+    let status = finish(&outcomes, setup.cache.is_some(), verbose, false);
     render_summary(
         &mut stderr,
         present,
@@ -112,7 +112,7 @@ pub(crate) fn format_with_io<R: Read, O: Write, E: Write>(
     mut stdout: O,
     mut stderr: E,
 ) -> anyhow::Result<ExitStatus> {
-    let setup = match build_run(&args.rules, args.no_cache) {
+    let setup = match build_run(args.rules, args.no_cache) {
         Ok(s) => s,
         Err(s) => return Ok(s),
     };
@@ -152,10 +152,10 @@ pub(crate) fn format_with_io<R: Read, O: Write, E: Write>(
 /// Builds the run-level setup. The cwd's own config governs stdin
 /// input and the cache settings, while each path input re-resolves
 /// from its own ancestors through the seeded resolver.
-fn build_run(rules: &RuleFilter, no_cache: bool) -> Result<RunSetup, ExitStatus> {
+fn build_run(rules: RuleFilter, no_cache: bool) -> Result<RunSetup, ExitStatus> {
     let (cwd_dir, config) = super::load_config_or_status()?;
     let cache = open_cache(&config, no_cache);
-    let resolver = ConfigResolver::new(rules.select.clone(), rules.ignore.clone());
+    let resolver = ConfigResolver::new(rules.select, rules.ignore);
     let cwd = resolver.seed(cwd_dir, &config);
     Ok(RunSetup {
         cache,
@@ -202,7 +202,7 @@ fn format_paths_diff<O: Write, E: Write>(
         }
     }
     let summary = emitter_summary(&outcomes);
-    let status = finish(&outcomes, setup, verbose, false);
+    let status = finish(&outcomes, setup.cache.is_some(), verbose, false);
     render_summary(
         stderr,
         present,
@@ -228,7 +228,7 @@ fn format_paths_rewrite<O: Write, E: Write>(
     if !format.is_text() {
         emit_outcomes(&outcomes, format, stdout, &summary)?;
     }
-    let status = finish(&outcomes, setup, verbose, true);
+    let status = finish(&outcomes, setup.cache.is_some(), verbose, true);
     render_summary(
         stderr,
         present,
@@ -376,6 +376,13 @@ mod tests {
         }
     }
 
+    fn fixture(source: &str) -> (TempDir, PathBuf) {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("a.py");
+        std::fs::write(&file, source).expect("writes");
+        (tmp, file)
+    }
+
     fn format_args(paths: Vec<PathBuf>, stdin: bool, diff: bool) -> FormatArgs {
         FormatArgs {
             diff,
@@ -393,6 +400,30 @@ mod tests {
             file: source.source_file().clone(),
             formatted_text: None,
         }
+    }
+
+    fn run_check(args: CheckArgs) -> ExitStatus {
+        check_with_io(
+            args,
+            false,
+            &windowed(),
+            io::empty(),
+            Vec::<u8>::new(),
+            io::sink(),
+        )
+        .expect("runs without anyhow")
+    }
+
+    fn run_format(args: FormatArgs) -> ExitStatus {
+        format_with_io(
+            args,
+            false,
+            &windowed(),
+            io::empty(),
+            Vec::<u8>::new(),
+            io::sink(),
+        )
+        .expect("runs without anyhow")
     }
 
     fn windowed() -> Presentation {
@@ -445,42 +476,21 @@ mod tests {
 
     #[test]
     fn check_clean_returns_clean() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "x = 1\n").expect("writes");
+        let (tmp, _file) = fixture("x = 1\n");
 
-        let status = check_with_io(
-            check_args(vec![tmp.path().to_path_buf()], false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_check(check_args(vec![tmp.path().to_path_buf()], false));
 
         assert_eq!(status, ExitStatus::Clean);
     }
 
     #[test]
     fn check_ignore_overrides_the_files_own_config() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+        let (_tmp, file) = fixture("alpha = 1\nb = 22\n");
 
         let mut args = check_args(vec![file], false);
         args.rules.ignore = vec![RuleId::from("align-equals")];
-        let status = check_with_io(
-            args,
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
 
-        assert_eq!(status, ExitStatus::Clean);
+        assert_eq!(run_check(args), ExitStatus::Clean);
     }
 
     #[test]
@@ -532,63 +542,30 @@ mod tests {
 
     #[test]
     fn check_pending_format_returns_format_change() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+        let (tmp, _file) = fixture("alpha = 1\nb = 22\n");
 
-        let status = check_with_io(
-            check_args(vec![tmp.path().to_path_buf()], false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_check(check_args(vec![tmp.path().to_path_buf()], false));
 
         assert_eq!(status, ExitStatus::FormatChange);
     }
 
     #[test]
     fn check_resolves_config_from_the_files_own_ancestors() {
-        let tmp = TempDir::new().expect("tempdir");
+        let (tmp, file) = fixture("alpha = 1\nb = 22\n");
         write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
 
-        let status = check_with_io(
-            check_args(vec![file], false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
-
-        assert_eq!(status, ExitStatus::Clean);
+        assert_eq!(run_check(check_args(vec![file], false)), ExitStatus::Clean);
     }
 
     #[test]
     fn check_select_overrides_the_files_own_config() {
-        let tmp = TempDir::new().expect("tempdir");
+        let (tmp, file) = fixture("alpha = 1\nb = 22\n");
         write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
 
         let mut args = check_args(vec![file], false);
         args.rules.select = vec![RuleId::from("align-equals")];
-        let status = check_with_io(
-            args,
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
 
-        assert_eq!(status, ExitStatus::FormatChange);
+        assert_eq!(run_check(args), ExitStatus::FormatChange);
     }
 
     #[test]
@@ -622,19 +599,9 @@ mod tests {
 
     #[test]
     fn check_unparseable_path_returns_parse_error() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "def foo(").expect("writes");
+        let (tmp, _file) = fixture("def foo(");
 
-        let status = check_with_io(
-            check_args(vec![tmp.path().to_path_buf()], false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs without anyhow");
+        let status = run_check(check_args(vec![tmp.path().to_path_buf()], false));
 
         assert_eq!(status, ExitStatus::ParseError);
     }
@@ -767,39 +734,19 @@ mod tests {
 
     #[test]
     fn format_diff_resolves_config_from_the_files_own_ancestors() {
-        let tmp = TempDir::new().expect("tempdir");
+        let (tmp, file) = fixture("alpha = 1\nb = 22\n");
         write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
 
-        let status = format_with_io(
-            format_args(vec![file], false, true),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_format(format_args(vec![file], false, true));
 
         assert_eq!(status, ExitStatus::Clean);
     }
 
     #[test]
     fn format_diff_returns_clean_for_already_canonical_file() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "x = 1\n").expect("writes");
+        let (tmp, _file) = fixture("x = 1\n");
 
-        let status = format_with_io(
-            format_args(vec![tmp.path().to_path_buf()], false, true),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_format(format_args(vec![tmp.path().to_path_buf()], false, true));
 
         assert_eq!(status, ExitStatus::Clean);
     }
@@ -809,34 +756,16 @@ mod tests {
         let tmp = TempDir::new().expect("tempdir");
         let missing = tmp.path().join("does_not_exist");
 
-        let status = format_with_io(
-            format_args(vec![missing], false, true),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs without anyhow");
+        let status = run_format(format_args(vec![missing], false, true));
 
         assert_eq!(status, ExitStatus::ConfigError);
     }
 
     #[test]
     fn format_diff_returns_format_change_for_pending_change() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+        let (tmp, _file) = fixture("alpha = 1\nb = 22\n");
 
-        let status = format_with_io(
-            format_args(vec![tmp.path().to_path_buf()], false, true),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_format(format_args(vec![tmp.path().to_path_buf()], false, true));
 
         assert_eq!(status, ExitStatus::FormatChange);
     }
@@ -850,19 +779,9 @@ mod tests {
 
     #[test]
     fn format_paths_does_not_rewrite_when_pipeline_is_empty() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "x = 1\n").expect("writes");
+        let (tmp, file) = fixture("x = 1\n");
 
-        let status = format_with_io(
-            format_args(vec![tmp.path().to_path_buf()], false, false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_format(format_args(vec![tmp.path().to_path_buf()], false, false));
 
         assert_eq!(status, ExitStatus::Clean);
         let contents = std::fs::read_to_string(&file).expect("reads");
@@ -871,9 +790,7 @@ mod tests {
 
     #[test]
     fn format_paths_rewrite_emits_json_when_format_is_non_text() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+        let (tmp, _file) = fixture("alpha = 1\nb = 22\n");
 
         let mut args = format_args(vec![tmp.path().to_path_buf()], false, false);
         args.output_format = OutputFormat::Json;
@@ -890,6 +807,18 @@ mod tests {
 
         assert_eq!(status, ExitStatus::Clean);
         assert!(!stdout.is_empty());
+    }
+
+    #[test]
+    fn format_rewrite_resolves_config_from_the_files_own_ancestors() {
+        let (tmp, file) = fixture("alpha = 1\nb = 22\n");
+        write_pyproject(tmp.path(), "[tool.prose.rules]\nalign-equals = false\n");
+
+        let status = run_format(format_args(vec![file.clone()], false, false));
+
+        assert_eq!(status, ExitStatus::Clean);
+        let after = std::fs::read_to_string(&file).expect("reads");
+        assert_eq!(after, "alpha = 1\nb = 22\n");
     }
 
     #[test]
@@ -956,38 +885,18 @@ mod tests {
 
     #[test]
     fn format_unparseable_returns_parse_error() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "def foo(").expect("writes");
+        let (tmp, _file) = fixture("def foo(");
 
-        let status = format_with_io(
-            format_args(vec![tmp.path().to_path_buf()], false, false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs without anyhow");
+        let status = run_format(format_args(vec![tmp.path().to_path_buf()], false, false));
 
         assert_eq!(status, ExitStatus::ParseError);
     }
 
     #[test]
     fn format_writes_and_returns_clean_for_pending_change() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+        let (tmp, file) = fixture("alpha = 1\nb = 22\n");
 
-        let status = format_with_io(
-            format_args(vec![tmp.path().to_path_buf()], false, false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_format(format_args(vec![tmp.path().to_path_buf()], false, false));
 
         assert_eq!(status, ExitStatus::Clean);
         let after = std::fs::read_to_string(&file).expect("reads");
@@ -996,22 +905,12 @@ mod tests {
 
     #[test]
     fn format_writes_return_config_error_when_target_is_readonly() {
-        let tmp = TempDir::new().expect("tempdir");
-        let file = tmp.path().join("a.py");
-        std::fs::write(&file, "alpha = 1\nb = 22\n").expect("writes");
+        let (tmp, file) = fixture("alpha = 1\nb = 22\n");
         let mut perms = std::fs::metadata(&file).expect("metadata").permissions();
         perms.set_readonly(true);
         std::fs::set_permissions(&file, perms).expect("set_permissions");
 
-        let status = format_with_io(
-            format_args(vec![tmp.path().to_path_buf()], false, false),
-            false,
-            &windowed(),
-            io::empty(),
-            Vec::<u8>::new(),
-            io::sink(),
-        )
-        .expect("runs successfully");
+        let status = run_format(format_args(vec![tmp.path().to_path_buf()], false, false));
 
         assert_eq!(status, ExitStatus::ConfigError);
     }

--- a/src/cli/runner/process.rs
+++ b/src/cli/runner/process.rs
@@ -1,5 +1,5 @@
-//! Per-file processing: read, cache-lookup, run the pipeline, and
-//! classify the outcome.
+//! Per-file processing: read, resolve config, cache-lookup, run the
+//! pipeline, and classify the outcome.
 
 use std::{
     io::{self, Read},
@@ -49,6 +49,9 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
         Ok(b) => b,
         Err(e) => return config_error(e),
     };
+    let Some(resolved) = setup.resolver.resolve(path) else {
+        return FileOutcome::Failed(ExitStatus::ConfigError);
+    };
     // Plain `format` would persist only `run`'s post-edit diagnostics, and
     // a `--validate` check must re-confirm the rewrite parses rather than
     // trust an entry an earlier unvalidated run wrote, so both bypass the
@@ -59,7 +62,7 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
         .cache
         .as_ref()
         .filter(|_| !matches!(pass, Pass::Rewrite | Pass::Diagnose { validate: true }))
-        .map(|c| (c, CacheKey::compute(&bytes, &setup.config_toml)));
+        .map(|c| (c, CacheKey::compute(&bytes, &resolved.config_toml)));
     if let Some(outcome) = keyed
         .as_ref()
         .and_then(|(c, k)| c.lookup(k))
@@ -81,7 +84,7 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
             return FileOutcome::Failed(ExitStatus::ParseError);
         }
     };
-    let outcome = run_pipeline(source, &setup.pipeline, pass);
+    let outcome = run_pipeline(source, &resolved.pipeline, pass);
     if let (
         Some((c, k)),
         FileOutcome::Done {

--- a/src/cli/runner/process.rs
+++ b/src/cli/runner/process.rs
@@ -10,9 +10,9 @@ use rayon::iter::{ParallelBridge, ParallelIterator};
 use ruff_source_file::SourceFileBuilder;
 
 use super::{FileOutcome, Pass, RunSetup, has_format_change};
-use crate::cli::exit_status::ExitStatus;
 use crate::{
     cache::{CacheEntry, CacheKey, Rewrite},
+    cli::exit_status::ExitStatus,
     pipeline::Pipeline,
     source::Source,
     walker,
@@ -39,10 +39,7 @@ pub(super) fn cache_rewrite(needs_rewrite: bool, formatted_text: Option<&str>) -
     if !needs_rewrite {
         return Rewrite::Skipped;
     }
-    match formatted_text {
-        Some(text) => Rewrite::Changed(text.to_owned()),
-        None => Rewrite::Unchanged,
-    }
+    formatted_text.map_or(Rewrite::Unchanged, |text| Rewrite::Changed(text.to_owned()))
 }
 
 pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOutcome {
@@ -73,10 +70,7 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
     }
     let text = match String::from_utf8(bytes) {
         Ok(t) => t,
-        Err(e) => {
-            eprintln!("error: {} is not valid UTF-8: {e}", path.display());
-            return FileOutcome::Failed(ExitStatus::ConfigError);
-        }
+        Err(e) => return config_error(format_args!("{} is not valid UTF-8: {e}", path.display())),
     };
     let source = match Source::build(text, path.display().to_string()) {
         Ok(s) => s,

--- a/src/cli/runner/process.rs
+++ b/src/cli/runner/process.rs
@@ -17,6 +17,7 @@ use crate::{
     source::Source,
     walker,
 };
+
 pub(super) fn apply_rewrite(path: &Path, outcome: FileOutcome) -> FileOutcome {
     let FileOutcome::Done {
         formatted_text: Some(text),
@@ -196,8 +197,7 @@ pub(super) fn run_pipeline(source: Source, pipeline: &Pipeline, pass: Pass) -> F
 }
 
 pub(super) fn walk_error<E: std::fmt::Display>(err: E) -> FileOutcome {
-    eprintln!("error: cannot walk: {err}");
-    FileOutcome::Failed(ExitStatus::ConfigError)
+    config_error(format_args!("cannot walk: {err}"))
 }
 
 fn config_error(e: impl std::fmt::Display) -> FileOutcome {

--- a/src/cli/runner/report.rs
+++ b/src/cli/runner/report.rs
@@ -5,11 +5,15 @@ use std::io::{self, Write};
 
 use anyhow::Context;
 
-use super::{FileOutcome, Mode, RunSetup, has_format_change};
-use crate::cli::args::OutputFormat;
-use crate::cli::exit_status::ExitStatus;
-use crate::cli::output::{self, Presentation, Summary};
-use crate::diagnostics::{Diagnostic, Emitter, EmitterSummary, Github, Json, Run, Sarif, Text};
+use super::{FileOutcome, Mode, has_format_change};
+use crate::{
+    cli::{
+        args::OutputFormat,
+        exit_status::ExitStatus,
+        output::{self, Presentation, Summary},
+    },
+    diagnostics::{Diagnostic, Emitter, EmitterSummary, Github, Json, Run, Sarif, Text},
+};
 
 pub(super) fn emit_outcomes<W: Write>(
     outcomes: &[FileOutcome],
@@ -72,12 +76,12 @@ pub(super) fn file_changed(diagnostics: &[Diagnostic], formatted_text: Option<&s
 
 pub(super) fn finish(
     outcomes: &[FileOutcome],
-    setup: &RunSetup,
+    cache_enabled: bool,
     verbose: bool,
     demote_format_change: bool,
 ) -> ExitStatus {
     if verbose {
-        report_verbose(outcomes, setup.cache.is_some(), &mut io::stderr());
+        report_verbose(outcomes, cache_enabled, &mut io::stderr());
     }
     status_from_outcomes(outcomes, demote_format_change)
 }

--- a/src/cli/runner/resolve.rs
+++ b/src/cli/runner/resolve.rs
@@ -1,0 +1,158 @@
+//! Per-file config resolution: each input draws its config from its
+//! own ancestors, memoized per parent directory.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use crate::{config::Config, pipeline::Pipeline, rule::RuleId};
+
+/// Resolves the config governing each input file by walking the
+/// file's ancestors, memoizing per parent directory so siblings share
+/// one resolution. A directory whose config fails to load reports
+/// once and memoizes the failure.
+pub(super) struct ConfigResolver {
+    by_dir: Mutex<HashMap<PathBuf, Option<Arc<Resolved>>>>,
+    ignore: Vec<RuleId>,
+    select: Vec<RuleId>,
+}
+
+impl ConfigResolver {
+    pub(super) fn new(select: Vec<RuleId>, ignore: Vec<RuleId>) -> Self {
+        Self {
+            by_dir: Mutex::new(HashMap::new()),
+            ignore,
+            select,
+        }
+    }
+
+    fn build(&self, config: &Config) -> Resolved {
+        Resolved {
+            config_toml: toml::to_string(config).unwrap_or_default(),
+            pipeline: Pipeline::with_filters(config, &self.select, &self.ignore),
+        }
+    }
+
+    /// Returns the resolution governing `path`, or `None` when the
+    /// walk from its directory finds a config that fails to load.
+    pub(super) fn resolve(&self, path: &Path) -> Option<Arc<Resolved>> {
+        let file = std::path::absolute(path)
+            .inspect_err(|e| eprintln!("error: cannot resolve `{}`: {e}", path.display()))
+            .ok()?;
+        let dir = file.parent().unwrap_or(&file);
+        self.by_dir
+            .lock()
+            .expect("resolver lock")
+            .entry(dir.to_path_buf())
+            .or_insert_with(|| match Config::load(dir) {
+                Ok(config) => Some(Arc::new(self.build(&config))),
+                Err(e) => {
+                    eprintln!("error: loading config for `{}`: {e}", dir.display());
+                    None
+                }
+            })
+            .clone()
+    }
+
+    /// Pre-resolves `dir` to `config`, so inputs under `dir` reuse it
+    /// without re-reading.
+    pub(super) fn seed(&self, dir: PathBuf, config: &Config) -> Arc<Resolved> {
+        let resolved = Arc::new(self.build(config));
+        self.by_dir
+            .lock()
+            .expect("resolver lock")
+            .insert(dir, Some(Arc::clone(&resolved)));
+        resolved
+    }
+}
+
+/// One directory's resolved configuration: the pipeline its enabled
+/// rules build and the serialized TOML that keys the cache.
+pub(super) struct Resolved {
+    pub(super) config_toml: String,
+    pub(super) pipeline: Pipeline,
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::testing::{assert_send_sync, write_pyproject};
+
+    fn resolver() -> ConfigResolver {
+        ConfigResolver::new(Vec::new(), Vec::new())
+    }
+
+    #[test]
+    fn config_resolver_is_send_and_sync() {
+        assert_send_sync::<ConfigResolver>();
+    }
+
+    #[test]
+    fn resolve_draws_the_files_own_ancestor_config() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 120\n");
+        let file = tmp.path().join("mod.py");
+
+        let resolved = resolver().resolve(&file).expect("resolves");
+
+        assert!(resolved.config_toml.contains("code-line-length = 120"));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_defaults_without_an_ancestor_config() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file = tmp.path().join("mod.py");
+
+        let resolved = resolver().resolve(&file).expect("resolves");
+
+        assert!(resolved.config_toml.contains("code-line-length = 88"));
+    }
+
+    #[test]
+    fn resolve_memoizes_the_failure_of_a_broken_config() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[this is not valid TOML");
+        let resolver = resolver();
+
+        assert!(resolver.resolve(&tmp.path().join("a.py")).is_none());
+        assert!(resolver.resolve(&tmp.path().join("b.py")).is_none());
+    }
+
+    #[test]
+    fn resolve_rejects_an_empty_path() {
+        assert!(resolver().resolve(Path::new("")).is_none());
+    }
+
+    #[test]
+    fn resolve_shares_one_resolution_across_siblings() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 120\n");
+        let resolver = resolver();
+
+        let first = resolver
+            .resolve(&tmp.path().join("a.py"))
+            .expect("resolves");
+        let second = resolver
+            .resolve(&tmp.path().join("b.py"))
+            .expect("resolves");
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn seed_pre_resolves_the_directory() {
+        let tmp = TempDir::new().expect("tempdir");
+        let resolver = resolver();
+
+        let seeded = resolver.seed(tmp.path().to_path_buf(), &Config::default());
+        let hit = resolver
+            .resolve(&tmp.path().join("a.py"))
+            .expect("resolves");
+
+        assert!(Arc::ptr_eq(&seeded, &hit));
+    }
+}

--- a/src/cli/runner/resolve.rs
+++ b/src/cli/runner/resolve.rs
@@ -30,7 +30,7 @@ impl ConfigResolver {
 
     fn build(&self, config: &Config) -> Resolved {
         Resolved {
-            config_toml: toml::to_string(config).unwrap_or_default(),
+            config_toml: toml::to_string(config).expect("Config serializes"),
             pipeline: Pipeline::with_filters(config, &self.select, &self.ignore),
         }
     }
@@ -140,6 +140,20 @@ mod tests {
             .expect("resolves");
 
         assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn resolve_walks_past_the_parent_to_an_ancestor_config() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 120\n");
+        let nested = tmp.path().join("pkg/inner");
+        std::fs::create_dir_all(&nested).expect("nested dirs create");
+
+        let resolved = resolver()
+            .resolve(&nested.join("mod.py"))
+            .expect("resolves");
+
+        assert!(resolved.config_toml.contains("code-line-length = 120"));
     }
 
     #[test]

--- a/src/cli/runner/resolve.rs
+++ b/src/cli/runner/resolve.rs
@@ -41,12 +41,11 @@ impl ConfigResolver {
         let file = std::path::absolute(path)
             .inspect_err(|e| eprintln!("error: cannot resolve `{}`: {e}", path.display()))
             .ok()?;
-        let dir = file.parent().unwrap_or(&file);
         self.by_dir
             .lock()
             .expect("resolver lock")
-            .entry(dir.to_path_buf())
-            .or_insert_with(|| match Config::load(dir) {
+            .entry(file.parent().unwrap_or(&file).to_path_buf())
+            .or_insert_with_key(|dir| match Config::load(dir) {
                 Ok(config) => Some(Arc::new(self.build(&config))),
                 Err(e) => {
                     eprintln!("error: loading config for `{}`: {e}", dir.display());

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -8,6 +8,7 @@ use std::{
 
 use super::de::deserialize_prose;
 use super::{Config, ConfigError, PYPROJECT_TOML};
+
 /// A diagnostic surfaced while resolving configuration.
 pub(super) enum ConfigNotice<'a> {
     /// A `prose.toml` outranked a `[tool.prose]` table in a

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1,7 +1,10 @@
 //! Config-file discovery: the upward walk, TOML reads, and the
 //! precedence / unknown-key notices.
 
-use std::path::{Path, PathBuf};
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 
 use super::de::deserialize_prose;
 use super::{Config, ConfigError, PYPROJECT_TOML};
@@ -55,10 +58,13 @@ pub(super) fn pyproject_declares_prose(dir: &Path) -> bool {
         .is_some_and(|value| prose_table(&value).is_some())
 }
 
+/// Reads a config file that may not exist. `NotADirectory` reads as
+/// absent too, so a walk whose starting path is itself a file skips
+/// the join through that file rather than erroring.
 pub(super) fn read_optional(path: PathBuf) -> Result<Option<String>, ConfigError> {
     match fs_err::read_to_string(path) {
         Ok(contents) => Ok(Some(contents)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) if matches!(e.kind(), ErrorKind::NotADirectory | ErrorKind::NotFound) => Ok(None),
         Err(e) => Err(e.into()),
     }
 }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -6,8 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use super::de::deserialize_prose;
-use super::{Config, ConfigError, PYPROJECT_TOML};
+use super::{Config, ConfigError, PYPROJECT_TOML, de::deserialize_prose};
 
 /// A diagnostic surfaced while resolving configuration.
 pub(super) enum ConfigNotice<'a> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -185,6 +185,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::testing::write_pyproject;
 
     fn assert_toml_error(toml: &str) {
         assert_matches!(Config::from_pyproject_str(toml), Err(ConfigError::Toml(_)));
@@ -192,10 +193,6 @@ mod tests {
 
     fn write_prose_toml(dir: &Path, contents: &str) {
         std::fs::write(dir.join("prose.toml"), contents).expect("prose.toml writes");
-    }
-
-    fn write_pyproject(dir: &Path, contents: &str) {
-        std::fs::write(dir.join("pyproject.toml"), contents).expect("pyproject writes");
     }
 
     #[test]
@@ -361,6 +358,18 @@ mod tests {
 
         assert_eq!(config.code_line_length, NonZeroUsize::new(88));
         assert!(config.rules.align_equals.enabled);
+    }
+
+    #[test]
+    fn load_from_a_file_path_walks_from_its_directory() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_prose_toml(tmp.path(), "code-line-length = 120\n");
+        let file = tmp.path().join("mod.py");
+        std::fs::write(&file, "x = 1\n").expect("writes");
+
+        let config = Config::load(&file).expect("loads");
+
+        assert_eq!(config.code_line_length, NonZeroUsize::new(120));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -185,14 +185,10 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::testing::write_pyproject;
+    use crate::testing::{write_prose_toml, write_pyproject};
 
     fn assert_toml_error(toml: &str) {
         assert_matches!(Config::from_pyproject_str(toml), Err(ConfigError::Toml(_)));
-    }
-
-    fn write_prose_toml(dir: &Path, contents: &str) {
-        std::fs::write(dir.join("prose.toml"), contents).expect("prose.toml writes");
     }
 
     #[test]
@@ -361,6 +357,37 @@ mod tests {
     }
 
     #[test]
+    fn load_emits_precedence_notice_when_both_present() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_prose_toml(tmp.path(), "code-line-length = 120\n");
+        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+
+        let mut precedence_notices = 0;
+        let config = Config::load_with_notices(tmp.path(), |notice| {
+            if matches!(notice, ConfigNotice::ProseTomlPrecedence(_)) {
+                precedence_notices += 1;
+            }
+        })
+        .expect("loads");
+
+        assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+        assert_eq!(precedence_notices, 1);
+    }
+
+    #[test]
+    fn load_empty_prose_toml_returns_defaults_and_stops_walk() {
+        let tmp = TempDir::new().expect("tempdir");
+        let nested = tmp.path().join("child");
+        std::fs::create_dir_all(&nested).expect("nested dirs create");
+        write_prose_toml(&nested, "");
+        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+
+        let config = Config::load(&nested).expect("loads");
+
+        assert_eq!(config.code_line_length, NonZeroUsize::new(88));
+    }
+
+    #[test]
     fn load_from_a_file_path_walks_from_its_directory() {
         let tmp = TempDir::new().expect("tempdir");
         write_prose_toml(tmp.path(), "code-line-length = 120\n");
@@ -438,37 +465,6 @@ mod tests {
     }
 
     #[test]
-    fn load_emits_precedence_notice_when_both_present() {
-        let tmp = TempDir::new().expect("tempdir");
-        write_prose_toml(tmp.path(), "code-line-length = 120\n");
-        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
-
-        let mut precedence_notices = 0;
-        let config = Config::load_with_notices(tmp.path(), |notice| {
-            if matches!(notice, ConfigNotice::ProseTomlPrecedence(_)) {
-                precedence_notices += 1;
-            }
-        })
-        .expect("loads");
-
-        assert_eq!(config.code_line_length, NonZeroUsize::new(120));
-        assert_eq!(precedence_notices, 1);
-    }
-
-    #[test]
-    fn load_empty_prose_toml_returns_defaults_and_stops_walk() {
-        let tmp = TempDir::new().expect("tempdir");
-        let nested = tmp.path().join("child");
-        std::fs::create_dir_all(&nested).expect("nested dirs create");
-        write_prose_toml(&nested, "");
-        write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
-
-        let config = Config::load(&nested).expect("loads");
-
-        assert_eq!(config.code_line_length, NonZeroUsize::new(88));
-    }
-
-    #[test]
     fn load_picks_nearest_prose_toml_over_ancestor_pyproject() {
         let tmp = TempDir::new().expect("tempdir");
         let nested = tmp.path().join("child");
@@ -498,19 +494,6 @@ mod tests {
         write_prose_toml(tmp.path(), "code-line-length = 120\n");
 
         let config = Config::load(tmp.path()).expect("loads");
-
-        assert_eq!(config.code_line_length, NonZeroUsize::new(120));
-    }
-
-    #[test]
-    fn load_walks_past_sectionless_pyproject_to_ancestor_prose_toml() {
-        let tmp = TempDir::new().expect("tempdir");
-        let nested = tmp.path().join("child");
-        std::fs::create_dir_all(&nested).expect("nested dirs create");
-        write_pyproject(&nested, "[project]\nname = \"x\"\n");
-        write_prose_toml(tmp.path(), "code-line-length = 120\n");
-
-        let config = Config::load(&nested).expect("loads");
 
         assert_eq!(config.code_line_length, NonZeroUsize::new(120));
     }
@@ -551,6 +534,19 @@ mod tests {
         std::fs::create_dir(tmp.path().join("prose.toml")).expect("dir at config path");
 
         assert_matches!(Config::load(tmp.path()), Err(ConfigError::Io(_)));
+    }
+
+    #[test]
+    fn load_walks_past_sectionless_pyproject_to_ancestor_prose_toml() {
+        let tmp = TempDir::new().expect("tempdir");
+        let nested = tmp.path().join("child");
+        std::fs::create_dir_all(&nested).expect("nested dirs create");
+        write_pyproject(&nested, "[project]\nname = \"x\"\n");
+        write_prose_toml(tmp.path(), "code-line-length = 120\n");
+
+        let config = Config::load(&nested).expect("loads");
+
+        assert_eq!(config.code_line_length, NonZeroUsize::new(120));
     }
 
     #[test]
@@ -676,6 +672,15 @@ mod tests {
         assert_toml_error("[tool.prose.rules.signature-layout]\nmax-inline-params = 0\n");
     }
 
+    #[test]
+    fn rules_bare_bool_false_leaves_other_knobs_default() {
+        let config = Config::from_pyproject_str("[tool.prose.rules]\nalphabetize = false\n")
+            .expect("parses");
+
+        assert!(!config.rules.alphabetize.enabled);
+        assert!(config.rules.alphabetize.docstring_entries);
+    }
+
     #[rstest]
     #[case("false", false)]
     #[case("true", true)]
@@ -686,15 +691,6 @@ mod tests {
 
         assert_eq!(config.rules.alphabetize.enabled, expected);
         assert!(config.rules.align_equals.enabled);
-    }
-
-    #[test]
-    fn rules_bare_bool_false_leaves_other_knobs_default() {
-        let config = Config::from_pyproject_str("[tool.prose.rules]\nalphabetize = false\n")
-            .expect("parses");
-
-        assert!(!config.rules.alphabetize.enabled);
-        assert!(config.rules.alphabetize.docstring_entries);
     }
 
     #[test]

--- a/src/server/config_cache.rs
+++ b/src/server/config_cache.rs
@@ -38,8 +38,9 @@ impl ConfigCache {
     }
 
     /// Returns the configuration governing `uri`. A watched session
-    /// memoizes by path; an unwatched one re-reads each call. An unsaved
-    /// buffer whose URI names no file falls back to the defaults.
+    /// memoizes by path, whereas an unwatched one re-reads each call.
+    /// An unsaved buffer whose URI names no file falls back to the
+    /// defaults.
     pub(super) fn resolve(&mut self, uri: &Uri) -> &Config {
         let Some(path) = file_path(uri) else {
             return &self.default;
@@ -93,20 +94,20 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-
-    fn uri(s: &str) -> Uri {
-        Uri::from_str(s).expect("valid uri")
-    }
+    use crate::testing::write_prose_toml;
 
     fn line_length(config: &Config) -> Option<usize> {
         config.code_line_length.map(std::num::NonZeroUsize::get)
     }
 
+    fn uri(s: &str) -> Uri {
+        Uri::from_str(s).expect("valid uri")
+    }
+
     #[test]
     fn broken_config_logs_and_falls_back_to_defaults() {
         let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("prose.toml"), "code-line-length = = oops\n")
-            .expect("writes");
+        write_prose_toml(dir.path(), "code-line-length = = oops\n");
         let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
 
         let mut cache = ConfigCache::new(true);
@@ -120,14 +121,13 @@ mod tests {
     #[test]
     fn disabled_cache_re_reads_on_each_resolve() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let toml = dir.path().join("prose.toml");
-        std::fs::write(&toml, "code-line-length = 100\n").expect("writes");
+        write_prose_toml(dir.path(), "code-line-length = 100\n");
         let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
 
         let mut cache = ConfigCache::new(false);
         assert_eq!(line_length(cache.resolve(&file)), Some(100));
 
-        std::fs::write(&toml, "code-line-length = 80\n").expect("rewrites");
+        write_prose_toml(dir.path(), "code-line-length = 80\n");
         assert_eq!(
             line_length(cache.resolve(&file)),
             Some(80),
@@ -138,14 +138,13 @@ mod tests {
     #[test]
     fn enabled_cache_is_stale_until_cleared() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let toml = dir.path().join("prose.toml");
-        std::fs::write(&toml, "code-line-length = 100\n").expect("writes");
+        write_prose_toml(dir.path(), "code-line-length = 100\n");
         let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
 
         let mut cache = ConfigCache::new(true);
         assert_eq!(line_length(cache.resolve(&file)), Some(100));
 
-        std::fs::write(&toml, "code-line-length = 80\n").expect("rewrites");
+        write_prose_toml(dir.path(), "code-line-length = 80\n");
         assert_eq!(
             line_length(cache.resolve(&file)),
             Some(100),
@@ -187,9 +186,22 @@ mod tests {
     }
 
     #[test]
+    fn resolve_reads_config_for_an_on_disk_document() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_prose_toml(dir.path(), "code-line-length = 100\n");
+        let doc = dir.path().join("mod.py");
+        std::fs::write(&doc, "x = 1\n").expect("writes");
+        let file = uri(&format!("file://{}", doc.display()));
+
+        let mut cache = ConfigCache::new(true);
+
+        assert_eq!(line_length(cache.resolve(&file)), Some(100));
+    }
+
+    #[test]
     fn resolve_reads_prose_toml_beside_the_document() {
         let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("prose.toml"), "code-line-length = 100\n").expect("writes");
+        write_prose_toml(dir.path(), "code-line-length = 100\n");
         let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
 
         let mut cache = ConfigCache::new(true);

--- a/src/server/config_cache.rs
+++ b/src/server/config_cache.rs
@@ -1,6 +1,6 @@
 //! Per-document `[tool.prose]` resolution. With a `didChangeWatchedFiles`
-//! watcher registered, each path's config is memoized and cleared on a
-//! watched change. Without one, resolution re-reads on every call.
+//! watcher registered, each directory's config is memoized and cleared on
+//! a watched change. Without one, resolution re-reads on every call.
 
 use std::{
     collections::HashMap,
@@ -11,11 +11,12 @@ use lsp_types::Uri;
 
 use crate::config::Config;
 
-/// Resolves the configuration governing each document, memoizing by path
-/// only when a watcher can invalidate the cache on a config change.
+/// Resolves the configuration governing each document, memoizing per
+/// parent directory only when a watcher can invalidate the cache on a
+/// config change.
 #[derive(Default)]
 pub(super) struct ConfigCache {
-    by_path: HashMap<PathBuf, Config>,
+    by_dir: HashMap<PathBuf, Config>,
     default: Config,
     enabled: bool,
     fresh: Config,
@@ -34,23 +35,23 @@ impl ConfigCache {
     /// Drops every cached config, forcing the next resolve to re-read from
     /// disk.
     pub(super) fn clear(&mut self) {
-        self.by_path.clear();
+        self.by_dir.clear();
     }
 
     /// Returns the configuration governing `uri`. A watched session
-    /// memoizes by path, whereas an unwatched one re-reads each call.
-    /// An unsaved buffer whose URI names no file falls back to the
+    /// memoizes per parent directory so sibling documents share one
+    /// resolution, whereas an unwatched one re-reads each call. An
+    /// unsaved buffer whose URI names no file falls back to the
     /// defaults.
     pub(super) fn resolve(&mut self, uri: &Uri) -> &Config {
         let Some(path) = file_path(uri) else {
             return &self.default;
         };
+        let dir = path.parent().unwrap_or(&path).to_path_buf();
         if self.enabled {
-            self.by_path
-                .entry(path)
-                .or_insert_with_key(|path| load(path))
+            self.by_dir.entry(dir).or_insert_with_key(|dir| load(dir))
         } else {
-            self.fresh = load(&path);
+            self.fresh = load(&dir);
             &self.fresh
         }
     }
@@ -207,5 +208,23 @@ mod tests {
         let mut cache = ConfigCache::new(true);
 
         assert_eq!(line_length(cache.resolve(&file)), Some(100));
+    }
+
+    #[test]
+    fn sibling_documents_share_one_resolution() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_prose_toml(dir.path(), "code-line-length = 100\n");
+        let first = uri(&format!("file://{}", dir.path().join("a.py").display()));
+        let second = uri(&format!("file://{}", dir.path().join("b.py").display()));
+
+        let mut cache = ConfigCache::new(true);
+        assert_eq!(line_length(cache.resolve(&first)), Some(100));
+
+        write_prose_toml(dir.path(), "code-line-length = 80\n");
+        assert_eq!(
+            line_length(cache.resolve(&second)),
+            Some(100),
+            "sibling serves the memoized entry",
+        );
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -16,6 +16,10 @@ pub(crate) fn range(start: u32, end: u32) -> TextRange {
     TextRange::new(start.into(), end.into())
 }
 
+pub(crate) fn write_prose_toml(dir: &Path, contents: &str) {
+    std::fs::write(dir.join("prose.toml"), contents).expect("prose.toml writes");
+}
+
 pub(crate) fn write_pyproject(dir: &Path, contents: &str) {
     std::fs::write(dir.join("pyproject.toml"), contents).expect("pyproject writes");
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,5 +1,7 @@
 //! Helpers shared across `#[cfg(test)] mod tests` blocks.
 
+use std::path::Path;
+
 use ruff_text_size::TextRange;
 
 use crate::source::Source;
@@ -12,4 +14,8 @@ pub(crate) fn parse(src: &str) -> Source {
 
 pub(crate) fn range(start: u32, end: u32) -> TextRange {
     TextRange::new(start.into(), end.into())
+}
+
+pub(crate) fn write_pyproject(dir: &Path, contents: &str) {
+    std::fs::write(dir.join("pyproject.toml"), contents).expect("pyproject writes");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,9 +1,12 @@
 //! End-to-end tests against the `prose` binary, exercising
 //! `cli::run` and the exit-code matrix.
 
-use std::{fs::write, path::PathBuf};
+use std::{
+    fs::write,
+    path::{Path, PathBuf},
+};
 
-use assert_cmd::Command;
+use assert_cmd::{Command, assert::Assert};
 use rstest::rstest;
 use tempfile::{TempDir, tempdir};
 
@@ -18,7 +21,7 @@ fn assert_cache_hit_matches_miss(name: &str, source: &str) {
 
 /// Runs `check` twice against one isolated cache, asserts the warm
 /// run reproduces the cold stdout byte for byte, and returns it.
-fn assert_warm_run_matches_cold(paths: &[&PathBuf]) -> String {
+fn assert_warm_run_matches_cold(paths: &[&Path]) -> String {
     let (mut cold_cmd, cache_dir) = prose_isolated();
     let cold = cold_cmd
         .args(["check", "--output-format", "json"])
@@ -33,7 +36,7 @@ fn assert_warm_run_matches_cold(paths: &[&PathBuf]) -> String {
         .code(1);
 
     assert_eq!(cold.get_output().stdout, warm.get_output().stdout);
-    String::from_utf8(warm.get_output().stdout.clone()).expect("utf-8")
+    stdout_utf8(&warm)
 }
 
 fn fixture(name: &str, source: &str) -> (TempDir, PathBuf) {
@@ -78,11 +81,23 @@ fn sibling_projects(parent: &TempDir, source: &str) -> (PathBuf, PathBuf) {
     (x, y)
 }
 
+fn stderr_utf8(assert: &Assert) -> String {
+    String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8")
+}
+
+fn stdout_utf8(assert: &Assert) -> String {
+    String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8")
+}
+
+fn summary_line(out: &str) -> serde_json::Value {
+    serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses")
+}
+
 #[test]
 fn cache_clean_subcommand_exits_zero_and_reports_count() {
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.args(["cache", "clean"]).assert().success();
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let out = stdout_utf8(&assert);
     assert!(out.starts_with("removed "), "stdout was {out:?}");
     assert!(out.contains("entries"));
     assert!(out.contains("bytes"));
@@ -92,7 +107,7 @@ fn cache_clean_subcommand_exits_zero_and_reports_count() {
 fn cache_compact_subcommand_exits_zero_and_reports_count() {
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.args(["cache", "compact"]).assert().success();
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let out = stdout_utf8(&assert);
     assert!(out.starts_with("removed "), "stdout was {out:?}");
 }
 
@@ -104,6 +119,16 @@ fn cache_hit_produces_identical_diagnostics_to_miss() {
 #[test]
 fn cache_hit_renders_collapsing_literal_like_a_cold_run() {
     assert_cache_hit_matches_miss("collapse.py", "d = {\n    \"a\": 1,\n    \"b\": 2,\n}\n");
+}
+
+#[test]
+fn cache_info_subcommand_prints_path_and_counts() {
+    let (mut cmd, _cache_dir) = prose_isolated();
+    let assert = cmd.args(["cache", "info"]).assert().success();
+    let out = stdout_utf8(&assert);
+    assert!(out.contains("path:"), "stdout was {out:?}");
+    assert!(out.contains("entries: 0"));
+    assert!(out.contains("bytes: 0"));
 }
 
 #[test]
@@ -131,7 +156,7 @@ fn cache_invalidates_on_config_change() {
         .env("PROSE_CACHE_DIR", cache_dir.path())
         .assert()
         .success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(err.contains("0 hits, 1 misses"), "stderr was {err:?}");
 }
 
@@ -142,20 +167,9 @@ fn cache_keys_each_file_against_its_governing_config() {
 
     let out = assert_warm_run_matches_cold(&[&suppressed, &flagged]);
 
-    let summary: serde_json::Value =
-        serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses");
+    let summary = summary_line(&out);
     assert_eq!(summary["files_visited"], 2);
     assert_eq!(summary["files_changed"], 1);
-}
-
-#[test]
-fn cache_info_subcommand_prints_path_and_counts() {
-    let (mut cmd, _cache_dir) = prose_isolated();
-    let assert = cmd.args(["cache", "info"]).assert().success();
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
-    assert!(out.contains("path:"), "stdout was {out:?}");
-    assert!(out.contains("entries: 0"));
-    assert!(out.contains("bytes: 0"));
 }
 
 #[test]
@@ -170,8 +184,44 @@ fn check_clean_summary_anchors_with_hyacinth() {
     let (_dir, path) = fixture("clean.py", "x = 1\n");
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.arg("check").arg(&path).assert().success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert_eq!(err.trim(), "🪻 All clean.");
+}
+
+#[test]
+fn check_dash_clean_exits_zero() {
+    prose()
+        .args(["check", "-"])
+        .write_stdin("x = 1\n")
+        .assert()
+        .success();
+}
+
+#[test]
+fn check_dash_unaligned_exits_format_change() {
+    prose()
+        .args(["check", "-"])
+        .write_stdin("ab = 1\nx = 2\n")
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn check_file_in_another_project_draws_its_own_config() {
+    let cwd_project = tempdir().expect("tempdir");
+    write(
+        cwd_project.path().join("pyproject.toml"),
+        SUPPRESSING_PYPROJECT,
+    )
+    .expect("writes pyproject");
+    let (_dir, path) = fixture("unaligned.py", "alpha = 1\nb = 22\n");
+
+    prose()
+        .args(["check", "--no-cache"])
+        .arg(&path)
+        .current_dir(cwd_project.path())
+        .assert()
+        .code(1);
 }
 
 #[test]
@@ -183,9 +233,8 @@ fn check_json_closes_clean_run_with_summary_envelope() {
         .arg(&path)
         .assert()
         .success();
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
-    let summary: serde_json::Value =
-        serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses");
+    let out = stdout_utf8(&assert);
+    let summary = summary_line(&out);
     assert_eq!(summary["kind"], "summary");
     assert_eq!(summary["diagnostics_total"], 0);
     assert_eq!(summary["files_visited"], 1);
@@ -201,9 +250,8 @@ fn check_json_counts_a_collapsing_literal_as_changed() {
         .arg(&path)
         .assert()
         .code(1);
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
-    let summary: serde_json::Value =
-        serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses");
+    let out = stdout_utf8(&assert);
+    let summary = summary_line(&out);
     assert_eq!(summary["files_changed"], 1);
 }
 
@@ -216,9 +264,8 @@ fn check_json_summary_counts_a_changed_file() {
         .arg(&path)
         .assert()
         .code(1);
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
-    let summary: serde_json::Value =
-        serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses");
+    let out = stdout_utf8(&assert);
+    let summary = summary_line(&out);
     assert_eq!(summary["kind"], "summary");
     assert_eq!(summary["files_visited"], 1);
     assert_eq!(summary["files_changed"], 1);
@@ -238,18 +285,6 @@ fn check_json_summary_counts_a_changed_file() {
 }
 
 #[test]
-fn check_violation_summary_anchors_with_bookmark() {
-    let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
-    let (mut cmd, _cache_dir) = prose_isolated();
-    let assert = cmd.arg("check").arg(&path).assert().code(1);
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
-    assert!(
-        err.contains("🔖 1 diagnostic in 1 file."),
-        "stderr was {err:?}"
-    );
-}
-
-#[test]
 fn check_no_cache_flag_runs_clean() {
     let (_dir, path) = fixture("clean.py", "x = 1\n");
     prose()
@@ -257,45 +292,6 @@ fn check_no_cache_flag_runs_clean() {
         .arg(&path)
         .assert()
         .success();
-}
-
-#[test]
-fn check_respects_cache_disabled_in_pyproject() {
-    let project = tempdir().expect("tempdir");
-    std::fs::write(
-        project.path().join("pyproject.toml"),
-        "[tool.prose.cache]\nenabled = false\n",
-    )
-    .expect("writes pyproject");
-    let py = project.path().join("clean.py");
-    std::fs::write(&py, "x = 1\n").expect("writes");
-    let (mut cmd, _cache_dir) = prose_isolated();
-    let assert = cmd
-        .args(["--verbose", "check"])
-        .arg(&py)
-        .current_dir(project.path())
-        .assert()
-        .success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
-    assert!(err.contains("cache: bypassed"), "stderr was {err:?}");
-}
-
-#[test]
-fn check_file_in_another_project_draws_its_own_config() {
-    let cwd_project = tempdir().expect("tempdir");
-    write(
-        cwd_project.path().join("pyproject.toml"),
-        SUPPRESSING_PYPROJECT,
-    )
-    .expect("writes pyproject");
-    let (_dir, path) = fixture("unaligned.py", "alpha = 1\nb = 22\n");
-
-    prose()
-        .args(["check", "--no-cache"])
-        .arg(&path)
-        .current_dir(cwd_project.path())
-        .assert()
-        .code(1);
 }
 
 #[test]
@@ -322,7 +318,7 @@ fn check_resolves_each_files_config_from_its_own_project() {
         .assert()
         .code(1);
 
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let out = stdout_utf8(&assert);
     let diagnostics: Vec<serde_json::Value> = out
         .lines()
         .map(|line| serde_json::from_str(line).expect("parses"))
@@ -336,6 +332,36 @@ fn check_resolves_each_files_config_from_its_own_project() {
 }
 
 #[test]
+fn check_respects_cache_disabled_in_pyproject() {
+    let project = tempdir().expect("tempdir");
+    std::fs::write(
+        project.path().join("pyproject.toml"),
+        "[tool.prose.cache]\nenabled = false\n",
+    )
+    .expect("writes pyproject");
+    let py = project.path().join("clean.py");
+    std::fs::write(&py, "x = 1\n").expect("writes");
+    let (mut cmd, _cache_dir) = prose_isolated();
+    let assert = cmd
+        .args(["--verbose", "check"])
+        .arg(&py)
+        .current_dir(project.path())
+        .assert()
+        .success();
+    let err = stderr_utf8(&assert);
+    assert!(err.contains("cache: bypassed"), "stderr was {err:?}");
+}
+
+#[test]
+fn check_stdin_clean_exits_zero() {
+    prose()
+        .args(["check", "--stdin"])
+        .write_stdin("x = 1\n")
+        .assert()
+        .success();
+}
+
+#[test]
 fn check_stdin_resolves_config_from_the_cwd() {
     let project = tempdir().expect("tempdir");
     write(project.path().join("pyproject.toml"), SUPPRESSING_PYPROJECT).expect("writes pyproject");
@@ -344,33 +370,6 @@ fn check_stdin_resolves_config_from_the_cwd() {
         .args(["check", "--stdin"])
         .write_stdin("alpha = 1\nb = 22\n")
         .current_dir(project.path())
-        .assert()
-        .success();
-}
-
-#[test]
-fn check_dash_clean_exits_zero() {
-    prose()
-        .args(["check", "-"])
-        .write_stdin("x = 1\n")
-        .assert()
-        .success();
-}
-
-#[test]
-fn check_dash_unaligned_exits_format_change() {
-    prose()
-        .args(["check", "-"])
-        .write_stdin("ab = 1\nx = 2\n")
-        .assert()
-        .code(1);
-}
-
-#[test]
-fn check_stdin_clean_exits_zero() {
-    prose()
-        .args(["check", "--stdin"])
-        .write_stdin("x = 1\n")
         .assert()
         .success();
 }
@@ -408,7 +407,7 @@ fn check_validate_bypasses_a_check_populated_cache_entry() {
         .env("PROSE_CACHE_DIR", cache_dir.path())
         .assert()
         .code(1);
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(
         err.contains("0 hits, 1 misses"),
         "validate must bypass the cache, stderr was {err:?}"
@@ -425,14 +424,16 @@ fn check_validate_flag_accepts_a_valid_rewrite() {
         .code(1);
 }
 
-#[rstest]
-fn color_arms_exit_zero(#[values("always", "never")] arm: &str) {
-    let (_dir, path) = fixture("clean.py", "x = 1\n");
+#[test]
+fn check_violation_summary_anchors_with_bookmark() {
+    let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
     let (mut cmd, _cache_dir) = prose_isolated();
-    cmd.args(["--color", arm, "check"])
-        .arg(&path)
-        .assert()
-        .success();
+    let assert = cmd.arg("check").arg(&path).assert().code(1);
+    let err = stderr_utf8(&assert);
+    assert!(
+        err.contains("🔖 1 diagnostic in 1 file."),
+        "stderr was {err:?}"
+    );
 }
 
 #[test]
@@ -445,7 +446,7 @@ fn color_always_summary_emits_truecolor_when_colorterm_set() {
         .arg(&path)
         .assert()
         .success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(
         err.contains("\u{1b}[38;2;138;128;203m"),
         "stderr was {err:?}"
@@ -462,9 +463,19 @@ fn color_always_summary_falls_back_to_ansi_without_colorterm() {
         .arg(&path)
         .assert()
         .success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(err.contains("\u{1b}[35m"), "stderr was {err:?}");
     assert!(!err.contains("38;2;"), "stderr was {err:?}");
+}
+
+#[rstest]
+fn color_arms_exit_zero(#[values("always", "never")] arm: &str) {
+    let (_dir, path) = fixture("clean.py", "x = 1\n");
+    let (mut cmd, _cache_dir) = prose_isolated();
+    cmd.args(["--color", arm, "check"])
+        .arg(&path)
+        .assert()
+        .success();
 }
 
 #[test]
@@ -476,7 +487,7 @@ fn color_never_summary_stays_plain() {
         .arg(&path)
         .assert()
         .success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(!err.contains('\u{1b}'), "stderr was {err:?}");
 }
 
@@ -529,11 +540,24 @@ fn format_dash_writes_rewrite_to_stdout() {
 }
 
 #[test]
+fn format_diff_off_tty_leaves_a_plain_patch() {
+    let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
+    let (mut cmd, _cache_dir) = prose_isolated();
+    let assert = cmd.args(["format", "--diff"]).arg(&path).assert().code(1);
+    let stdout = stdout_utf8(&assert);
+    assert!(stdout.contains("--- "), "patch header missing: {stdout:?}");
+    assert!(
+        !stdout.contains('🧵'),
+        "decoration leaked off a TTY: {stdout:?}"
+    );
+}
+
+#[test]
 fn format_diff_renders_diff_and_leaves_file_unchanged() {
     let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.args(["format", "--diff"]).arg(&path).assert().code(1);
-    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let stdout = stdout_utf8(&assert);
     assert!(stdout.contains("@@"), "diff missing hunks: {stdout:?}");
     assert!(
         stdout.contains("-x = 2"),
@@ -548,24 +572,11 @@ fn format_diff_renders_diff_and_leaves_file_unchanged() {
 }
 
 #[test]
-fn format_diff_off_tty_leaves_a_plain_patch() {
-    let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
-    let (mut cmd, _cache_dir) = prose_isolated();
-    let assert = cmd.args(["format", "--diff"]).arg(&path).assert().code(1);
-    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
-    assert!(stdout.contains("--- "), "patch header missing: {stdout:?}");
-    assert!(
-        !stdout.contains('🧵'),
-        "decoration leaked off a TTY: {stdout:?}"
-    );
-}
-
-#[test]
 fn format_diff_summary_reports_would_reformat() {
     let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.args(["format", "--diff"]).arg(&path).assert().code(1);
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(
         err.contains("🗞️ 1 file would be reformatted."),
         "stderr was {err:?}"
@@ -581,7 +592,7 @@ fn format_json_renders_collapsing_literal_without_aborting() {
         .arg(&path)
         .assert()
         .success();
-    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let stdout = stdout_utf8(&assert);
     assert!(
         stdout.contains("collection-layout"),
         "json missing the format diagnostic: {stdout:?}"
@@ -601,7 +612,7 @@ fn format_json_rewrites_over_a_check_cache_entry() {
         .success();
     let after = std::fs::read_to_string(&path).expect("reads");
     assert_ne!(after, "ab = 1\nx = 2\n");
-    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let stdout = stdout_utf8(&assert);
     assert!(
         stdout.contains("align-equals"),
         "json missing the diagnostic: {stdout}"
@@ -625,7 +636,7 @@ fn format_rewrite_summary_reports_reformatted() {
     let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.arg("format").arg(&path).assert().success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(err.contains("🗞️ Reformatted 1 file."), "stderr was {err:?}");
 }
 
@@ -668,6 +679,22 @@ fn no_args_prints_help_and_exits_clean() {
 }
 
 #[test]
+fn quiet_check_reduces_summary_to_a_bare_count() {
+    let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
+    let (mut cmd, _cache_dir) = prose_isolated();
+    let assert = cmd
+        .env("COLORTERM", "truecolor")
+        .args(["--color", "always", "check", "--quiet"])
+        .arg(&path)
+        .assert()
+        .code(1);
+    let err = stderr_utf8(&assert);
+    assert_eq!(err.trim(), "1 diagnostic in 1 file.");
+    assert!(!err.contains('🔖'), "quiet kept the anchor: {err:?}");
+    assert!(!err.contains('\u{1b}'), "quiet kept color: {err:?}");
+}
+
+#[test]
 fn server_completes_a_stdio_session_over_the_real_binary() {
     let session = lsp_session(&[
         r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#,
@@ -682,7 +709,7 @@ fn server_completes_a_stdio_session_over_the_real_binary() {
         .write_stdin(session)
         .assert()
         .success();
-    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let out = stdout_utf8(&assert);
     assert!(
         out.contains("documentFormattingProvider"),
         "initialize result missing capabilities: {out:?}",
@@ -694,22 +721,6 @@ fn server_completes_a_stdio_session_over_the_real_binary() {
 }
 
 #[test]
-fn quiet_check_reduces_summary_to_a_bare_count() {
-    let (_dir, path) = fixture("unaligned.py", "ab = 1\nx = 2\n");
-    let (mut cmd, _cache_dir) = prose_isolated();
-    let assert = cmd
-        .env("COLORTERM", "truecolor")
-        .args(["--color", "always", "check", "--quiet"])
-        .arg(&path)
-        .assert()
-        .code(1);
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
-    assert_eq!(err.trim(), "1 diagnostic in 1 file.");
-    assert!(!err.contains('🔖'), "quiet kept the anchor: {err:?}");
-    assert!(!err.contains('\u{1b}'), "quiet kept color: {err:?}");
-}
-
-#[test]
 fn verbose_flag_prints_cache_telemetry_to_stderr() {
     let (_dir, path) = fixture("clean.py", "x = 1\n");
     let (mut cmd, _cache_dir) = prose_isolated();
@@ -718,7 +729,7 @@ fn verbose_flag_prints_cache_telemetry_to_stderr() {
         .arg(&path)
         .assert()
         .success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(err.contains("cache:"), "stderr was {err:?}");
     assert!(err.contains("files"));
 }
@@ -731,7 +742,7 @@ fn verbose_flag_with_no_cache_reports_bypassed() {
         .arg(&path)
         .assert()
         .success();
-    let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
+    let err = stderr_utf8(&assert);
     assert!(err.contains("cache: bypassed"), "stderr was {err:?}");
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -7,22 +7,33 @@ use assert_cmd::Command;
 use rstest::rstest;
 use tempfile::{TempDir, tempdir};
 
+/// A `[tool.prose]` table disabling the rule the shared fixture
+/// content fires, so a file governed by it checks clean.
+const SUPPRESSING_PYPROJECT: &str = "[tool.prose.rules]\nalign-equals = false\n";
+
 fn assert_cache_hit_matches_miss(name: &str, source: &str) {
     let (_dir, path) = fixture(name, source);
-    let (mut miss_cmd, cache_dir) = prose_isolated();
-    let miss = miss_cmd
+    assert_warm_run_matches_cold(&[&path]);
+}
+
+/// Runs `check` twice against one isolated cache, asserts the warm
+/// run reproduces the cold stdout byte for byte, and returns it.
+fn assert_warm_run_matches_cold(paths: &[&PathBuf]) -> String {
+    let (mut cold_cmd, cache_dir) = prose_isolated();
+    let cold = cold_cmd
         .args(["check", "--output-format", "json"])
-        .arg(&path)
+        .args(paths)
         .assert()
         .code(1);
-    let hit = prose()
+    let warm = prose()
         .args(["check", "--output-format", "json"])
-        .arg(&path)
+        .args(paths)
         .env("PROSE_CACHE_DIR", cache_dir.path())
         .assert()
         .code(1);
 
-    assert_eq!(miss.get_output().stdout, hit.get_output().stdout);
+    assert_eq!(cold.get_output().stdout, warm.get_output().stdout);
+    String::from_utf8(warm.get_output().stdout.clone()).expect("utf-8")
 }
 
 fn fixture(name: &str, source: &str) -> (TempDir, PathBuf) {
@@ -50,6 +61,21 @@ fn prose_isolated() -> (Command, TempDir) {
     let mut cmd = prose();
     cmd.env("PROSE_CACHE_DIR", dir.path());
     (cmd, dir)
+}
+
+/// Two sibling projects holding identical `source`: `suppressed/x.py`
+/// under a config disabling `align-equals`, `flagged/y.py` under none.
+fn sibling_projects(parent: &TempDir, source: &str) -> (PathBuf, PathBuf) {
+    let suppressed = parent.path().join("suppressed");
+    let flagged = parent.path().join("flagged");
+    std::fs::create_dir_all(&suppressed).expect("dirs create");
+    std::fs::create_dir_all(&flagged).expect("dirs create");
+    write(suppressed.join("pyproject.toml"), SUPPRESSING_PYPROJECT).expect("writes pyproject");
+    let x = suppressed.join("x.py");
+    let y = flagged.join("y.py");
+    write(&x, source).expect("writes");
+    write(&y, source).expect("writes");
+    (x, y)
 }
 
 #[test]
@@ -107,6 +133,19 @@ fn cache_invalidates_on_config_change() {
         .success();
     let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
     assert!(err.contains("0 hits, 1 misses"), "stderr was {err:?}");
+}
+
+#[test]
+fn cache_keys_each_file_against_its_governing_config() {
+    let parent = tempdir().expect("tempdir");
+    let (suppressed, flagged) = sibling_projects(&parent, "alpha = 1\nb = 22\n");
+
+    let out = assert_warm_run_matches_cold(&[&suppressed, &flagged]);
+
+    let summary: serde_json::Value =
+        serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses");
+    assert_eq!(summary["files_visited"], 2);
+    assert_eq!(summary["files_changed"], 1);
 }
 
 #[test]
@@ -239,6 +278,74 @@ fn check_respects_cache_disabled_in_pyproject() {
         .success();
     let err = String::from_utf8(assert.get_output().stderr.clone()).expect("utf-8");
     assert!(err.contains("cache: bypassed"), "stderr was {err:?}");
+}
+
+#[test]
+fn check_file_in_another_project_draws_its_own_config() {
+    let cwd_project = tempdir().expect("tempdir");
+    write(
+        cwd_project.path().join("pyproject.toml"),
+        SUPPRESSING_PYPROJECT,
+    )
+    .expect("writes pyproject");
+    let (_dir, path) = fixture("unaligned.py", "alpha = 1\nb = 22\n");
+
+    prose()
+        .args(["check", "--no-cache"])
+        .arg(&path)
+        .current_dir(cwd_project.path())
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn check_relative_path_resolves_its_ancestor_config() {
+    let project = tempdir().expect("tempdir");
+    write(project.path().join("pyproject.toml"), SUPPRESSING_PYPROJECT).expect("writes pyproject");
+    write(project.path().join("unaligned.py"), "alpha = 1\nb = 22\n").expect("writes");
+
+    prose()
+        .args(["check", "--no-cache", "unaligned.py"])
+        .current_dir(project.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn check_resolves_each_files_config_from_its_own_project() {
+    let parent = tempdir().expect("tempdir");
+    let (suppressed, flagged) = sibling_projects(&parent, "alpha = 1\nb = 22\n");
+
+    let assert = prose()
+        .args(["check", "--no-cache", "--output-format", "json"])
+        .args([&suppressed, &flagged])
+        .assert()
+        .code(1);
+
+    let out = String::from_utf8(assert.get_output().stdout.clone()).expect("utf-8");
+    let diagnostics: Vec<serde_json::Value> = out
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("parses"))
+        .filter(|record: &serde_json::Value| record["kind"] != "summary")
+        .collect();
+    assert!(!diagnostics.is_empty(), "stdout was {out:?}");
+    for diagnostic in &diagnostics {
+        let filename = diagnostic["filename"].as_str().expect("a filename");
+        assert!(filename.ends_with("y.py"), "flagged {filename:?}");
+    }
+}
+
+#[test]
+fn check_stdin_resolves_config_from_the_cwd() {
+    let project = tempdir().expect("tempdir");
+    write(project.path().join("pyproject.toml"), SUPPRESSING_PYPROJECT).expect("writes pyproject");
+
+    prose()
+        .args(["check", "--stdin"])
+        .write_stdin("alpha = 1\nb = 22\n")
+        .current_dir(project.path())
+        .assert()
+        .success();
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -93,6 +93,14 @@ fn summary_line(out: &str) -> serde_json::Value {
     serde_json::from_str(out.lines().last().expect("a summary line")).expect("parses")
 }
 
+/// A project directory whose config disables the rule the shared
+/// fixture content fires.
+fn suppressed_project() -> TempDir {
+    let dir = tempdir().expect("tempdir");
+    write(dir.path().join("pyproject.toml"), SUPPRESSING_PYPROJECT).expect("writes pyproject");
+    dir
+}
+
 #[test]
 fn cache_clean_subcommand_exits_zero_and_reports_count() {
     let (mut cmd, _cache_dir) = prose_isolated();
@@ -208,12 +216,7 @@ fn check_dash_unaligned_exits_format_change() {
 
 #[test]
 fn check_file_in_another_project_draws_its_own_config() {
-    let cwd_project = tempdir().expect("tempdir");
-    write(
-        cwd_project.path().join("pyproject.toml"),
-        SUPPRESSING_PYPROJECT,
-    )
-    .expect("writes pyproject");
+    let cwd_project = suppressed_project();
     let (_dir, path) = fixture("unaligned.py", "alpha = 1\nb = 22\n");
 
     prose()
@@ -296,8 +299,7 @@ fn check_no_cache_flag_runs_clean() {
 
 #[test]
 fn check_relative_path_resolves_its_ancestor_config() {
-    let project = tempdir().expect("tempdir");
-    write(project.path().join("pyproject.toml"), SUPPRESSING_PYPROJECT).expect("writes pyproject");
+    let project = suppressed_project();
     write(project.path().join("unaligned.py"), "alpha = 1\nb = 22\n").expect("writes");
 
     prose()
@@ -363,8 +365,7 @@ fn check_stdin_clean_exits_zero() {
 
 #[test]
 fn check_stdin_resolves_config_from_the_cwd() {
-    let project = tempdir().expect("tempdir");
-    write(project.path().join("pyproject.toml"), SUPPRESSING_PYPROJECT).expect("writes pyproject");
+    let project = suppressed_project();
 
     prose()
         .args(["check", "--stdin"])
@@ -653,6 +654,19 @@ fn format_rewrites_after_check_populated_the_cache() {
         .success();
     let after = std::fs::read_to_string(&path).expect("reads");
     assert_ne!(after, "ab = 1\nx = 2\n");
+}
+
+#[test]
+fn format_stdin_resolves_config_from_the_cwd() {
+    let project = suppressed_project();
+
+    prose()
+        .args(["format", "--stdin"])
+        .write_stdin("alpha = 1\nb = 22\n")
+        .current_dir(project.path())
+        .assert()
+        .success()
+        .stdout("alpha = 1\nb = 22\n");
 }
 
 #[test]


### PR DESCRIPTION
### 🪻 Quick Summary

Resolves each input file's configuration from that file's own ancestors, replacing the single cwd-rooted load that previously governed every input. `check` and `format` now walk upward from each file's directory to the nearest `prose.toml` or `[tool.prose]` table, memoizing per parent directory so sibling inputs share one resolution, whereas stdin keeps the working directory's config as the one input with no path of its own. The cache keys each file against the config that actually governed it, a broken ancestor config fails only the files it governs while the rest of the run completes, and the server's per-document cache adopts the same per-directory keying. A polish pass is folded in, consolidating test scaffolding behind shared helpers and tightening the runner's plumbing.

---

### 🗞️ Key Changes

- Adds `ConfigResolver`, walking each input's ancestors through `Config::load` and memoizing per parent directory behind a `Mutex`, so a tree of inputs under one project loads its config once rather than once per file.

- Keys each file's cache entry against the serialized config that actually governed it, so two files resolving different configs in one invocation cache independently and a hit replays the right diagnostics.

- Fails a file whose ancestor config breaks with a config error while the rest of the run proceeds, reporting the broken directory once and memoizing the failure so siblings skip the re-read.

- Keeps stdin input and the cache settings on the cwd's own config, seeded into the resolver so path inputs under the cwd reuse the already-loaded resolution.

- Re-keys the server's `ConfigCache` per parent directory, so sibling documents in an editor session share one resolution the way CLI siblings now do.

- Treats `NotADirectory` like `NotFound` in the config walk's `read_optional`, so a walk whose starting path is itself a file skips the join through that file rather than erroring.

- Pins cross-project resolution, relative paths, stdin cwd behavior on both subcommands, per-config cache keys, sibling sharing, and the nested-subdirectory walk across unit and CLI tests.

- Consolidates runner and CLI test boilerplate behind shared helpers and narrows runner plumbing, with `finish` taking a `cache_enabled` bool and `build_run` taking `RuleFilter` by value.

- Aligns the configuration, cache, exit-code, GitHub Actions, and pipeline docs pages with the per-file resolution model.

---

### 🧵 Related Issues

- Closes #243
