### PR TITLE
[250] Emit RFC-3986 `file://` artifact URIs from the SARIF emitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +626,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
 ]
 
 [[package]]
@@ -1022,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
- "fluent-uri",
+ "fluent-uri 0.1.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1309,6 +1326,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dirs",
+ "fluent-uri 0.4.1",
  "fs-err",
  "ignore",
  "indoc",
@@ -1521,6 +1539,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2200,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ blake3             = "1"
 clap               = { version = "4.5", features = ["derive"] }
 clap_complete      = "4.5"
 dirs               = "6"
+fluent-uri         = "0.4"
 fs-err             = "3"
 ignore             = "0.4"
 itertools          = "0.14"

--- a/src/diagnostics/sarif.rs
+++ b/src/diagnostics/sarif.rs
@@ -18,6 +18,7 @@ use crate::{
     diagnostics::{
         Diagnostic, Emitter, EmitterSummary, Run, diagnostics, line_columns, write_json_line,
     },
+    file_uri,
     rule::RuleId,
 };
 
@@ -39,7 +40,9 @@ impl Emitter for Sarif {
 }
 
 fn artifact_location(file: &SourceFile) -> ArtifactLocation {
-    ArtifactLocation::builder().uri(file.name()).build()
+    ArtifactLocation::builder()
+        .uri(file_uri::from_path(file.name()))
+        .build()
 }
 
 fn collect_rule_ids(runs: &[Run<'_>]) -> Vec<RuleId> {
@@ -184,12 +187,12 @@ mod tests {
     }
 
     #[test]
-    fn emits_an_absolute_path_unchanged() {
+    fn encodes_the_absolute_artifact_uri() {
         let file = SourceFileBuilder::new("/tmp/My Project/mod.py", "x = 1\n").finish();
         let v = emit_value(&file, std::slice::from_ref(&diag()));
         let uri = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]
             ["uri"];
-        assert_eq!(uri, "/tmp/My Project/mod.py");
+        assert_eq!(uri, "file:///tmp/My%20Project/mod.py");
     }
 
     #[test]

--- a/src/file_uri.rs
+++ b/src/file_uri.rs
@@ -1,0 +1,85 @@
+//! Mapping between filesystem paths and `file://` URIs.
+
+use std::path::{Path, PathBuf};
+
+use fluent_uri::pct_enc::{EString, encoder::Path as PathEncoder};
+use lsp_types::Uri;
+
+const SCHEME: &str = "file";
+
+/// Renders an absolute source path as a percent-encoded `file://` URI,
+/// passing a relative path through unchanged.
+pub(crate) fn from_path(name: &str) -> String {
+    if Path::new(name).is_absolute() {
+        let mut encoded = EString::<PathEncoder>::new();
+        encoded.encode_str::<PathEncoder>(name);
+        format!("{SCHEME}://{encoded}")
+    } else {
+        name.to_owned()
+    }
+}
+
+/// Turns a `file://` URI into a filesystem path, or `None` for a URI that
+/// names no local file.
+pub(crate) fn to_path(uri: &Uri) -> Option<PathBuf> {
+    if uri.scheme().map(|scheme| scheme.as_str()) != Some(SCHEME) {
+        return None;
+    }
+    let decoded = uri.path().as_estr().decode().into_string().ok()?;
+    // A Windows drive arrives as `/C:/dir`, so drop its leading slash.
+    let path = match decoded.strip_prefix('/') {
+        Some(rest) if has_drive_prefix(rest) => rest,
+        _ => decoded.as_ref(),
+    };
+    Some(PathBuf::from(path))
+}
+
+/// Returns `true` when `s` opens with a `C:`-style Windows drive letter.
+fn has_drive_prefix(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::testing::uri;
+
+    #[test]
+    fn from_path_passes_a_relative_path_through_unchanged() {
+        assert_eq!(from_path("src/My Project/mod.py"), "src/My Project/mod.py");
+    }
+
+    #[rstest]
+    #[case("/tmp/My Project/mod.py", "file:///tmp/My%20Project/mod.py")]
+    #[case("/tmp/café/mod.py", "file:///tmp/caf%C3%A9/mod.py")]
+    #[case("/tmp/a#b?c[d]/mod.py", "file:///tmp/a%23b%3Fc%5Bd%5D/mod.py")]
+    fn from_path_round_trips_an_absolute_path(#[case] path: &str, #[case] expected: &str) {
+        let encoded = from_path(path);
+        assert_eq!(encoded, expected);
+        assert_eq!(to_path(&uri(&encoded)), Some(PathBuf::from(path)));
+    }
+
+    #[test]
+    fn to_path_decodes_percent_escapes() {
+        assert_eq!(
+            to_path(&uri("file:///tmp/a%20b.py")),
+            Some(PathBuf::from("/tmp/a b.py")),
+        );
+    }
+
+    #[test]
+    fn to_path_rejects_a_non_file_scheme() {
+        assert!(to_path(&uri("untitled:Untitled-1")).is_none());
+    }
+
+    #[test]
+    fn to_path_strips_a_windows_drive_slash() {
+        assert_eq!(
+            to_path(&uri("file:///C:/Users/x.py")),
+            Some(PathBuf::from("C:/Users/x.py")),
+        );
+    }
+}

--- a/src/file_uri.rs
+++ b/src/file_uri.rs
@@ -22,9 +22,7 @@ pub(crate) fn from_path(name: &str) -> String {
 /// Turns a `file://` URI into a filesystem path, or `None` for a URI that
 /// names no local file.
 pub(crate) fn to_path(uri: &Uri) -> Option<PathBuf> {
-    if uri.scheme().map(|scheme| scheme.as_str()) != Some(SCHEME) {
-        return None;
-    }
+    uri.scheme().filter(|scheme| scheme.as_str() == SCHEME)?;
     let decoded = uri.path().as_estr().decode().into_string().ok()?;
     // A Windows drive arrives as `/C:/dir`, so drop its leading slash.
     let path = match decoded.strip_prefix('/') {
@@ -36,8 +34,7 @@ pub(crate) fn to_path(uri: &Uri) -> Option<PathBuf> {
 
 /// Returns `true` when `s` opens with a `C:`-style Windows drive letter.
 fn has_drive_prefix(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+    matches!(s.as_bytes(), [drive, b':', ..] if drive.is_ascii_alphabetic())
 }
 
 #[cfg(test)]
@@ -73,6 +70,11 @@ mod tests {
     #[test]
     fn to_path_rejects_a_non_file_scheme() {
         assert!(to_path(&uri("untitled:Untitled-1")).is_none());
+    }
+
+    #[test]
+    fn to_path_rejects_a_non_utf8_percent_escape() {
+        assert!(to_path(&uri("file:///%FF.py")).is_none());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub(crate) mod cache;
 pub mod cli;
 pub mod config;
 pub mod diagnostics;
+mod file_uri;
 pub mod pipeline;
 mod primitives;
 pub mod rule;

--- a/src/server/config_cache.rs
+++ b/src/server/config_cache.rs
@@ -9,7 +9,7 @@ use std::{
 
 use lsp_types::Uri;
 
-use crate::config::Config;
+use crate::{config::Config, file_uri};
 
 /// Resolves the configuration governing each document, memoizing per
 /// parent directory only when a watcher can invalidate the cache on a
@@ -44,7 +44,7 @@ impl ConfigCache {
     /// unsaved buffer whose URI names no file falls back to the
     /// defaults.
     pub(super) fn resolve(&mut self, uri: &Uri) -> &Config {
-        let Some(path) = file_path(uri) else {
+        let Some(path) = file_uri::to_path(uri) else {
             return &self.default;
         };
         let dir = path.parent().unwrap_or(&path).to_path_buf();
@@ -55,27 +55,6 @@ impl ConfigCache {
             &self.fresh
         }
     }
-}
-
-/// Turns a `file://` URI into a filesystem path, or `None` for a URI that
-/// names no local file.
-fn file_path(uri: &Uri) -> Option<PathBuf> {
-    if uri.scheme().map(|scheme| scheme.as_str()) != Some("file") {
-        return None;
-    }
-    let decoded = uri.path().as_estr().decode().into_string().ok()?;
-    // A Windows drive arrives as `/C:/dir`, so drop its leading slash.
-    let path = match decoded.strip_prefix('/') {
-        Some(rest) if has_drive_prefix(rest) => rest,
-        _ => decoded.as_ref(),
-    };
-    Some(PathBuf::from(path))
-}
-
-/// Returns `true` when `s` opens with a `C:`-style Windows drive letter.
-fn has_drive_prefix(s: &str) -> bool {
-    let bytes = s.as_bytes();
-    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 /// Loads the config governing `path`, logging a present-but-broken config
@@ -92,24 +71,22 @@ fn load(path: &Path) -> Config {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
-    use crate::testing::write_prose_toml;
+    use crate::testing::{uri, write_prose_toml};
+
+    fn doc_uri(path: &Path) -> Uri {
+        uri(&file_uri::from_path(&path.display().to_string()))
+    }
 
     fn line_length(config: &Config) -> Option<usize> {
         config.code_line_length.map(std::num::NonZeroUsize::get)
-    }
-
-    fn uri(s: &str) -> Uri {
-        Uri::from_str(s).expect("valid uri")
     }
 
     #[test]
     fn broken_config_logs_and_falls_back_to_defaults() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_prose_toml(dir.path(), "code-line-length = = oops\n");
-        let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
+        let file = doc_uri(&dir.path().join("mod.py"));
 
         let mut cache = ConfigCache::new(true);
 
@@ -123,7 +100,7 @@ mod tests {
     fn disabled_cache_re_reads_on_each_resolve() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_prose_toml(dir.path(), "code-line-length = 100\n");
-        let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
+        let file = doc_uri(&dir.path().join("mod.py"));
 
         let mut cache = ConfigCache::new(false);
         assert_eq!(line_length(cache.resolve(&file)), Some(100));
@@ -140,7 +117,7 @@ mod tests {
     fn enabled_cache_is_stale_until_cleared() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_prose_toml(dir.path(), "code-line-length = 100\n");
-        let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
+        let file = doc_uri(&dir.path().join("mod.py"));
 
         let mut cache = ConfigCache::new(true);
         assert_eq!(line_length(cache.resolve(&file)), Some(100));
@@ -153,27 +130,6 @@ mod tests {
         );
         cache.clear();
         assert_eq!(line_length(cache.resolve(&file)), Some(80));
-    }
-
-    #[test]
-    fn file_path_decodes_percent_escapes() {
-        assert_eq!(
-            file_path(&uri("file:///tmp/a%20b.py")),
-            Some(PathBuf::from("/tmp/a b.py")),
-        );
-    }
-
-    #[test]
-    fn file_path_rejects_a_non_file_scheme() {
-        assert!(file_path(&uri("untitled:Untitled-1")).is_none());
-    }
-
-    #[test]
-    fn file_path_strips_a_windows_drive_slash() {
-        assert_eq!(
-            file_path(&uri("file:///C:/Users/x.py")),
-            Some(PathBuf::from("C:/Users/x.py")),
-        );
     }
 
     #[test]
@@ -192,7 +148,7 @@ mod tests {
         write_prose_toml(dir.path(), "code-line-length = 100\n");
         let doc = dir.path().join("mod.py");
         std::fs::write(&doc, "x = 1\n").expect("writes");
-        let file = uri(&format!("file://{}", doc.display()));
+        let file = doc_uri(&doc);
 
         let mut cache = ConfigCache::new(true);
 
@@ -203,7 +159,7 @@ mod tests {
     fn resolve_reads_prose_toml_beside_the_document() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_prose_toml(dir.path(), "code-line-length = 100\n");
-        let file = uri(&format!("file://{}", dir.path().join("mod.py").display()));
+        let file = doc_uri(&dir.path().join("mod.py"));
 
         let mut cache = ConfigCache::new(true);
 
@@ -214,8 +170,8 @@ mod tests {
     fn sibling_documents_share_one_resolution() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_prose_toml(dir.path(), "code-line-length = 100\n");
-        let first = uri(&format!("file://{}", dir.path().join("a.py").display()));
-        let second = uri(&format!("file://{}", dir.path().join("b.py").display()));
+        let first = doc_uri(&dir.path().join("a.py"));
+        let second = doc_uri(&dir.path().join("b.py"));
 
         let mut cache = ConfigCache::new(true);
         assert_eq!(line_length(cache.resolve(&first)), Some(100));

--- a/src/server/dispatch/mod.rs
+++ b/src/server/dispatch/mod.rs
@@ -150,7 +150,7 @@ fn register_config_watchers(
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, thread};
+    use std::thread;
 
     use lsp_server::{ErrorCode, Notification, RequestId, Response};
     use lsp_types::{
@@ -166,6 +166,7 @@ mod tests {
     use serde_json::Value;
 
     use super::*;
+    use crate::testing;
 
     const DID_CHANGE: &str = "textDocument/didChange";
     const DID_CLOSE: &str = "textDocument/didClose";
@@ -179,7 +180,7 @@ mod tests {
     const SHUTDOWN: &str = "shutdown";
 
     fn uri() -> Uri {
-        Uri::from_str("file:///module.py").expect("valid uri")
+        testing::uri("file:///module.py")
     }
 
     fn note<P: Serialize>(method: &str, params: P) -> Message {

--- a/src/server/documents.rs
+++ b/src/server/documents.rs
@@ -39,13 +39,8 @@ impl DocumentStore {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
-
-    fn uri(s: &str) -> Uri {
-        Uri::from_str(s).expect("valid uri")
-    }
+    use crate::testing::uri;
 
     #[test]
     fn get_returns_none_for_absent_uri() {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,7 +1,8 @@
 //! Helpers shared across `#[cfg(test)] mod tests` blocks.
 
-use std::path::Path;
+use std::{path::Path, str::FromStr};
 
+use lsp_types::Uri;
 use ruff_diagnostics::Edit;
 use ruff_text_size::TextRange;
 
@@ -61,6 +62,10 @@ pub(crate) fn parse(src: &str) -> Source {
 
 pub(crate) fn range(start: u32, end: u32) -> TextRange {
     TextRange::new(start.into(), end.into())
+}
+
+pub(crate) fn uri(s: &str) -> Uri {
+    Uri::from_str(s).expect("valid uri")
 }
 
 pub(crate) fn write_prose_toml(dir: &Path, contents: &str) {


### PR DESCRIPTION
### 🪻 Quick Summary

Emits a percent-encoded [**RFC 3986**](https://www.rfc-editor.org/rfc/rfc3986) `file://` URI for the SARIF emitter's `artifactLocation.uri`, replacing the bare filesystem path that left a source carrying spaces or non-ASCII as a string no conformant [**SARIF 2.1.0**](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) reader could parse. The encode reuses [**`fluent-uri`**](https://docs.rs/fluent-uri), the same crate the server's config resolver already decodes editor URIs through, landing as a shared `file_uri` module that owns both the path-to-URI render and the URI-to-path decode the resolver previously kept inline. A relative path still passes through untouched, keeping the repo-relative reads GitHub Code Scanning performs today.

---

### 🗞️ Key Changes

- Adds `fluent-uri` as a direct dependency and renders an absolute source path as a percent-encoded `file://` artifact URI through its `Path` encoder, so a path with spaces, non-ASCII, or URI-reserved characters reaches Code Scanning as a parseable URI rather than a bare string.

- Extracts a shared `file_uri` module owning both directions, where `from_path` is the SARIF emitter's encode and `to_path` is the decode that previously lived as `config_cache::file_path`, routing `config_cache::resolve` through it so one home holds the `file` scheme and the Windows-drive convention.

- Passes a relative source path through `from_path` unchanged, keeping the `<source>` stdin placeholder and the repo-relative reads as bare strings.

- Consolidates the `fn uri(s: &str) -> Uri` test helper into `crate::testing`, replacing the per-module copies the `file_uri`, `config_cache`, `documents`, and `dispatch` test modules each carried.

- Pins a path with spaces, non-ASCII, and URI-reserved characters each round-tripping through `from_path` and back through `to_path`, a relative path landing untouched, and a non-UTF-8 percent-escape rejected.

---

### ☕ Implementation Notes

#### Two `fluent-uri` Majors Coexist by Design

`Cargo.lock` carries both `fluent-uri` 0.1.4 and 0.4.1. The decode side operates on `lsp_types::Uri`, which pins the older 0.1 line, whereas the encode side enters as a direct dependency on the current 0.4 line for its percent-encoding API. The two majors coexist until the `lsp-types` pin moves, so `to_path` reads the 0.1-flavored `Uri` while `from_path` builds through 0.4's `EString` path encoder.

---

### 🧵 Related Issues

- Closes #250
