### PR TITLE
[245] Partition over-cap alignment runs from the widest member down

### DIFF
--- a/site/.vitepress/data/fixtures.data.ts
+++ b/site/.vitepress/data/fixtures.data.ts
@@ -38,7 +38,7 @@ function descriptionHtml(
   // already use on this surface.
   return md.render(text).replace(
     /<InlineRuleLink slug="([^"]+)" \/>/g,
-    (_, slug) => `<a class="body-link" href="${ruleHrefs.get(slug)}"><code>${slug}</code></a>`
+    (_, slug) => `<a class="body-link" href="${ruleHrefs.get(slug)!}"><code>${slug}</code></a>`
   )
 }
 

--- a/site/.vitepress/data/fixtures.data.ts
+++ b/site/.vitepress/data/fixtures.data.ts
@@ -6,9 +6,11 @@ import { lintDecorations }               from '../lib/fixtures/lint-findings'
 import { readFixtureToggle }             from '../lib/fixtures/toggle'
 import { fixtureWatchGlobs, readFixtureDocs, walkFixtures } from '../lib/fixtures/walker'
 import { getRenderer, renderFencedHtml } from '../lib/markdown/renderer'
-import { repoRoot }                      from '../lib/shared/paths'
+import { discoverRuleSlugs }             from '../lib/rules/discovery'
+import { repoRoot, rulesDir }            from '../lib/shared/paths'
 
-const root = repoRoot(import.meta.url)
+const root      = repoRoot(import.meta.url)
+const ruleHrefs = new Map(discoverRuleSlugs(rulesDir(import.meta.url)).map(r => [r.slug, r.href]))
 
 interface FixtureEntry {
   changesSource    : boolean
@@ -36,7 +38,7 @@ function descriptionHtml(
   // already use on this surface.
   return md.render(text).replace(
     /<InlineRuleLink slug="([^"]+)" \/>/g,
-    (_, slug) => `<a class="body-link" href="/rules/${slug}"><code>${slug}</code></a>`
+    (_, slug) => `<a class="body-link" href="${ruleHrefs.get(slug)}"><code>${slug}</code></a>`
   )
 }
 

--- a/site/.vitepress/data/glossary.data.ts
+++ b/site/.vitepress/data/glossary.data.ts
@@ -1,8 +1,12 @@
 import { defineLoader } from 'vitepress'
 
-import { glossary }            from '../lib/glossary/entries'
-import { getRenderer }         from '../lib/markdown/renderer'
-import type { GlossaryFamily } from '../lib/shared/registries'
+import { glossary, type GlossaryEntry } from '../lib/glossary/entries'
+import { getRenderer }                  from '../lib/markdown/renderer'
+import { discoverRuleSlugs }            from '../lib/rules/discovery'
+import { rulesDir }                     from '../lib/shared/paths'
+import type { GlossaryFamily }          from '../lib/shared/registries'
+
+const ruleHrefs = new Map(discoverRuleSlugs(rulesDir(import.meta.url)).map(r => [r.slug, r.href]))
 
 export interface RenderedGlossaryEntry {
   aliases        : readonly string[]
@@ -32,7 +36,7 @@ export default defineLoader({
         aliases        : entry.aliases ?? [],
         definitionHtml : md.renderInline(entry.definition),
         families       : entry.families,
-        href           : entry.href,
+        href           : entryHref(slug, entry),
         initial        : firstLetter(slug),
         primaryFamily  : entry.families[0],
         slug
@@ -42,6 +46,18 @@ export default defineLoader({
     return { entries }
   }
 })
+
+function entryHref(slug: string, entry: GlossaryEntry): string | undefined {
+  if (entry.rule !== undefined) {
+    const href = ruleHrefs.get(entry.rule)
+    if (!href) throw new Error(`Glossary "${slug}" names unknown rule "${entry.rule}"`)
+    return href
+  }
+  if (entry.href?.startsWith('/rules/')) {
+    throw new Error(`Glossary "${slug}" hand-writes a rule URL, use the rule field instead`)
+  }
+  return entry.href
+}
 
 function firstLetter(slug: string): string {
   return slug.match(/[a-z]/i)?.[0].toUpperCase() ?? '#'

--- a/site/.vitepress/data/landing.data.ts
+++ b/site/.vitepress/data/landing.data.ts
@@ -14,7 +14,6 @@ export interface Step {
 export interface Surface {
   bodyHtml : string
   family   : RuleFamily
-  icon     : string
   number   : string
 }
 
@@ -33,7 +32,6 @@ const SURFACE_SOURCES: readonly SurfaceSource[] = [
     body   : 'Equals signs, colons, the `import` keyword, and match arrows line up across '
            + 'consecutive lines. The eye drops down the column.',
     family : 'alignment',
-    icon   : '🪜',
     number : '01'
   },
   {
@@ -41,7 +39,6 @@ const SURFACE_SOURCES: readonly SurfaceSource[] = [
            + 'set members read top-to-bottom by name, so a reader looking for an entry '
            + 'already knows where it sits.',
     family : 'ordering',
-    icon   : '🪉',
     number : '02'
   },
   {
@@ -49,7 +46,6 @@ const SURFACE_SOURCES: readonly SurfaceSource[] = [
            + 'collections drop their trailing comma, blank lines snap to canonical counts, '
            + 'and singletons collapse to their natural form.',
     family : 'formatting',
-    icon   : '🪶',
     number : '03'
   },
   {
@@ -57,7 +53,6 @@ const SURFACE_SOURCES: readonly SurfaceSource[] = [
            + 'line length, keep single-line shapes single-line, multi-line shapes '
            + 'multi-line, and quote style consistent throughout.',
     family : 'docs',
-    icon   : '📰',
     number : '04'
   },
   {
@@ -65,7 +60,6 @@ const SURFACE_SOURCES: readonly SurfaceSource[] = [
            + 'patterns, and single-use bindings surface as diagnostics. The formatter never '
            + 'rewrites these, because the fix belongs to the reader.',
     family : 'lint',
-    icon   : '🧶',
     number : '05'
   }
 ]

--- a/site/.vitepress/data/rules.data.ts
+++ b/site/.vitepress/data/rules.data.ts
@@ -44,7 +44,7 @@ declare const data: RulesData
 export { data }
 
 export default defineLoader({
-  watch: [`${rulesDirectory}/*.md`],
+  watch: [`${rulesDirectory}/*/*.md`],
   async load(): Promise<RulesData> {
     const md         = await getRenderer()
     const list       = discoverRuleSlugs(rulesDirectory).map(r => ({

--- a/site/.vitepress/lib/composables/route.ts
+++ b/site/.vitepress/lib/composables/route.ts
@@ -6,17 +6,16 @@ import { FAMILY_META, type RuleFamily }     from '../shared/registries'
 
 const CURRENT_RULE_KEY: InjectionKey<ComputedRef<RenderedRule | null>> = Symbol('currentRule')
 
-function ruleSlug(rel: string): string | null {
-  if (!rel.startsWith('rules/')) return null
-  const slug = rel.slice('rules/'.length).replace(/\.md$/, '')
-  return slug && slug !== 'index' ? slug : null
+function routeSegments(rel: string): readonly string[] {
+  if (!rel.startsWith('rules/')) return []
+  return rel.slice('rules/'.length).replace(/\.md$/, '').split('/')
 }
 
 function buildCurrentRule(): ComputedRef<RenderedRule | null> {
   const { page } = useData()
   return computed(() => {
-    const slug = ruleSlug(page.value.relativePath)
-    return slug ? rules.bySlug[slug] ?? null : null
+    const slug = routeSegments(page.value.relativePath).at(-1)
+    return slug && slug !== 'index' ? rules.bySlug[slug] ?? null : null
   })
 }
 
@@ -33,11 +32,7 @@ export function useCurrentRule(): ComputedRef<RenderedRule | null> {
 export function useCurrentFamily(): ComputedRef<RuleFamily | null> {
   const { page } = useData()
   return computed(() => {
-    const slug = ruleSlug(page.value.relativePath)
-    if (slug === null) return null
-    const ruleHit = rules.bySlug[slug]
-    if (ruleHit) return ruleHit.family
-    const family = slug.split('/')[0]
-    return family in FAMILY_META ? family as RuleFamily : null
+    const family = routeSegments(page.value.relativePath)[0]
+    return family && family in FAMILY_META ? family as RuleFamily : null
   })
 }

--- a/site/.vitepress/lib/config/sidebar.ts
+++ b/site/.vitepress/lib/config/sidebar.ts
@@ -1,8 +1,8 @@
 import type { DefaultTheme } from 'vitepress'
 
-import { type DiscoveredPrimitive }                   from '../primitives/discovery'
-import { type DiscoveredRule }                        from '../rules/discovery'
-import { FAMILY_META, FAMILY_ORDER, type RuleFamily } from '../shared/registries'
+import { type DiscoveredPrimitive }  from '../primitives/discovery'
+import { type DiscoveredRule }       from '../rules/discovery'
+import { FAMILY_META, FAMILY_ORDER } from '../shared/registries'
 
 const primLink = (slug: string, text: string): DefaultTheme.SidebarItem =>
   ({ link: `/primitives/${slug}`, text })

--- a/site/.vitepress/lib/config/sidebar.ts
+++ b/site/.vitepress/lib/config/sidebar.ts
@@ -7,8 +7,8 @@ import { FAMILY_META, FAMILY_ORDER, type RuleFamily } from '../shared/registries
 const primLink = (slug: string, text: string): DefaultTheme.SidebarItem =>
   ({ link: `/primitives/${slug}`, text })
 
-const ruleLink = (slug: string): DefaultTheme.SidebarItem =>
-  ({ link: `/rules/${slug}`, text: slug })
+const ruleLink = (rule: DiscoveredRule): DefaultTheme.SidebarItem =>
+  ({ link: rule.href, text: rule.slug })
 
 const USAGE_SIDEBAR: DefaultTheme.SidebarItem[] = [
   {
@@ -60,7 +60,7 @@ export function buildSidebar(
   const familySections: DefaultTheme.SidebarItem[] = FAMILY_ORDER.map(family => ({
     items : rules
       .filter(r => r.family === family)
-      .map(r => ruleLink(r.slug)),
+      .map(ruleLink),
     link  : `/rules/${family}/`,
     text  : FAMILY_META[family].label
   }))

--- a/site/.vitepress/lib/glossary/entries.ts
+++ b/site/.vitepress/lib/glossary/entries.ts
@@ -5,6 +5,7 @@ export interface GlossaryEntry {
   definition : string
   families   : readonly [GlossaryFamily, ...GlossaryFamily[]]
   href      ?: string
+  rule      ?: string
 }
 
 export const glossary: Record<string, GlossaryEntry> = {
@@ -178,7 +179,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'single name) that `collection-layout` can safely keep on one line without '
               + 'readability loss.',
     families  : ['formatting'],
-    href      : '/rules/formatting/collection-layout'
+    rule      : 'collection-layout'
   },
 
   'auto-fix': {
@@ -196,7 +197,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'comment blocks tight against the following statement while leaving '
               + 'banner-shaped blocks separated by 1 blank line below.',
     families  : ['formatting'],
-    href      : '/rules/formatting/blank-lines'
+    rule      : 'blank-lines'
   },
 
   'cache': {
@@ -237,7 +238,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`max-inline-dict-entries`, and `false` disables either. It replaces the magic '
               + 'trailing comma that Black and Ruff read with an explicit, configurable count.',
     families  : ['formatting'],
-    href      : '/rules/formatting/collection-layout'
+    rule      : 'collection-layout'
   },
 
   'dataclass': {
@@ -323,7 +324,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'at evaluation time so the reorder cannot lift a definition above a name it '
               + 'depends on.',
     families  : ['lint', 'ordering'],
-    href      : '/rules/formatting/unused-future-annotations'
+    rule      : 'unused-future-annotations'
   },
 
   'gitignore': {
@@ -374,7 +375,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'comment either way. The orderer primitive\'s `block_range` carries the '
               + 'block with its item when reordering siblings.',
     families  : ['formatting', 'ordering'],
-    href      : '/rules/formatting/blank-lines'
+    rule      : 'blank-lines'
   },
 
   'lexical scope': {
@@ -402,7 +403,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'shares a column for the post-pattern `:` separator across consecutive '
               + 'single-expression arms.',
     families  : ['alignment'],
-    href      : '/rules/alignment/align-match-case'
+    rule      : 'align-match-case'
   },
 
   'max-shift': {
@@ -456,7 +457,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`legacy-union-syntax` surfaces the legacy `typing` forms on projects whose '
               + '`target-version` allows the pipe form.',
     families  : ['lint'],
-    href      : '/rules/lint/legacy-union-syntax'
+    rule      : 'legacy-union-syntax'
   },
 
   'PEP 749': {
@@ -466,7 +467,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`from __future__ import annotations` becomes redundant and '
               + '`unused-future-annotations` removes it on 3.14+.',
     families  : ['lint'],
-    href      : '/rules/formatting/unused-future-annotations'
+    rule      : 'unused-future-annotations'
   },
 
   'Pydantic': {
@@ -527,7 +528,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'column to align to, either a single-member group or a multi-member group '
               + 'whose colons all share one source line, so a one-key dict reads as plain code.',
     families  : ['alignment'],
-    href      : '/rules/formatting/strip-align-padding'
+    rule      : 'strip-align-padding'
   },
 
   'structured section': {
@@ -539,7 +540,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`docstring-wrap` budgets these against `code-line-length` by default, so '
               + 'argument lines align with surrounding code.',
     families  : ['docs', 'alignment'],
-    href      : '/rules/docs/docstring-wrap'
+    rule      : 'docstring-wrap'
   },
 
   'target-version': {

--- a/site/.vitepress/lib/glossary/entries.ts
+++ b/site/.vitepress/lib/glossary/entries.ts
@@ -178,7 +178,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'single name) that `collection-layout` can safely keep on one line without '
               + 'readability loss.',
     families  : ['formatting'],
-    href      : '/rules/collection-layout'
+    href      : '/rules/formatting/collection-layout'
   },
 
   'auto-fix': {
@@ -196,7 +196,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'comment blocks tight against the following statement while leaving '
               + 'banner-shaped blocks separated by 1 blank line below.',
     families  : ['formatting'],
-    href      : '/rules/blank-lines'
+    href      : '/rules/formatting/blank-lines'
   },
 
   'cache': {
@@ -237,7 +237,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`max-inline-dict-entries`, and `false` disables either. It replaces the magic '
               + 'trailing comma that Black and Ruff read with an explicit, configurable count.',
     families  : ['formatting'],
-    href      : '/rules/collection-layout'
+    href      : '/rules/formatting/collection-layout'
   },
 
   'dataclass': {
@@ -323,7 +323,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'at evaluation time so the reorder cannot lift a definition above a name it '
               + 'depends on.',
     families  : ['lint', 'ordering'],
-    href      : '/rules/unused-future-annotations'
+    href      : '/rules/formatting/unused-future-annotations'
   },
 
   'gitignore': {
@@ -374,7 +374,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'comment either way. The orderer primitive\'s `block_range` carries the '
               + 'block with its item when reordering siblings.',
     families  : ['formatting', 'ordering'],
-    href      : '/rules/blank-lines'
+    href      : '/rules/formatting/blank-lines'
   },
 
   'lexical scope': {
@@ -402,7 +402,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'shares a column for the post-pattern `:` separator across consecutive '
               + 'single-expression arms.',
     families  : ['alignment'],
-    href      : '/rules/align-match-case'
+    href      : '/rules/alignment/align-match-case'
   },
 
   'max-shift': {
@@ -456,7 +456,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`legacy-union-syntax` surfaces the legacy `typing` forms on projects whose '
               + '`target-version` allows the pipe form.',
     families  : ['lint'],
-    href      : '/rules/legacy-union-syntax'
+    href      : '/rules/lint/legacy-union-syntax'
   },
 
   'PEP 749': {
@@ -466,7 +466,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`from __future__ import annotations` becomes redundant and '
               + '`unused-future-annotations` removes it on 3.14+.',
     families  : ['lint'],
-    href      : '/rules/unused-future-annotations'
+    href      : '/rules/formatting/unused-future-annotations'
   },
 
   'Pydantic': {
@@ -527,7 +527,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + 'column to align to, either a single-member group or a multi-member group '
               + 'whose colons all share one source line, so a one-key dict reads as plain code.',
     families  : ['alignment'],
-    href      : '/rules/strip-align-padding'
+    href      : '/rules/formatting/strip-align-padding'
   },
 
   'structured section': {
@@ -539,7 +539,7 @@ export const glossary: Record<string, GlossaryEntry> = {
               + '`docstring-wrap` budgets these against `code-line-length` by default, so '
               + 'argument lines align with surrounding code.',
     families  : ['docs', 'alignment'],
-    href      : '/rules/docstring-wrap'
+    href      : '/rules/docs/docstring-wrap'
   },
 
   'target-version': {

--- a/site/.vitepress/lib/rules/discovery.ts
+++ b/site/.vitepress/lib/rules/discovery.ts
@@ -3,12 +3,13 @@ import path from 'node:path'
 
 import matter from 'gray-matter'
 
-import { FAMILY_META, type RuleCategory, type RuleFamily } from '../shared/registries'
+import { FAMILY_ORDER, type RuleCategory, type RuleFamily } from '../shared/registries'
 
 export interface DiscoveredRule {
   caption  : string
   category : RuleCategory
   family   : RuleFamily
+  href     : string
   related  : readonly string[]
   slug     : string
 }
@@ -19,35 +20,39 @@ export function discoverRuleSlugs(rulesDirectory: string): DiscoveredRule[] {
   const cached = cache.get(rulesDirectory)
   if (cached !== undefined) return cached
 
+  const stray = fs.readdirSync(rulesDirectory).filter(f => f.endsWith('.md') && f !== 'index.md')
+  if (stray.length > 0) {
+    throw new Error(`Rule pages must live in a family directory, found stray: ${stray.join(', ')}`)
+  }
+
   const out    : DiscoveredRule[] = []
   const related: Array<{ refs: readonly string[]; slug: string }> = []
-  for (const file of fs.readdirSync(rulesDirectory).sort()) {
-    if (!file.endsWith('.md') || file === 'index.md') continue
-    const slug     = file.slice(0, -'.md'.length)
-    const body     = fs.readFileSync(path.join(rulesDirectory, file), 'utf8')
-    const fm       = matter(body).data
-    const category = fm.category
-    if (category !== 'auto-fix' && category !== 'lint') {
-      throw new Error(`Rule "${slug}" has invalid or missing category: ${JSON.stringify(category)}`)
+  for (const family of FAMILY_ORDER) {
+    const familyDirectory = path.join(rulesDirectory, family)
+    if (!fs.existsSync(familyDirectory)) continue
+    for (const file of fs.readdirSync(familyDirectory).sort()) {
+      if (!file.endsWith('.md') || file === 'index.md') continue
+      const slug    = file.slice(0, -'.md'.length)
+      const body    = fs.readFileSync(path.join(familyDirectory, file), 'utf8')
+      const fm      = matter(body).data
+      const caption = fm.caption
+      if (typeof caption !== 'string' || caption.trim() === '') {
+        throw new Error(`Rule "${slug}" has invalid or missing caption: ${JSON.stringify(caption)}`)
+      }
+      const relatedSlugs = Array.isArray(fm.related) ? fm.related as string[] : []
+      out.push({
+        caption,
+        category : family === 'lint' ? 'lint' : 'auto-fix',
+        family,
+        href     : `/rules/${family}/${slug}`,
+        related  : relatedSlugs,
+        slug
+      })
+      if (relatedSlugs.length > 0) related.push({ refs: relatedSlugs, slug })
     }
-    const family = fm.family
-    if (typeof family !== 'string' || !(family in FAMILY_META)) {
-      throw new Error(`Rule "${slug}" has invalid or missing family: ${JSON.stringify(family)}`)
-    }
-    if ((category === 'lint') !== (family === 'lint')) {
-      throw new Error(
-        `Rule "${slug}" mismatched category/family (${category}/${family}), `
-        + 'because the lint family pairs exclusively with the lint category'
-      )
-    }
-    const caption = fm.caption
-    if (typeof caption !== 'string' || caption.trim() === '') {
-      throw new Error(`Rule "${slug}" has invalid or missing caption: ${JSON.stringify(caption)}`)
-    }
-    const relatedSlugs = Array.isArray(fm.related) ? fm.related as string[] : []
-    out.push({ caption, category, family: family as RuleFamily, related: relatedSlugs, slug })
-    if (relatedSlugs.length > 0) related.push({ refs: relatedSlugs, slug })
   }
+
+  out.sort((a, b) => a.slug.localeCompare(b.slug))
 
   const known = new Set(out.map(r => r.slug))
   for (const { refs, slug } of related) {

--- a/site/.vitepress/lib/rules/discovery.ts
+++ b/site/.vitepress/lib/rules/discovery.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import matter from 'gray-matter'
 
-import { FAMILY_ORDER, type RuleCategory, type RuleFamily } from '../shared/registries'
+import { categoryOf, FAMILY_ORDER, type RuleCategory, type RuleFamily } from '../shared/registries'
 
 export interface DiscoveredRule {
   caption  : string
@@ -20,20 +20,24 @@ export function discoverRuleSlugs(rulesDirectory: string): DiscoveredRule[] {
   const cached = cache.get(rulesDirectory)
   if (cached !== undefined) return cached
 
-  const stray = fs.readdirSync(rulesDirectory).filter(f => f.endsWith('.md') && f !== 'index.md')
-  if (stray.length > 0) {
-    throw new Error(`Rule pages must live in a family directory, found stray: ${stray.join(', ')}`)
-  }
-
-  const out    : DiscoveredRule[] = []
-  const related: Array<{ refs: readonly string[]; slug: string }> = []
-  for (const family of FAMILY_ORDER) {
-    const familyDirectory = path.join(rulesDirectory, family)
-    if (!fs.existsSync(familyDirectory)) continue
-    for (const file of fs.readdirSync(familyDirectory).sort()) {
-      if (!file.endsWith('.md') || file === 'index.md') continue
+  const families = new Set<string>(FAMILY_ORDER)
+  const out      : DiscoveredRule[] = []
+  const stray    : string[] = []
+  for (const entry of fs.readdirSync(rulesDirectory, { withFileTypes: true })) {
+    if (entry.isFile()) {
+      if (entry.name.endsWith('.md') && entry.name !== 'index.md') stray.push(entry.name)
+      continue
+    }
+    const directory = path.join(rulesDirectory, entry.name)
+    const pages     = fs.readdirSync(directory).filter(f => f.endsWith('.md') && f !== 'index.md')
+    if (!families.has(entry.name)) {
+      stray.push(...pages.map(f => `${entry.name}/${f}`))
+      continue
+    }
+    const family = entry.name as RuleFamily
+    for (const file of pages) {
       const slug    = file.slice(0, -'.md'.length)
-      const body    = fs.readFileSync(path.join(familyDirectory, file), 'utf8')
+      const body    = fs.readFileSync(path.join(directory, file), 'utf8')
       const fm      = matter(body).data
       const caption = fm.caption
       if (typeof caption !== 'string' || caption.trim() === '') {
@@ -42,21 +46,29 @@ export function discoverRuleSlugs(rulesDirectory: string): DiscoveredRule[] {
       const relatedSlugs = Array.isArray(fm.related) ? fm.related as string[] : []
       out.push({
         caption,
-        category : family === 'lint' ? 'lint' : 'auto-fix',
+        category : categoryOf(family),
         family,
         href     : `/rules/${family}/${slug}`,
         related  : relatedSlugs,
         slug
       })
-      if (relatedSlugs.length > 0) related.push({ refs: relatedSlugs, slug })
     }
+  }
+  if (stray.length > 0) {
+    throw new Error(`Rule pages must live in a family directory, found stray: ${stray.join(', ')}`)
   }
 
   out.sort((a, b) => a.slug.localeCompare(b.slug))
 
-  const known = new Set(out.map(r => r.slug))
-  for (const { refs, slug } of related) {
-    for (const ref of refs) {
+  const known = new Set<string>()
+  for (const { slug } of out) {
+    if (known.has(slug)) {
+      throw new Error(`Rule "${slug}" has pages in more than one family directory`)
+    }
+    known.add(slug)
+  }
+  for (const { related, slug } of out) {
+    for (const ref of related) {
       if (!known.has(ref)) throw new Error(`Rule "${slug}" lists invalid related slug "${ref}"`)
     }
   }

--- a/site/.vitepress/lib/shared/registries.ts
+++ b/site/.vitepress/lib/shared/registries.ts
@@ -37,6 +37,10 @@ export const FAMILY_ORDER: readonly RuleFamily[] = [
   'alignment', 'ordering', 'formatting', 'docs', 'lint'
 ]
 
+export function categoryOf(family: RuleFamily): RuleCategory {
+  return family === 'lint' ? 'lint' : 'auto-fix'
+}
+
 export type PrimitiveSlug =
   | 'aligner' | 'binding-analysis' | 'cache' | 'colon-targets' | 'docstring' | 'edit'
   | 'orderer' | 'pipeline' | 'rule-id' | 'source' | 'suppression-map' | 'walker'

--- a/site/.vitepress/theme/components/landing/surfaces/SurfaceCardBase.vue
+++ b/site/.vitepress/theme/components/landing/surfaces/SurfaceCardBase.vue
@@ -65,7 +65,7 @@ const activeRule = computed(() => props.rules[activeIdx.value])
             :key="rule.slug"
             class="tab"
             :class="{ active: idx === activeIdx }"
-            :href="`/rules/${rule.slug}`"
+            :href="rule.href"
             :aria-label="rule.slug"
             @mouseenter="hoveredIdx = idx"
             @focus="hoveredIdx = idx"
@@ -78,7 +78,7 @@ const activeRule = computed(() => props.rules[activeIdx.value])
             <a
               :key="activeIdx"
               class="tab-label-link"
-              :href="`/rules/${activeRule?.slug}`"
+              :href="activeRule?.href"
               :aria-label="activeRule?.slug"
             >{{ activeRule?.slug }}</a>
           </Transition>

--- a/site/.vitepress/theme/components/landing/surfaces/SurfaceCardBase.vue
+++ b/site/.vitepress/theme/components/landing/surfaces/SurfaceCardBase.vue
@@ -4,18 +4,17 @@ import { computed, ref, useTemplateRef }                      from 'vue'
 
 import type { RenderedRule }            from '../../../../data/rules.data'
 import { formatFolio }                  from '../../../../lib/shared/numerals'
-import { FAMILY_META, type RuleFamily } from '../../../../lib/shared/registries'
+import { categoryOf, FAMILY_META, type RuleFamily } from '../../../../lib/shared/registries'
 
 const props = defineProps<{
   bodyHtml : string
   family   : RuleFamily
-  icon     : string
   number   : string
   rules    : readonly RenderedRule[]
 }>()
 
 const meta     = computed(() => FAMILY_META[props.family])
-const category = computed(() => props.family === 'lint' ? 'lint' : 'auto-fix')
+const category = computed(() => categoryOf(props.family))
 const href     = computed(() => `/rules/${props.family}/`)
 
 const rootRef = useTemplateRef<HTMLElement>('root')
@@ -54,7 +53,7 @@ const activeRule = computed(() => props.rules[activeIdx.value])
       :aria-label="`See all ${meta.label.toLowerCase()} rules`"
     />
     <span class="surface-card-number">— {{ number }}</span>
-    <span class="surface-card-icon" aria-hidden="true">{{ icon }}</span>
+    <span class="surface-card-icon" aria-hidden="true">{{ meta.badge }}</span>
     <h3 class="surface-card-label">{{ meta.label }}</h3>
     <p class="surface-card-blurb" v-html="bodyHtml" />
     <div class="surface-card-chips">

--- a/site/.vitepress/theme/components/landing/surfaces/Surfaces.vue
+++ b/site/.vitepress/theme/components/landing/surfaces/Surfaces.vue
@@ -83,7 +83,6 @@ const trackStyle = computed(() => ({
             :key="`${copy}-${card.family}`"
             :body-html="card.bodyHtml"
             :family="card.family"
-            :icon="card.icon"
             :number="card.number"
             :rules="card.rules"
             :aria-hidden="copy === 2 ? 'true' : undefined"

--- a/site/.vitepress/theme/components/primitives/PrimitivesCompositionDetail.vue
+++ b/site/.vitepress/theme/components/primitives/PrimitivesCompositionDetail.vue
@@ -84,7 +84,7 @@ watch(focusedEntry, scheduleUpdate, { immediate: true })
                 <span class="primitives-composition-card-mention-text">{{ dep }}</span>
               </a>
               <RuleTooltipPopper v-else-if="ruleOf(dep)" :rule="ruleOf(dep)!">
-                <a class="rule-chip" :href="`/rules/${dep}`" :data-family="ruleOf(dep)!.family">
+                <a class="rule-chip" :href="ruleOf(dep)!.href" :data-family="ruleOf(dep)!.family">
                   <span class="rule-chip-badge" aria-hidden="true">{{ ruleOf(dep)!.familyBadge }}</span>
                   <span class="rule-chip-slug">{{ dep }}</span>
                 </a>

--- a/site/.vitepress/theme/components/rules/CompositionCards.vue
+++ b/site/.vitepress/theme/components/rules/CompositionCards.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import FixtureNoChange from '../fixtures/FixtureNoChange.vue'
 import FixturePairDoc  from '../fixtures/FixturePairDoc.vue'
 import FixtureToggle   from '../fixtures/FixtureToggle.vue'
+import RuleSegmentChip from './RuleSegmentChip.vue'
 
 import { data as composition }  from '../../../data/composition.data'
 import { data as fixturesData } from '../../../data/fixtures.data'
@@ -104,16 +105,7 @@ function toggle(row: CardRow): void {
               class="composition-cards-tick-item"
               @click.stop
             >
-              <a
-                :href="seg.rule?.href"
-                class="composition-cards-chip"
-                :data-family="seg.family"
-                :title="seg.rule ? undefined : `${seg.slug} (${seg.family ?? 'undocumented'})`"
-              >
-                <span class="composition-cards-chip-label">
-                  <span class="composition-cards-chip-slug">{{ seg.slug }}</span>
-                </span>
-              </a>
+              <RuleSegmentChip :segment="seg" :with-tooltip="false" />
             </li>
           </ol>
           <div v-show="activeCase === row.case" class="composition-cards-toggle-slot" @click.stop>
@@ -153,18 +145,7 @@ function toggle(row: CardRow): void {
                 class="composition-cards-bar-cell"
                 @click.stop
               >
-                <RuleTooltipPopper :rule="seg.rule">
-                  <a
-                    :href="seg.rule?.href"
-                    class="composition-cards-chip"
-                    :data-family="seg.family"
-                    :title="seg.rule ? undefined : `${seg.slug} (${seg.family ?? 'undocumented'})`"
-                  >
-                    <span class="composition-cards-chip-label">
-                      <span class="composition-cards-chip-slug">{{ seg.slug }}</span>
-                    </span>
-                  </a>
-                </RuleTooltipPopper>
+                <RuleSegmentChip :segment="seg" :with-tooltip="true" />
               </li>
             </ol>
           </div>

--- a/site/.vitepress/theme/components/rules/CompositionCards.vue
+++ b/site/.vitepress/theme/components/rules/CompositionCards.vue
@@ -105,7 +105,7 @@ function toggle(row: CardRow): void {
               @click.stop
             >
               <a
-                :href="`/rules/${seg.slug}`"
+                :href="seg.rule?.href"
                 class="composition-cards-chip"
                 :data-family="seg.family"
                 :title="seg.rule ? undefined : `${seg.slug} (${seg.family ?? 'undocumented'})`"
@@ -155,7 +155,7 @@ function toggle(row: CardRow): void {
               >
                 <RuleTooltipPopper :rule="seg.rule">
                   <a
-                    :href="`/rules/${seg.slug}`"
+                    :href="seg.rule?.href"
                     class="composition-cards-chip"
                     :data-family="seg.family"
                     :title="seg.rule ? undefined : `${seg.slug} (${seg.family ?? 'undocumented'})`"

--- a/site/.vitepress/theme/components/rules/InlineRuleLink.vue
+++ b/site/.vitepress/theme/components/rules/InlineRuleLink.vue
@@ -9,6 +9,6 @@ const rule = lookup(rules.bySlug, props.slug, 'Inline rule link')
 
 <template>
   <RuleTooltipPopper :rule="rule">
-    <a class="rule-link" :data-family="rule.family" :href="`/rules/${slug}`">{{ slug }}</a>
+    <a class="rule-link" :data-family="rule.family" :href="rule.href">{{ slug }}</a>
   </RuleTooltipPopper>
 </template>

--- a/site/.vitepress/theme/components/rules/PipelineOrder.vue
+++ b/site/.vitepress/theme/components/rules/PipelineOrder.vue
@@ -23,7 +23,7 @@ import MiddleEllipsis from '../base/MiddleEllipsis.vue'
         <RuleTooltipPopper :rule="rule.documented ? rules.bySlug[rule.slug] : null">
           <a
             class="pipeline-order-link"
-            :href="rule.documented ? `/rules/${rule.slug}` : undefined"
+            :href="rule.documented ? rules.bySlug[rule.slug].href : undefined"
             :title="`${rule.slug}${rule.family ? ` (${rule.family})` : ''}`"
           >
             <span class="folio">№ {{ formatFolio(rule.position) }}</span>

--- a/site/.vitepress/theme/components/rules/RuleCard.vue
+++ b/site/.vitepress/theme/components/rules/RuleCard.vue
@@ -52,7 +52,7 @@ if (!props.clickable) {
     :data-category="rule.category"
     :data-family="rule.family"
   >
-    <a v-if="clickable" class="rule-card-cover" :href="`/rules/${rule.slug}`" :aria-label="rule.name" />
+    <a v-if="clickable" class="rule-card-cover" :href="rule.href" :aria-label="rule.name" />
     <div v-if="$slots.header" class="rule-card-header"><slot name="header" /></div>
     <span
       class="rule-card-badge"

--- a/site/.vitepress/theme/components/rules/RuleSegmentChip.vue
+++ b/site/.vitepress/theme/components/rules/RuleSegmentChip.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { RenderedRule } from '../../../data/rules.data'
+
+defineProps<{
+  segment     : { family: string | null; rule: RenderedRule | null; slug: string }
+  withTooltip : boolean
+}>()
+</script>
+
+<template>
+  <RuleTooltipPopper :rule="withTooltip ? segment.rule : null">
+    <a
+      :href="segment.rule?.href"
+      class="composition-cards-chip"
+      :data-family="segment.family"
+      :title="segment.rule ? undefined : `${segment.slug} (${segment.family ?? 'undocumented'})`"
+    >
+      <span class="composition-cards-chip-label">
+        <span class="composition-cards-chip-slug">{{ segment.slug }}</span>
+      </span>
+    </a>
+  </RuleTooltipPopper>
+</template>

--- a/site/.vitepress/theme/components/rules/RulesPlate.vue
+++ b/site/.vitepress/theme/components/rules/RulesPlate.vue
@@ -8,6 +8,7 @@ import { FAMILY_META }     from '../../../lib/shared/registries'
 const clusters = computed(() =>
   landing.surfaces.map(s => ({
     ...s,
+    icon  : FAMILY_META[s.family].badge,
     label : FAMILY_META[s.family].label,
     rules : rules.byFamily[s.family] ?? []
   }))

--- a/site/.vitepress/theme/components/rules/RulesPlate.vue
+++ b/site/.vitepress/theme/components/rules/RulesPlate.vue
@@ -24,7 +24,7 @@ const clusters = computed(() =>
       <ul class="rules-cluster-specimens">
         <li v-for="rule in cluster.rules" :key="rule.slug">
           <RuleTooltipPopper :rule="rule">
-            <a class="specimen" :href="`/rules/${rule.slug}`">
+            <a class="specimen" :href="rule.href">
               <span class="specimen-slug">{{ rule.slug }}</span>
             </a>
           </RuleTooltipPopper>

--- a/site/primitives/aligner.md
+++ b/site/primitives/aligner.md
@@ -11,7 +11,7 @@ stability: internal
 
 ## Public Surface
 
-*Aligner* lives at `src/primitives/aligner.rs` and is `pub(crate)`, so the type is reachable from inside the *Prose* crate but not from a downstream Rust caller in `0.2.x`. The downstream-visible consequence is the diagnostic stream the alignment rules emit, with the resolved column landing in the `Edit` each rule produces.
+*Aligner* lives at `src/primitives/aligner/` and is `pub(crate)`, so the type is reachable from inside the *Prose* crate but not from a downstream Rust caller in `0.2.x`. The downstream-visible consequence is the diagnostic stream the alignment rules emit, with the resolved column landing in the `Edit` each rule produces.
 
 A downstream consumer in `0.2.x` can:
 
@@ -32,7 +32,7 @@ The entry point `emit_group(source: &Source, members: &[Member], settings: Setti
 
 ### Supporting Helpers
 
-A consuming rule rarely hand-builds the walker from raw AST traversal, since `aligner.rs` exposes a set of `pub(crate)` helpers covering the common shapes a new alignment rule needs:
+A consuming rule rarely hand-builds the walker from raw AST traversal, since the aligner module exposes a set of `pub(crate)` helpers covering the common shapes a new alignment rule needs:
 
 1. `line_adjacent_groups(items, member_of)` partitions `items` into runs of line-adjacent siblings via `Source::is_line_adjacent`, then maps each item through `member_of`. Single-member runs drop out.
 2. `keyed_line_adjacent_groups(items, key_of, member_of)` is the same shape with a per-item key that further partitions adjacent items into sub-groups by key.
@@ -85,7 +85,7 @@ impl Visitor<'_> {
 }
 ```
 
-`line_adjacent_groups` handles the grouping for the common contiguous-statements shape, with the per-item qualifier folding through `line_anchored_member` or `line_anchored_member_at_kind` depending on whether the gap anchors at a known offset or at a specific token. `walker.emit_group(&members)` pushes per-row edits into `self.edits`, so the rule never has to thread a returned `Vec<Edit>` per group, and `apply` drains the accumulator from `visitor.walker.edits` at the end.
+`line_adjacent_groups` handles the grouping for the common contiguous-statements shape, with the per-item qualifier folding through `line_anchored_member` or `line_anchored_member_at_kind` depending on whether the gap anchors at a known offset or at a specific token. `walker.emit_group(&members)` records each group's edits in the walker's `groups` accumulator, so the rule never has to thread a returned `Vec<Edit>` per group, and `apply` returns `visitor.walker.groups` at the end.
 
 When the alignment context is `:`-shaped *(dict items, class fields, annotated parameters, docstring args, match arms)*, the grouping logic lives in [[colon-targets]] instead. A new colon-shaped rule implements `ColonEmitter`'s `handle` and `dict`/`match_arms` overrides, calls `walk(source)`, and forwards each yielded `&[Member]` slice to `walker.emit_group(&members)`.
 

--- a/site/primitives/aligner.md
+++ b/site/primitives/aligner.md
@@ -49,7 +49,7 @@ Aligners always carry a **one-space buffer** between content and the aligned tok
 
 When the widest member exceeds `max_shift`, the policy decides what happens next.
 
-The `split` policy partitions the group into sub-groups of contiguous rows where the within-group widest is under `max_shift`, resolving each sub-group independently. The `drop` policy excludes the widest members from the padding calculation, leaving the group aligned to the widest non-overflow row.
+The `split` policy partitions the group into width bands, seeding each band at the widest unassigned member and claiming every member within `max_shift` of it, so the dominant column is sized by the rows that need it and a row sits alone only as a genuine width outlier. The `drop` policy excludes the widest members from the padding calculation, leaving the group aligned to the widest non-overflow row.
 
 A row carrying a line-level skip directive *(`# prose: skip`, `# fmt: skip`, or `# prose: skip[<rule>]`)* is **held** out of its group: excluded from the column math, emitting no edit, and transparent to the run so the rows on either side align as one block around it. The grouping treats a held row's own trailing skip comment as not breaking the run, while a standalone comment or blank line between rows still does. This is the same exclude-then-align shape as the `drop` policy, chosen by the author rather than by width.
 

--- a/site/rules/alignment/align-colons.md
+++ b/site/rules/alignment/align-colons.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : alignment
-caption  : "aligns the `:` separator across dict literals, dataclass and Pydantic fields, function-signature annotations, and docstring `Args:` blocks."
-related  : [align-equals, align-imports, alphabetize, collection-layout, align-match-case, strip-align-padding]
-layout   : doc
+caption : "aligns the `:` separator across dict literals, dataclass and Pydantic fields, function-signature annotations, and docstring `Args:` blocks."
+related : [align-equals, align-imports, alphabetize, collection-layout, align-match-case, strip-align-padding]
+layout  : doc
 ---
 
 # align-colons

--- a/site/rules/alignment/align-comparisons.md
+++ b/site/rules/alignment/align-comparisons.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : alignment
-caption  : "aligns comparison operators vertically across the operands of a multi-line `and`-chain or `or`-chain."
-related  : [align-colons, align-equals, align-imports, alphabetize, align-match-case]
-layout   : doc
+caption : "aligns comparison operators vertically across the operands of a multi-line `and`-chain or `or`-chain."
+related : [align-colons, align-equals, align-imports, alphabetize, align-match-case]
+layout  : doc
 ---
 
 # align-comparisons

--- a/site/rules/alignment/align-equals.md
+++ b/site/rules/alignment/align-equals.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : alignment
-caption  : "aligns the `=` separator across consecutive single-target assignments and annotated function-parameter defaults."
-related  : [align-colons, align-imports, align-match-case, strip-align-padding]
-layout   : doc
+caption : "aligns the `=` separator across consecutive single-target assignments and annotated function-parameter defaults."
+related : [align-colons, align-imports, align-match-case, strip-align-padding]
+layout  : doc
 ---
 
 # align-equals

--- a/site/rules/alignment/align-imports.md
+++ b/site/rules/alignment/align-imports.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : alignment
-caption  : "aligns the `import` and `as` keywords across consecutive import statements."
-related  : [align-colons, align-equals, alphabetize, bare-imports, blank-lines, align-match-case]
-layout   : doc
+caption : "aligns the `import` and `as` keywords across consecutive import statements."
+related : [align-colons, align-equals, alphabetize, bare-imports, blank-lines, align-match-case]
+layout  : doc
 ---
 
 # align-imports

--- a/site/rules/alignment/align-match-case.md
+++ b/site/rules/alignment/align-match-case.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : alignment
-caption  : "aligns the post-pattern `:` across single-expression case bodies inside a `match` statement."
-related  : [align-colons, align-equals, align-imports, strip-align-padding]
-layout   : doc
+caption : "aligns the post-pattern `:` across single-expression case bodies inside a `match` statement."
+related : [align-colons, align-equals, align-imports, strip-align-padding]
+layout  : doc
 ---
 
 # align-match-case

--- a/site/rules/docs/docstring-expand.md
+++ b/site/rules/docs/docstring-expand.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : docs
-caption  : "expands a one-line docstring into the multi-line block shape."
-related  : [docstring-wrap, docstring-frame]
-layout   : doc
+caption : "expands a one-line docstring into the multi-line block shape."
+related : [docstring-wrap, docstring-frame]
+layout  : doc
 ---
 
 # docstring-expand

--- a/site/rules/docs/docstring-frame.md
+++ b/site/rules/docs/docstring-frame.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : docs
-caption  : "drops a multi-line docstring's opener and closer onto their own lines."
-related  : [docstring-wrap, docstring-expand]
-layout   : doc
+caption : "drops a multi-line docstring's opener and closer onto their own lines."
+related : [docstring-wrap, docstring-expand]
+layout  : doc
 ---
 
 # docstring-frame

--- a/site/rules/docs/docstring-wrap.md
+++ b/site/rules/docs/docstring-wrap.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : docs
-caption  : "wraps multi-line docstring bodies at the configured measure."
-related  : [docstring-frame, docstring-expand]
-layout   : doc
+caption : "wraps multi-line docstring bodies at the configured measure."
+related : [docstring-frame, docstring-expand]
+layout  : doc
 ---
 
 # docstring-wrap

--- a/site/rules/formatting/blank-lines.md
+++ b/site/rules/formatting/blank-lines.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "normalizes blank-line counts to canonical values between thematically adjacent statements."
-related  : [alphabetize, align-imports, bare-imports]
-layout   : doc
+caption : "normalizes blank-line counts to canonical values between thematically adjacent statements."
+related : [alphabetize, align-imports, bare-imports]
+layout  : doc
 ---
 
 # blank-lines

--- a/site/rules/formatting/call-layout.md
+++ b/site/rules/formatting/call-layout.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "explodes a keyword-expressible call carrying more than the inline-argument cap to one keyword argument per line."
-related  : [alphabetize, collection-layout, signature-layout, strip-trailing-commas]
-layout   : doc
+caption : "explodes a keyword-expressible call carrying more than the inline-argument cap to one keyword argument per line."
+related : [alphabetize, collection-layout, signature-layout, strip-trailing-commas]
+layout  : doc
 ---
 
 # call-layout
@@ -14,7 +12,7 @@ A call carrying enough arguments to read as a wall of positionals folds better o
 
 The pass fires only on a call every argument of which is keyword-expressible. A positional argument resolves to its parameter name through the call site's in-module binding, so the exploded form reads `name=value` whatever order the source passed it. A positional-only prefix, a `*` or `**` unpacking, and a positional call whose callee does not resolve to a module function each leave the call inline, because the rule cannot name those arguments. The expanded form lays each argument one indent step past the call, the closing `)` dropping to the call's own indent, and a nested eligible call in an argument value explodes in the same pass.
 
-The rule reshapes layout and nothing more. Argument order stays with [`alphabetize`](/rules/alphabetize), which runs ahead of it, so disabling alphabetization leaves the exploded arguments in source order. The `=` spacing stays with [`align-equals`](/rules/align-equals), and whether the last argument carries a trailing comma stays with [`strip-trailing-commas`](/rules/strip-trailing-commas), which the explode carries through untouched.
+The rule reshapes layout and nothing more. Argument order stays with [`alphabetize`](/rules/ordering/alphabetize), which runs ahead of it, so disabling alphabetization leaves the exploded arguments in source order. The `=` spacing stays with [`align-equals`](/rules/alignment/align-equals), and whether the last argument carries a trailing comma stays with [`strip-trailing-commas`](/rules/formatting/strip-trailing-commas), which the explode carries through untouched.
 
 <template #configuration>
 

--- a/site/rules/formatting/collection-layout.md
+++ b/site/rules/formatting/collection-layout.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "splits list, tuple, dict, and set literals into one-entry-per-line layout once they overflow their width, or a dict crosses an entry-count cap."
-related  : [align-colons, alphabetize, signature-layout, strip-align-padding, strip-trailing-commas]
-layout   : doc
+caption : "splits list, tuple, dict, and set literals into one-entry-per-line layout once they overflow their width, or a dict crosses an entry-count cap."
+related : [align-colons, alphabetize, signature-layout, strip-align-padding, strip-trailing-commas]
+layout  : doc
 ---
 
 # collection-layout

--- a/site/rules/formatting/import-layout.md
+++ b/site/rules/formatting/import-layout.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "splits an over-budget `from ... import ...` into a run of repeated-prefix statements packed to the import budget."
-related  : [align-imports, alphabetize, bare-imports, collection-layout, signature-layout]
-layout   : doc
+caption : "splits an over-budget `from ... import ...` into a run of repeated-prefix statements packed to the import budget."
+related : [align-imports, alphabetize, bare-imports, collection-layout, signature-layout]
+layout  : doc
 ---
 
 # import-layout

--- a/site/rules/formatting/signature-layout.md
+++ b/site/rules/formatting/signature-layout.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "normalizes function signatures to one line or one parameter per line, gated by line length and inline-parameter count."
-related  : [align-colons, align-equals, collection-layout, strip-trailing-commas]
-layout   : doc
+caption : "normalizes function signatures to one line or one parameter per line, gated by line length and inline-parameter count."
+related : [align-colons, align-equals, collection-layout, strip-trailing-commas]
+layout  : doc
 ---
 
 # signature-layout

--- a/site/rules/formatting/strip-align-padding.md
+++ b/site/rules/formatting/strip-align-padding.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "strips padding from alignment groups that resolve to a single member."
-related  : [align-colons, align-equals, align-imports, align-match-case]
-layout   : doc
+caption : "strips padding from alignment groups that resolve to a single member."
+related : [align-colons, align-equals, align-imports, align-match-case]
+layout  : doc
 ---
 
 # strip-align-padding

--- a/site/rules/formatting/strip-trailing-commas.md
+++ b/site/rules/formatting/strip-trailing-commas.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "removes trailing commas from inside single-line collections."
-related  : [collection-layout, align-colons]
-layout   : doc
+caption : "removes trailing commas from inside single-line collections."
+related : [collection-layout, align-colons]
+layout  : doc
 ---
 
 # strip-trailing-commas

--- a/site/rules/formatting/unused-future-annotations.md
+++ b/site/rules/formatting/unused-future-annotations.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : formatting
-caption  : "removes `from __future__ import annotations` lines that no longer carry their weight on the target Python version."
-related  : [legacy-union-syntax]
-layout   : doc
+caption : "removes `from __future__ import annotations` lines that no longer carry their weight on the target Python version."
+related : [legacy-union-syntax]
+layout  : doc
 ---
 
 # unused-future-annotations

--- a/site/rules/lint/bare-imports.md
+++ b/site/rules/lint/bare-imports.md
@@ -1,9 +1,7 @@
 ---
-category : lint
-family   : lint
-caption  : "surfaces a narrowly-used bare import that `from x import …` would replace."
-related  : [alphabetize, align-imports, blank-lines]
-layout   : doc
+caption : "surfaces a narrowly-used bare import that `from x import …` would replace."
+related : [alphabetize, align-imports, blank-lines]
+layout  : doc
 ---
 
 # bare-imports

--- a/site/rules/lint/legacy-union-syntax.md
+++ b/site/rules/lint/legacy-union-syntax.md
@@ -1,9 +1,7 @@
 ---
-category : lint
-family   : lint
-caption  : "surfaces `Union[A, B]` and `Optional[T]` patterns that should read as modern `A | B` and `T | None`."
-related  : [unused-future-annotations]
-layout   : doc
+caption : "surfaces `Union[A, B]` and `Optional[T]` patterns that should read as modern `A | B` and `T | None`."
+related : [unused-future-annotations]
+layout  : doc
 ---
 
 # legacy-union-syntax

--- a/site/rules/lint/reassigned-constants.md
+++ b/site/rules/lint/reassigned-constants.md
@@ -1,9 +1,7 @@
 ---
-category : lint
-family   : lint
-caption  : "surfaces a module-level constant reassigned despite its `UPPER_SNAKE_CASE` casing."
-related  : [step-narration, single-use-variables]
-layout   : doc
+caption : "surfaces a module-level constant reassigned despite its `UPPER_SNAKE_CASE` casing."
+related : [step-narration, single-use-variables]
+layout  : doc
 ---
 
 # reassigned-constants

--- a/site/rules/lint/single-use-variables.md
+++ b/site/rules/lint/single-use-variables.md
@@ -1,9 +1,7 @@
 ---
-category : lint
-family   : lint
-caption  : "surfaces single-use local bindings that could inline cleanly."
-related  : [reassigned-constants, step-narration]
-layout   : doc
+caption : "surfaces single-use local bindings that could inline cleanly."
+related : [reassigned-constants, step-narration]
+layout  : doc
 ---
 
 # single-use-variables

--- a/site/rules/lint/step-narration.md
+++ b/site/rules/lint/step-narration.md
@@ -1,9 +1,7 @@
 ---
-category : lint
-family   : lint
-caption  : "surfaces comments that narrate the next line."
-related  : [reassigned-constants, single-use-variables]
-layout   : doc
+caption : "surfaces comments that narrate the next line."
+related : [reassigned-constants, single-use-variables]
+layout  : doc
 ---
 
 # step-narration

--- a/site/rules/ordering/alphabetize.md
+++ b/site/rules/ordering/alphabetize.md
@@ -1,9 +1,7 @@
 ---
-category : auto-fix
-family   : ordering
-caption  : "alphabetizes import siblings, dict-key blocks, and dataclass field runs."
-related  : [align-colons, align-imports, bare-imports, blank-lines]
-layout   : doc
+caption : "alphabetizes import siblings, dict-key blocks, and dataclass field runs."
+related : [align-colons, align-imports, bare-imports, blank-lines]
+layout  : doc
 ---
 
 # alphabetize

--- a/src/primitives/aligner/emit.rs
+++ b/src/primitives/aligner/emit.rs
@@ -4,6 +4,7 @@
 
 use std::cmp::Reverse;
 
+use itertools::Itertools;
 use ruff_diagnostics::Edit;
 use ruff_text_size::TextRange;
 
@@ -21,18 +22,12 @@ pub(super) fn emit_group(
     settings: Settings,
     edits: &mut Vec<Edit>,
 ) {
-    let Some(first) = members.first() else {
+    let Some((min_w, max_w)) = members.iter().map(|m| m.width).minmax().into_option() else {
         return;
     };
-    let (min_w, max_w) = members
-        .iter()
-        .fold((first.width, first.width), |(mn, mx), m| {
-            (mn.min(m.width), mx.max(m.width))
-        });
-    let max_op_w = max_op_width(members);
     if max_w - min_w <= settings.max_shift {
         let suffix = settings.suffix_len(members.len());
-        emit_with_paddings(source, members, max_w, max_op_w, suffix, edits);
+        emit_with_paddings(source, members, max_w, max_op_width(members), suffix, edits);
         return;
     }
     match settings.policy {
@@ -166,18 +161,19 @@ mod tests {
     /// row pointing at that row's pre-`=` whitespace. `gap_chars` seeds
     /// the existing pre-`=` whitespace.
     fn rows(specs: &[(usize, usize)]) -> (Source, Vec<Member>) {
+        let offset = |t: &str| TextSize::try_from(t.len()).expect("test source fits in u32");
         let mut text = String::new();
         let mut members = Vec::new();
         for &(width, gap_chars) in specs {
-            let line_start = u32::try_from(text.len()).expect("test source fits in u32");
+            let line_start = offset(&text);
             text.push_str(&"x".repeat(width));
-            let gap_start = u32::try_from(text.len()).expect("test source fits in u32");
+            let gap_start = offset(&text);
             text.push_str(&" ".repeat(gap_chars));
-            let gap_end = u32::try_from(text.len()).expect("test source fits in u32");
+            let gap_end = offset(&text);
             text.push_str("= 0\n");
             members.push(Member {
-                gap: TextRange::new(TextSize::new(gap_start), TextSize::new(gap_end)),
-                line_start: TextSize::new(line_start),
+                gap: TextRange::new(gap_start, gap_end),
+                line_start,
                 op_width: 0,
                 width,
             });
@@ -283,6 +279,23 @@ mod tests {
             sorted_summaries(&edits),
             vec![fill(&members[0], 3), fill(&members[1], 2)],
         );
+    }
+
+    #[test]
+    fn emit_group_drop_keeps_member_exactly_at_cap_boundary() {
+        // Width 9 sits exactly max_shift=8 from the width-1 minimum, so
+        // the inclusive band keeps it and the pair aligns at 9.
+        let (source, members) = rows(&[(1, 1), (9, 1), (30, 1)]);
+        let mut edits = Vec::new();
+
+        emit_group(
+            &source,
+            &members,
+            settings(8, MaxAlignShiftPolicy::Drop),
+            &mut edits,
+        );
+
+        assert_eq!(sorted_summaries(&edits), vec![fill(&members[0], 9)]);
     }
 
     #[test]
@@ -393,6 +406,29 @@ mod tests {
                 fill(&members[0], 4),
                 fill(&members[1], 3),
                 fill(&members[3], 2),
+            ],
+        );
+    }
+
+    #[test]
+    fn emit_group_split_partitions_into_three_bands() {
+        // Widths 30/25 band at the cap, 15/10 band next, and 1 lands
+        // alone: the loop must keep seeding past the second band.
+        let (source, members) = rows(&[(30, 1), (25, 1), (15, 1), (10, 1), (1, 1)]);
+        let mut edits = Vec::new();
+
+        let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
+        emit_group(&source, &members, settings, &mut edits);
+
+        // Band [30, 25] aligns at 30, band [15, 10] aligns at 15, and
+        // [1] is the stripped singleton. Members 0 and 2 are seeds
+        // already at gap=1.
+        assert_eq!(
+            sorted_summaries(&edits),
+            vec![
+                fill(&members[1], 6),
+                fill(&members[3], 6),
+                delete(&members[4]),
             ],
         );
     }

--- a/src/primitives/aligner/emit.rs
+++ b/src/primitives/aligner/emit.rs
@@ -2,11 +2,14 @@
 //! Dispatches a group through its `max-shift` policy and rewrites each
 //! member's gap to the computed column.
 
+use std::cmp::Reverse;
+
 use ruff_diagnostics::Edit;
 use ruff_text_size::TextRange;
 
 use super::{Member, Settings};
 use crate::{config::MaxAlignShiftPolicy, source::Source};
+
 /// Aligns the members of a group, dispatching through `settings.policy`
 /// when the widest padding exceeds `settings.max_shift`. A singleton
 /// group collapses its gap to one space, or to zero when
@@ -28,11 +31,7 @@ pub(super) fn emit_group(
         });
     let max_op_w = max_op_width(members);
     if max_w - min_w <= settings.max_shift {
-        let suffix = if members.len() == 1 && settings.strip_singleton_subgroup {
-            0
-        } else {
-            1
-        };
+        let suffix = settings.suffix_len(members.len());
         emit_with_paddings(source, members, max_w, max_op_w, suffix, edits);
         return;
     }
@@ -56,6 +55,13 @@ pub(crate) fn space_padding_edit(source: &Source, range: TextRange, n: usize) ->
     Some(Edit::range_replacement(" ".repeat(n), range))
 }
 
+/// Returns the length of the prefix of `members` whose widths sit
+/// within `max_shift` of `anchor_width`. The slice must be sorted so
+/// distance from the anchor grows monotonically.
+fn band_len(members: &[Member], anchor_width: usize, max_shift: usize) -> usize {
+    members.partition_point(|m| m.width.abs_diff(anchor_width) <= max_shift)
+}
+
 /// Sorts by width, keeps only the members whose width sits within
 /// `max_shift` of the minimum, and aligns that subset. Excluded
 /// members retain their original spacing. A kept set of fewer than
@@ -67,7 +73,7 @@ fn emit_drop(source: &Source, members: &[Member], settings: Settings, edits: &mu
         .first()
         .expect("emit_drop invariant: members is non-empty")
         .width;
-    let kept_end = sorted.partition_point(|m| m.width <= min + settings.max_shift);
+    let kept_end = band_len(&sorted, min, settings.max_shift);
     let kept = &sorted[..kept_end];
     if kept.len() < 2 {
         return;
@@ -76,20 +82,24 @@ fn emit_drop(source: &Source, members: &[Member], settings: Settings, edits: &mu
     emit_with_paddings(source, kept, max_w, max_op_width(kept), 1, edits);
 }
 
-/// Partitions greedily into sub-groups capped at `settings.max_shift`
-/// spread, each aligning at its own widest member. A singleton
-/// collapses its gap to one space, or to zero when
+/// Partitions into width bands, seeding each at the widest unassigned
+/// member and claiming every member whose width sits within
+/// `settings.max_shift` of the seed, so the dominant column is sized
+/// by the members that need it and a member lands alone only as a
+/// width outlier among the members not yet claimed by a wider band.
+/// Each band aligns at its seed's width. A singleton collapses its
+/// gap to one space, or to zero when
 /// `settings.strip_singleton_subgroup` is set.
 fn emit_split(source: &Source, members: &[Member], settings: Settings, edits: &mut Vec<Edit>) {
-    let subs = partition_by_spread(members, settings.max_shift);
-    for &(start, end, sub_max_w) in &subs {
-        let sub = &members[start..end];
-        let (max_w, suffix) = if sub.len() == 1 && settings.strip_singleton_subgroup {
-            (sub[0].width, 0)
-        } else {
-            (sub_max_w, 1)
-        };
-        emit_with_paddings(source, sub, max_w, max_op_width(sub), suffix, edits);
+    let mut sorted = members.to_vec();
+    sorted.sort_unstable_by_key(|m| Reverse(m.width));
+    let mut rest = sorted.as_slice();
+    while let Some(seed) = rest.first() {
+        let end = band_len(rest, seed.width, settings.max_shift);
+        let (band, tail) = rest.split_at(end);
+        let suffix = settings.suffix_len(band.len());
+        emit_with_paddings(source, band, seed.width, max_op_width(band), suffix, edits);
+        rest = tail;
     }
 }
 
@@ -120,33 +130,6 @@ fn emit_with_paddings(
 /// is empty.
 fn max_op_width(members: &[Member]) -> usize {
     members.iter().map(|m| m.op_width).max().unwrap_or(0)
-}
-
-/// Returns the half-open `(start, end, max_width)` sub-group ranges
-/// into `members` produced by greedily extending each sub-group while
-/// the running `max_width - min_width` stays at or below `max_shift`.
-fn partition_by_spread(members: &[Member], max_shift: usize) -> Vec<(usize, usize, usize)> {
-    let mut subs = Vec::new();
-    let mut cursor = 0;
-    while cursor < members.len() {
-        let mut min_w = members[cursor].width;
-        let mut max_w = min_w;
-        let mut end = cursor + 1;
-        while end < members.len() {
-            let w = members[end].width;
-            let new_min = min_w.min(w);
-            let new_max = max_w.max(w);
-            if new_max - new_min > max_shift {
-                break;
-            }
-            min_w = new_min;
-            max_w = new_max;
-            end += 1;
-        }
-        subs.push((cursor, end, max_w));
-        cursor = end;
-    }
-    subs
 }
 
 #[cfg(test)]
@@ -187,13 +170,9 @@ mod tests {
         let mut members = Vec::new();
         for &(width, gap_chars) in specs {
             let line_start = u32::try_from(text.len()).expect("test source fits in u32");
-            for _ in 0..width {
-                text.push('x');
-            }
+            text.push_str(&"x".repeat(width));
             let gap_start = u32::try_from(text.len()).expect("test source fits in u32");
-            for _ in 0..gap_chars {
-                text.push(' ');
-            }
+            text.push_str(&" ".repeat(gap_chars));
             let gap_end = u32::try_from(text.len()).expect("test source fits in u32");
             text.push_str("= 0\n");
             members.push(Member {
@@ -322,31 +301,79 @@ mod tests {
     }
 
     #[test]
-    fn emit_group_split_distances_widest_singleton_when_strip_is_set() {
+    fn emit_group_split_aligns_band_across_interleaved_outlier() {
         // Widths span 13 → 4, a 9-wide spread that exceeds max_shift=8.
-        // The greedy partition isolates the leading width-13 member as
-        // a singleton. With strip on, that singleton's gap collapses to
-        // zero so its `:` sits distanced, while the [4, 11, 7] remainder
-        // aligns within its own max_w of 11.
+        // The width-13 seed claims 11 and 7, so the band aligns at 13
+        // around the interleaved width-4 outlier, which strips to a
+        // zero-width gap.
         let (source, members) = rows(&[(13, 1), (4, 1), (11, 1), (7, 1)]);
         let mut edits = Vec::new();
 
         let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
         emit_group(&source, &members, settings, &mut edits);
 
-        // member[2] is the remainder's widest, already at gap=1.
+        // member[0] is the seed, already at gap=1.
         assert_eq!(
             sorted_summaries(&edits),
             vec![
-                delete(&members[0]),
-                fill(&members[1], 8),
-                fill(&members[3], 5),
+                delete(&members[1]),
+                fill(&members[2], 3),
+                fill(&members[3], 7),
             ],
         );
     }
 
     #[test]
-    fn emit_group_split_partitions_into_contiguous_subgroups() {
+    fn emit_group_split_bands_equal_widths_and_strips_outlier() {
+        // The two width-13 members band together regardless of the
+        // width-4 row between them, leaving that row the lone stripped
+        // singleton.
+        let (source, members) = rows(&[(13, 1), (4, 1), (13, 1)]);
+        let mut edits = Vec::new();
+
+        let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
+        emit_group(&source, &members, settings, &mut edits);
+
+        // Both width-13 gaps already sit at one space.
+        assert_eq!(sorted_summaries(&edits), vec![delete(&members[1])]);
+    }
+
+    #[test]
+    fn emit_group_split_claims_mid_width_into_widest_band() {
+        // The width-20 seed claims 12 (spread 8 fits the cap), so 4
+        // lands alone even though 12 sits within the cap of its own
+        // width: banding is greedy from the widest unassigned member.
+        let (source, members) = rows(&[(20, 1), (12, 1), (4, 1)]);
+        let mut edits = Vec::new();
+
+        let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
+        emit_group(&source, &members, settings, &mut edits);
+
+        assert_eq!(
+            sorted_summaries(&edits),
+            vec![fill(&members[1], 9), delete(&members[2])],
+        );
+    }
+
+    #[test]
+    fn emit_group_split_leaves_over_cap_pair_natural() {
+        let (source, members) = rows(&[(20, 1), (4, 1)]);
+        let mut edits = Vec::new();
+
+        emit_group(
+            &source,
+            &members,
+            settings(8, MaxAlignShiftPolicy::Split),
+            &mut edits,
+        );
+
+        // Each member is its own band. Without strip, both singleton
+        // targets are the one-space gap each row already carries.
+        assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn emit_group_split_partitions_by_width_not_source_order() {
         let (source, members) = rows(&[(1, 1), (2, 1), (15, 1), (3, 1), (4, 1)]);
         let mut edits = Vec::new();
 
@@ -357,34 +384,41 @@ mod tests {
             &mut edits,
         );
 
-        // sub-groups: [1,2] aligns at max=2, [15] singleton, [3,4]
-        // aligns at max=4. After alignment, targets are 2/1/1/2/1
-        // spaces. members 1, 2, 4 already have 1 space.
+        // bands: [15] singleton at its natural one-space gap, then
+        // [4, 3, 2, 1] aligns at 4. Targets are 4/3/1/2/1 spaces, and
+        // members 2 and 4 already carry theirs.
         assert_eq!(
             sorted_summaries(&edits),
-            vec![fill(&members[0], 2), fill(&members[3], 2)],
+            vec![
+                fill(&members[0], 4),
+                fill(&members[1], 3),
+                fill(&members[3], 2),
+            ],
         );
     }
 
     #[test]
-    fn emit_group_split_strips_every_isolated_singleton() {
-        // widths 13, 4, 13 yield spread = 9, exceeding max_shift=8, and
-        // the greedy partition isolates each as its own singleton. With
-        // strip on, every singleton's gap collapses to zero.
-        let (source, members) = rows(&[(13, 1), (4, 1), (13, 1)]);
+    fn emit_group_split_right_aligns_operators_within_band() {
+        let (source, members) = rows(&[(12, 1), (11, 1), (1, 1)]);
+        let members = [
+            members[0].with_op_width(2),
+            members[1].with_op_width(1),
+            members[2].with_op_width(1),
+        ];
         let mut edits = Vec::new();
 
-        let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
-        emit_group(&source, &members, settings, &mut edits);
-
-        assert_eq!(
-            sorted_summaries(&edits),
-            vec![
-                delete(&members[0]),
-                delete(&members[1]),
-                delete(&members[2]),
-            ],
+        emit_group(
+            &source,
+            &members,
+            settings(8, MaxAlignShiftPolicy::Split),
+            &mut edits,
         );
+
+        // Band [12, 11] right-aligns on its own widest operator, so
+        // member[1] targets 1+1+1=3 spaces while member[0] keeps its
+        // one-space gap and the [1] singleton takes no operator padding
+        // from the wide band.
+        assert_eq!(sorted_summaries(&edits), vec![fill(&members[1], 3)]);
     }
 
     #[test]
@@ -395,16 +429,30 @@ mod tests {
         let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
         emit_group(&source, &members, settings, &mut edits);
 
-        // [1] is a narrow singleton, so strip collapses its gap to 0
-        // while [10, 11] and [12, 13] align within their own max_w.
+        // The width-13 seed claims 12, 11, and 10 into one band aligned
+        // at 13, while [1] is the stripped singleton.
         assert_eq!(
             sorted_summaries(&edits),
             vec![
-                fill(&members[0], 2),
+                fill(&members[0], 4),
+                fill(&members[1], 3),
                 delete(&members[2]),
                 fill(&members[3], 2),
             ],
         );
+    }
+
+    #[test]
+    fn emit_group_strips_lone_member_gap_when_flag_is_set() {
+        let (source, members) = rows(&[(3, 5)]);
+        let mut edits = Vec::new();
+
+        let settings = settings(8, MaxAlignShiftPolicy::Split).with_singleton_subgroup_strip();
+        emit_group(&source, &members, settings, &mut edits);
+
+        // A lone member is its own group, so strip collapses the
+        // five-space gap to zero rather than the one-space suffix.
+        assert_eq!(sorted_summaries(&edits), vec![delete(&members[0])]);
     }
 
     #[test]

--- a/src/primitives/aligner/mod.rs
+++ b/src/primitives/aligner/mod.rs
@@ -122,8 +122,8 @@ impl Member {
 
 /// Emission knobs shared by every alignment rule.
 ///
-/// `strip_singleton_subgroup` collapses size-one sub-groups in
-/// `emit_split` to a zero-width gap.
+/// `strip_singleton_subgroup` collapses a size-one group's or
+/// sub-group's gap to zero width.
 #[derive(Clone, Copy)]
 pub(crate) struct Settings {
     max_shift: usize,
@@ -140,6 +140,13 @@ impl Settings {
             policy,
             strip_singleton_subgroup: false,
         }
+    }
+
+    /// Returns the gap width before the aligned token for a group of
+    /// `member_count` rows, zero for a stripped singleton and one
+    /// space otherwise.
+    fn suffix_len(self, member_count: usize) -> usize {
+        usize::from(member_count != 1 || !self.strip_singleton_subgroup)
     }
 
     /// Returns a copy of `self` with `strip_singleton_subgroup` enabled.

--- a/src/rules/strip_align_padding.rs
+++ b/src/rules/strip_align_padding.rs
@@ -70,9 +70,10 @@ impl ColonEmitter for Emitter {
 
 #[cfg(test)]
 mod tests {
-    use ruff_text_size::{Ranged, TextRange, TextSize};
+    use ruff_text_size::{Ranged, TextSize};
 
     use super::*;
+    use crate::testing::range;
 
     fn run_strip(members: &[aligner::Member]) -> Vec<Edit> {
         let mut emitter = Emitter { edits: Vec::new() };
@@ -89,13 +90,13 @@ mod tests {
     fn strip_skips_multi_member_groups_on_distinct_lines() {
         let members = [
             aligner::Member {
-                gap: TextRange::new(TextSize::new(2), TextSize::new(2)),
+                gap: range(2, 2),
                 line_start: TextSize::new(0),
                 op_width: 0,
                 width: 2,
             },
             aligner::Member {
-                gap: TextRange::new(TextSize::new(8), TextSize::new(8)),
+                gap: range(8, 8),
                 line_start: TextSize::new(6),
                 op_width: 0,
                 width: 2,
@@ -107,7 +108,7 @@ mod tests {
     #[test]
     fn strip_skips_zero_width_member_with_empty_gap() {
         let member = aligner::Member {
-            gap: TextRange::new(TextSize::new(0), TextSize::new(0)),
+            gap: range(0, 0),
             line_start: TextSize::new(0),
             op_width: 0,
             width: 0,
@@ -118,7 +119,7 @@ mod tests {
     #[test]
     fn strip_skips_zero_width_member_with_indent_gap() {
         let member = aligner::Member {
-            gap: TextRange::new(TextSize::new(0), TextSize::new(4)),
+            gap: range(0, 4),
             line_start: TextSize::new(0),
             op_width: 0,
             width: 0,
@@ -130,13 +131,13 @@ mod tests {
     fn strip_strips_every_member_when_colons_share_a_line() {
         let members = [
             aligner::Member {
-                gap: TextRange::new(TextSize::new(3), TextSize::new(5)),
+                gap: range(3, 5),
                 line_start: TextSize::new(0),
                 op_width: 0,
                 width: 3,
             },
             aligner::Member {
-                gap: TextRange::new(TextSize::new(8), TextSize::new(10)),
+                gap: range(8, 10),
                 line_start: TextSize::new(0),
                 op_width: 0,
                 width: 5,
@@ -148,7 +149,7 @@ mod tests {
     #[test]
     fn strip_strips_singleton_with_content_and_gap() {
         let member = aligner::Member {
-            gap: TextRange::new(TextSize::new(3), TextSize::new(5)),
+            gap: range(3, 5),
             line_start: TextSize::new(0),
             op_width: 0,
             width: 3,

--- a/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/diagnostics.snap
+++ b/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/input.py
+---
+align-colons@86..103

--- a/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/input.py
+++ b/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/input.py
@@ -1,0 +1,6 @@
+options = {
+    "timeout_seconds"     : 30.0,
+    "max_keepalive"       : 8,
+    "ttl"                 : 60,
+    "verify_certificates" : True,
+}

--- a/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/input.py.snap
+++ b/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/input.py.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/input.py
+---
+options = {
+    "timeout_seconds"     : 30.0,
+    "max_keepalive"       : 8,
+    "ttl": 60,
+    "verify_certificates" : True,
+}

--- a/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/meta.toml
+++ b/tests/fixtures/align_colons/hand_aligned_dict_keeps_dominant_column/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = true
+title       = "A Hand-Aligned Dict Keeps Its Dominant Column"
+
+description = '''
+A dict hand-aligned at its widest key, with key widths spanning just past `max-shift`. The width partition seeds at the widest key and claims every key within the cap, so **the dominant column survives** and only the short outlier strips flush against its `:`.
+'''

--- a/tests/fixtures/align_colons/narrow_singleton_strips_to_zero/input.py.snap
+++ b/tests/fixtures/align_colons/narrow_singleton_strips_to_zero/input.py.snap
@@ -4,8 +4,8 @@ expression: output
 input_file: tests/fixtures/align_colons/narrow_singleton_strips_to_zero/input.py
 ---
 class Packet:
-    connection  : int
-    descriptors : list
+    connection     : int
+    descriptors    : list
     n: int
     payload_size   : int
     request_buffer : bytes

--- a/tests/fixtures/align_colons/narrow_singleton_strips_to_zero/meta.toml
+++ b/tests/fixtures/align_colons/narrow_singleton_strips_to_zero/meta.toml
@@ -3,5 +3,5 @@ previewable = false
 title       = "A Narrow Singleton Sub-Group Strips to Zero"
 
 description = '''
-Class-field widths split into sub-groups under `max-shift`. A lone narrow field whose width sits below the surrounding sub-groups' max **collapses its gap to zero**, leaving its `:` flush against the name.
+Class-field widths partition from the widest field down under `max-shift`. A lone narrow field outside the dominant band's cap **collapses its gap to zero**, leaving its `:` flush against the name while every other field shares the dominant column.
 '''

--- a/tests/fixtures/align_colons/wide_singleton_drops_from_run/input.py.snap
+++ b/tests/fixtures/align_colons/wide_singleton_drops_from_run/input.py.snap
@@ -7,5 +7,5 @@ class Packet:
     short       : int
     medium_size : str
     really_really_long_field: bytes
-    longer : int
-    tiny   : str
+    longer      : int
+    tiny        : str

--- a/tests/fixtures/align_colons/wide_singleton_drops_from_run/meta.toml
+++ b/tests/fixtures/align_colons/wide_singleton_drops_from_run/meta.toml
@@ -3,5 +3,5 @@ previewable = false
 title       = "A Wide Singleton Drops Out of the Run"
 
 description = '''
-Under the default `split` policy, the greedy partitioner isolates `really_really_long_field` as a singleton sub-group. Exceeding `max-shift`, it **drops out of the alignment** with its `:` hugging the name, while the narrower fields align within their own sub-groups.
+Under the default `split` policy, the width partition seeds its first band at `really_really_long_field` and claims no neighbor within `max-shift`, leaving it a singleton. It **drops out of the alignment** with its `:` hugging the name, while the narrower fields share one column.
 '''

--- a/tests/fixtures/align_equals/outlier_target_splits_subgroups/input.py.snap
+++ b/tests/fixtures/align_equals/outlier_target_splits_subgroups/input.py.snap
@@ -6,5 +6,5 @@ input_file: tests/fixtures/align_equals/outlier_target_splits_subgroups/input.py
 short       = 1
 medium_size = 2
 really_really_long_target = 3
-longer = 4
-tiny   = 5
+longer      = 4
+tiny        = 5

--- a/tests/fixtures/align_equals/outlier_target_splits_subgroups/meta.toml
+++ b/tests/fixtures/align_equals/outlier_target_splits_subgroups/meta.toml
@@ -3,5 +3,5 @@ previewable = true
 title       = "A Widest Member past `max-shift` Splits the Group"
 
 description = '''
-An outlier target **partitions the group** under the default `split` policy. Members above align among themselves, members below align among themselves, and the outlier collapses to one space. Each sub-group settles on a different `=` column.
+An outlier target **partitions the group** under the default `split` policy. The width bands seed from the widest member down, so the outlier sits alone collapsed to one space while every other member shares the dominant `=` column.
 '''

--- a/tests/fixtures/align_equals/over_cap_pair_stays_natural/diagnostics.snap
+++ b/tests/fixtures/align_equals/over_cap_pair_stays_natural/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: tests/diagnostics.rs
+expression: render(&diagnostics)
+input_file: tests/fixtures/align_equals/over_cap_pair_stays_natural/input.py
+---
+

--- a/tests/fixtures/align_equals/over_cap_pair_stays_natural/input.py
+++ b/tests/fixtures/align_equals/over_cap_pair_stays_natural/input.py
@@ -1,0 +1,2 @@
+ttl = 60
+maximum_connection_backoff_seconds = 30.0

--- a/tests/fixtures/align_equals/over_cap_pair_stays_natural/input.py.snap
+++ b/tests/fixtures/align_equals/over_cap_pair_stays_natural/input.py.snap
@@ -1,0 +1,7 @@
+---
+source: tests/integration.rs
+expression: output
+input_file: tests/fixtures/align_equals/over_cap_pair_stays_natural/input.py
+---
+ttl = 60
+maximum_connection_backoff_seconds = 30.0

--- a/tests/fixtures/align_equals/over_cap_pair_stays_natural/meta.toml
+++ b/tests/fixtures/align_equals/over_cap_pair_stays_natural/meta.toml
@@ -1,0 +1,7 @@
+[docs]
+previewable = false
+title       = "An Over-Cap Pair Declines to Align"
+
+description = '''
+Two line-adjacent targets whose widths sit further apart than `max-shift`. Each seeds its own width band, so **neither pads toward the other** and both keep the natural single space before `=`.
+'''

--- a/tests/fixtures/align_imports/aliased_split_subgroups/diagnostics.snap
+++ b/tests/fixtures/align_imports/aliased_split_subgroups/diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/aliased_split_subgroups/input.py
 ---
-align-imports@31..47
+align-imports@31..120

--- a/tests/fixtures/align_imports/aliased_split_subgroups/input.py.snap
+++ b/tests/fixtures/align_imports/aliased_split_subgroups/input.py.snap
@@ -7,4 +7,4 @@ import datetime as dt
 import os       as o
 import re       as r
 import collections_with_a_very_long_module_name as long
-import json as j
+import json     as j

--- a/tests/fixtures/align_imports/aliased_split_subgroups/meta.toml
+++ b/tests/fixtures/align_imports/aliased_split_subgroups/meta.toml
@@ -3,5 +3,5 @@ previewable = true
 title       = "A Widest Member past `max-shift` Splits the Group"
 
 description = '''
-The shift-limit policy reaches `import M as A` runs by the same distance rules as `from`-imports. A widest module overshooting `max-shift = 8` **greedily partitions the run into sub-groups**, each aligning the `as` keyword at its own tightened column independently of the rest.
+The shift-limit policy reaches `import M as A` runs by the same distance rules as `from`-imports. A widest module overshooting `max-shift = 16` **seeds its own width band and claims no neighbor**, leaving the rest to align the `as` keyword at one shared column.
 '''

--- a/tests/fixtures/align_imports/split_subgroups/diagnostics.snap
+++ b/tests/fixtures/align_imports/split_subgroups/diagnostics.snap
@@ -3,4 +3,4 @@ source: tests/diagnostics.rs
 expression: render(&diagnostics)
 input_file: tests/fixtures/align_imports/split_subgroups/input.py
 ---
-align-imports@139..140
+align-imports@7..140

--- a/tests/fixtures/align_imports/split_subgroups/input.py.snap
+++ b/tests/fixtures/align_imports/split_subgroups/input.py.snap
@@ -3,9 +3,9 @@ source: tests/integration.rs
 expression: output
 input_file: tests/fixtures/align_imports/split_subgroups/input.py
 ---
-from io import BytesIO
-from re import sub
-from os import getenv
+from io      import BytesIO
+from re      import sub
+from os      import getenv
 from collections.abc.mapping_helpers.namespaced import OrderedDict
 from sys     import path
 from os.path import join

--- a/tests/fixtures/align_imports/split_subgroups/meta.toml
+++ b/tests/fixtures/align_imports/split_subgroups/meta.toml
@@ -3,5 +3,5 @@ previewable = false
 title       = "A Widest Member past the Default `max-shift` Splits the Group"
 
 description = '''
-A run whose widest module overshoots the default `max-shift = 8` **greedily partitions into contiguous sub-groups** under the default `split` policy. Each sub-group aligns `import` at its own column, so a single wide outlier does not drag its short neighbors across the page.
+A run whose widest module overshoots the default `max-shift = 16` **partitions into width bands seeded from the widest member down** under the default `split` policy. Each band aligns `import` at its own column, so a single wide outlier does not drag its short neighbors across the page.
 '''

--- a/tests/fixtures/composition/optional_union_field_annotations_align/diagnostics.snap
+++ b/tests/fixtures/composition/optional_union_field_annotations_align/diagnostics.snap
@@ -4,4 +4,4 @@ expression: render(&diagnostics)
 input_file: tests/fixtures/composition/optional_union_field_annotations_align/input.py
 ---
 align-colons@61..176
-align-equals@76..147
+align-equals@109..147

--- a/tests/fixtures/composition/varied_param_colons_and_defaults_align/diagnostics.snap
+++ b/tests/fixtures/composition/varied_param_colons_and_defaults_align/diagnostics.snap
@@ -4,3 +4,4 @@ expression: render(&diagnostics)
 input_file: tests/fixtures/composition/varied_param_colons_and_defaults_align/input.py
 ---
 align-colons@23..112
+align-equals@28..58

--- a/tests/site.rs
+++ b/tests/site.rs
@@ -55,7 +55,7 @@ fn every_case_directory_is_well_formed() {
     let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     let rule_slugs: BTreeSet<String> = Pipeline::known_ids()
         .iter()
-        .map(|id| id.to_string())
+        .map(ToString::to_string)
         .collect();
     let mut violations = Vec::new();
     let mut canonical = BTreeMap::<String, usize>::new();
@@ -176,12 +176,7 @@ fn every_fixture_invocation_resolves() {
 #[test]
 fn every_registered_rule_has_a_page() {
     let rules = Path::new(env!("CARGO_MANIFEST_DIR")).join("site/rules");
-    let families: Vec<PathBuf> = fs_err::read_dir(&rules)
-        .expect("site/rules reads")
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| path.is_dir())
-        .collect();
+    let families = subdirs(&rules);
     for id in Pipeline::known_ids() {
         assert!(
             families

--- a/tests/site.rs
+++ b/tests/site.rs
@@ -176,11 +176,18 @@ fn every_fixture_invocation_resolves() {
 #[test]
 fn every_registered_rule_has_a_page() {
     let rules = Path::new(env!("CARGO_MANIFEST_DIR")).join("site/rules");
+    let families: Vec<PathBuf> = fs_err::read_dir(&rules)
+        .expect("site/rules reads")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .collect();
     for id in Pipeline::known_ids() {
-        let page = rules.join(format!("{id}.md"));
         assert!(
-            page.is_file(),
-            "rule `{id}` registered in `KNOWN_IDS` has no page at `site/rules/{id}.md`"
+            families
+                .iter()
+                .any(|dir| dir.join(format!("{id}.md")).is_file()),
+            "rule `{id}` registered in `KNOWN_IDS` has no page under `site/rules/<family>/{id}.md`"
         );
     }
 }


### PR DESCRIPTION
### 🪻 Quick Summary

Partitions an over-cap `split` run from the widest member down, so the dominant alignment column is sized by the rows that need it and a row lands alone only as a genuine width outlier. The previous walk-order partition anchored each sub-group to the narrow members encountered first, which routinely broke the run's widest member off alone and rewrote a hand-aligned dict into a mixed shape whose widest key jammed against its own `:`. The branch also absorbs a docs-site restructure that nests every rule page under its family directory, deriving the taxonomy from the tree instead of per-page frontmatter.

---

### 🗞️ Key Changes

- Seeds each `emit_split` band at the widest unassigned member and claims every member within `max_shift` of it, replacing the walk-order partition that anchored sub-groups to the narrowest rows first.

- Extracts `band_len` as the cap-band predicate shared by `emit_drop` and `emit_split`, and folds the stripped-singleton gap choice into `Settings::suffix_len` for the group and band paths alike.

- Adds fixtures pinning a hand-aligned dict's surviving dominant column and a two-member over-cap pair declining to align, re-accepting the snapshots whose sub-grouping moved to width bands.

- Pins the width-band corners with inline tests, covering the greedy widest-first claim, the three-band partition, the drop policy's inclusive cap boundary, and operator right-alignment isolated per band.

- Nests every rule page under `site/rules/<family>/`, deriving `family` from the directory and `category` from the family through a shared `categoryOf`, deleting both frontmatter keys and their validation.

- Threads a discovered `href` through `DiscoveredRule` to the sidebar, data loaders, and rule-link components, and repairs the current-rule route composable for the nested path shape.

- Hardens discovery into a single directory pass that fails the build on a stray page outside a family directory, a page duplicated across two families, or a missing caption.

- Derives glossary rule links from discovery through a `rule` field that refuses hand-written rule URLs, drops the landing surfaces' badge field duplicating `FAMILY_META`, and extracts `RuleSegmentChip` from the chip markup `CompositionCards` repeated.

- Replaces the hand-rolled min/max fold with `Itertools::minmax`, builds test offsets through `TextSize::try_from`, and syncs the aligner primitive page to the width-band partition and the directory-module layout.

---

### ☕ Implementation Notes

#### Greedy Banding and the Singleton Condition

Requirement 2's singleton condition (*no other member within the cap of its width*) disagrees with requirement 1's algorithm when a mid-width member sits within the cap of both a wider seed and a narrower remnant. The implementation follows the greedy widest-first claim, reading the condition over unassigned members, and `emit_group_split_claims_mid_width_into_widest_band` pins the corner where width 4 lands alone even though width 12 sits within its cap.

#### Nested URLs Ship Without Redirects

The published rule-page URLs move to the nested shape with no redirect layer, a deliberate call given the site's age, wherein stale crawler entries 404 until the regenerated sitemap recirculates.

---

### 🧵 Related Issues

- Closes #245