### PR TITLE
[244] Key the check cache on the resolved rule selection

### DIFF
--- a/site/.vitepress/data/primitives-composition.data.ts
+++ b/site/.vitepress/data/primitives-composition.data.ts
@@ -54,7 +54,8 @@ const SOURCES: readonly PrimitiveEntrySource[] = [
     consumes   : ['source'],
     layer      : 'analysis',
     slug       : 'cache',
-    summary    : 'User-level on-disk cache keyed on `(source ++ config ++ version)`, collapsing repeat runs to a stat plus a hash plus a deserialize.',
+    summary    : 'User-level on-disk cache keyed on `(source ++ config ++ rules ++ version)`, '
+               + 'collapsing repeat runs to a stat plus a hash plus a deserialize.',
     tagline    : 'content-addressed result cache'
   },
   {

--- a/site/.vitepress/lib/glossary/entries.ts
+++ b/site/.vitepress/lib/glossary/entries.ts
@@ -204,7 +204,7 @@ export const glossary: Record<string, GlossaryEntry> = {
     aliases   : ['Cache', 'cached', 'caching'],
     definition: 'The user-level on-disk cache *Prose* keeps for repeat `prose check` and '
               + '`prose format` runs. Keyed by [[BLAKE3]] over '
-              + '`(source ++ config ++ prose_version)`, capped by the LRU eviction the '
+              + '`(source ++ config ++ rules ++ prose_version)`, capped by the LRU eviction the '
               + '`[cache] max-size-mib` knob configures, bypassable per invocation '
               + 'with `--no-cache`, and clearable with `prose cache clean`.',
     families  : ['engine', 'cli'],

--- a/site/primitives/cache.md
+++ b/site/primitives/cache.md
@@ -6,7 +6,7 @@ stability: internal
 
 <PrimitiveLayout primitive="cache">
 
-*Cache* is the user-level content-addressed cache that lets `prose check` and `prose format` skip the pipeline for unchanged source. Each entry is a bincode-serialized payload carrying the post-pipeline diagnostics and optional rewrite, keyed on the **BLAKE3** digest of `(source_bytes ++ config_toml ++ prose_version ++ cache_format_version)`. A repeat run against an unchanged file collapses to a stat plus a hash plus a deserialize, with no AST construction, no rule pipeline, and no rewrite computation.
+*Cache* is the user-level content-addressed cache that lets `prose check` and `prose format` skip the pipeline for unchanged source. Each entry is a bincode-serialized payload carrying the post-pipeline diagnostics and optional rewrite, keyed on the **BLAKE3** digest of `(source_bytes ++ config_toml ++ rule_ids ++ prose_version ++ cache_format_version)`. A repeat run against an unchanged file collapses to a stat plus a hash plus a deserialize, with no AST construction, no rule pipeline, and no rewrite computation.
 
 ## Consumer-Visible Surface
 
@@ -20,9 +20,9 @@ At `1.0` the cache surface stabilizes for downstream consumers integrating the p
 
 ## Key Shape
 
-The cache key is the **BLAKE3** digest of inputs concatenated in order: the source bytes, the canonical TOML serialization of the active `Config`, the *Prose* version from `CARGO_PKG_VERSION`, and a private `CACHE_FORMAT_VERSION` constant.
+The cache key is the **BLAKE3** digest of inputs concatenated in order: the source bytes, the canonical TOML serialization of the active `Config`, the resolved rule selection the pipeline runs, the *Prose* version from `CARGO_PKG_VERSION`, and a private `CACHE_FORMAT_VERSION` constant.
 
-A change to any one input produces a different key, so a config tweak invalidates only the entries it semantically affects, and a *Prose* release invalidates the entire cache. The `CACHE_FORMAT_VERSION` input lets the on-disk entry shape bump independently of the user-facing version, leaving a release that does not change the entry shape free to carry its existing cache forward.
+A change to any one input produces a different key, so a config tweak invalidates only the entries it semantically affects, a `--select` or `--ignore` run keys apart from a full one, and a *Prose* release invalidates the entire cache. The `CACHE_FORMAT_VERSION` input lets the on-disk entry shape bump independently of the user-facing version, leaving a release that does not change the entry shape free to carry its existing cache forward.
 
 The canonical TOML serialization runs through `toml::to_string`, so a semantically-equivalent re-shuffling of the user's config file produces the same key. Two workspaces editing identical files under matching configuration share a cache hit, because the key already disambiguates source content across projects.
 

--- a/site/reference/cache.md
+++ b/site/reference/cache.md
@@ -1,6 +1,6 @@
 # Cache
 
-*Prose* caches per-file pipeline output keyed on the source bytes, the configuration governing the file, and the *Prose* version. A repeat `prose check` or `prose format` against an unchanged file collapses to a stat, a hash, and a deserialize, since the cache hit re-emits diagnostics from the cached entry without entering the pipeline.
+*Prose* caches per-file pipeline output keyed on the source bytes, the configuration governing the file, the rules the run selects, and the *Prose* version. A repeat `prose check` or `prose format` against an unchanged file collapses to a stat, a hash, and a deserialize, since the cache hit re-emits diagnostics from the cached entry without entering the pipeline.
 
 The cache is enabled by default. The `[cache]` table tunes it, `--no-cache` bypasses it for one invocation, and `prose cache clean` clears it.
 
@@ -20,10 +20,11 @@ Resolution chains through `PROSE_CACHE_DIR` → the platform default. `PROSE_CAC
 
 ## Key Shape
 
-The cache key is the **BLAKE3** digest of `(source_bytes ++ config_toml ++ prose_version ++ cache_format_version)`. The inputs:
+The cache key is the **BLAKE3** digest of `(source_bytes ++ config_toml ++ rule_ids ++ prose_version ++ cache_format_version)`. The inputs:
 
 - the source bytes of the file under formatting
 - the canonical TOML serialization of the `Config` governing the file, so a semantically-equivalent re-shuffling of the user's config file produces the same key
+- the resolved rule selection the run enables after config toggles and the `--select` / `--ignore` filters, so a run narrowing the rule set keys separately from a full run
 - the *Prose* version from `CARGO_PKG_VERSION`, so a version bump invalidates the cache wholesale
 - a private `CACHE_FORMAT_VERSION` constant that bumps independently when the on-disk entry shape changes, leaving the user-facing version free to ship semver-meaningful bumps without unrelated cache turnover
 

--- a/src/cache/key.rs
+++ b/src/cache/key.rs
@@ -1,18 +1,28 @@
-//! The cache key: a BLAKE3 digest over the source, config, and
-//! version inputs.
+//! The cache key: a BLAKE3 digest over the source, config, resolved
+//! rule selection, and version inputs.
 
-pub(super) const CACHE_FORMAT_VERSION: &str = "2";
+use crate::rule::RuleId;
 
-/// BLAKE3 digest of `(source_bytes ++ config_toml ++ prose_version ++ cache_format_version)`.
+pub(super) const CACHE_FORMAT_VERSION: &str = "3";
+
+/// BLAKE3 digest of
+/// `source_bytes ++ config_toml ++ rule_ids ++ prose_version ++ cache_format_version`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct CacheKey(pub(super) blake3::Hash);
 
 impl CacheKey {
-    /// Computes the key for a source file under the pre-serialized config TOML.
-    pub fn compute(source_bytes: &[u8], config_toml: &str) -> Self {
+    /// Computes the key for a source file under the pre-serialized config
+    /// TOML and the resolved rule selection that governs it, so two runs
+    /// differing only in `--select` / `--ignore` key separately.
+    pub fn compute(
+        source_bytes: &[u8],
+        config_toml: &str,
+        rule_ids: impl IntoIterator<Item = RuleId>,
+    ) -> Self {
         Self::compute_with_versions(
             source_bytes,
             config_toml,
+            rule_ids,
             env!("CARGO_PKG_VERSION"),
             CACHE_FORMAT_VERSION,
         )
@@ -21,12 +31,17 @@ impl CacheKey {
     pub(super) fn compute_with_versions(
         source_bytes: &[u8],
         config_toml: &str,
+        rule_ids: impl IntoIterator<Item = RuleId>,
         prose_version: &str,
         format_version: &str,
     ) -> Self {
         let mut hasher = blake3::Hasher::new();
         hasher.update(source_bytes);
         hasher.update(config_toml.as_bytes());
+        for id in rule_ids {
+            hasher.update(id.as_str().as_bytes());
+            hasher.update(b"\n");
+        }
         hasher.update(prose_version.as_bytes());
         hasher.update(format_version.as_bytes());
         Self(hasher.finalize())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,9 +1,10 @@
 //! User-level content-addressed cache for `prose check` and `prose format`.
 //!
 //! Keys are BLAKE3 digests over the source bytes, the canonical TOML
-//! serialization of the active `Config`, the Prose version, and a
-//! private `CACHE_FORMAT_VERSION` that bumps independently when the
-//! on-disk entry shape changes. Entries live one file per key under
+//! serialization of the active `Config`, the resolved rule selection
+//! the pipeline runs, the Prose version, and a private
+//! `CACHE_FORMAT_VERSION` that bumps independently when the on-disk
+//! entry shape changes. Entries live one file per key under
 //! the platform's cache directory, with the path resolving through
 //! `PROSE_CACHE_DIR` → `dirs::cache_dir()`. Inserts write to a
 //! temporary sibling then `rename` onto the final path, so a
@@ -53,43 +54,76 @@ mod tests {
         }
     }
 
+    fn rules() -> [RuleId; 2] {
+        [RuleId::from("align-equals"), RuleId::from("alphabetize")]
+    }
+
     #[test]
     fn cache_key_differs_when_cache_format_version_changes() {
-        let key_a =
-            CacheKey::compute_with_versions(b"x = 1\n", CONFIG_A, env!("CARGO_PKG_VERSION"), "1");
-        let key_b =
-            CacheKey::compute_with_versions(b"x = 1\n", CONFIG_A, env!("CARGO_PKG_VERSION"), "2");
+        let key_a = CacheKey::compute_with_versions(
+            b"x = 1\n",
+            CONFIG_A,
+            rules(),
+            env!("CARGO_PKG_VERSION"),
+            "1",
+        );
+        let key_b = CacheKey::compute_with_versions(
+            b"x = 1\n",
+            CONFIG_A,
+            rules(),
+            env!("CARGO_PKG_VERSION"),
+            "2",
+        );
         assert_ne!(key_a, key_b);
     }
 
     #[test]
     fn cache_key_differs_when_config_changes() {
-        let key_a = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        let key_b = CacheKey::compute(b"x = 1\n", CONFIG_B);
+        let key_a = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
+        let key_b = CacheKey::compute(b"x = 1\n", CONFIG_B, rules());
         assert_ne!(key_a, key_b);
-        let key_c = CacheKey::compute(b"x = 1\n", CONFIG_B);
+        let key_c = CacheKey::compute(b"x = 1\n", CONFIG_B, rules());
         assert_eq!(key_b, key_c);
     }
 
     #[test]
     fn cache_key_differs_when_prose_version_changes() {
-        let key_a =
-            CacheKey::compute_with_versions(b"x = 1\n", CONFIG_A, "0.2.3", CACHE_FORMAT_VERSION);
-        let key_b =
-            CacheKey::compute_with_versions(b"x = 1\n", CONFIG_A, "0.3.0", CACHE_FORMAT_VERSION);
+        let key_a = CacheKey::compute_with_versions(
+            b"x = 1\n",
+            CONFIG_A,
+            rules(),
+            "0.2.3",
+            CACHE_FORMAT_VERSION,
+        );
+        let key_b = CacheKey::compute_with_versions(
+            b"x = 1\n",
+            CONFIG_A,
+            rules(),
+            "0.3.0",
+            CACHE_FORMAT_VERSION,
+        );
         assert_ne!(key_a, key_b);
     }
 
     #[test]
+    fn cache_key_differs_when_rule_selection_changes() {
+        let key_a = CacheKey::compute(b"x = 1\n", CONFIG_A, [RuleId::from("align-equals")]);
+        let key_b = CacheKey::compute(b"x = 1\n", CONFIG_A, [RuleId::from("alphabetize")]);
+        assert_ne!(key_a, key_b);
+        let key_c = CacheKey::compute(b"x = 1\n", CONFIG_A, [RuleId::from("align-equals")]);
+        assert_eq!(key_a, key_c);
+    }
+
+    #[test]
     fn cache_key_differs_when_source_changes() {
-        let key_a = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        let key_b = CacheKey::compute(b"x = 2\n", CONFIG_A);
+        let key_a = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
+        let key_b = CacheKey::compute(b"x = 2\n", CONFIG_A, rules());
         assert_ne!(key_a, key_b);
     }
 
     #[test]
     fn cache_key_hex_renders_64_lowercase_chars() {
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         let hex = key.0.to_hex();
         assert_eq!(hex.len(), 64);
         assert!(
@@ -101,8 +135,8 @@ mod tests {
     #[test]
     fn cache_key_is_stable_across_runs() {
         assert_eq!(
-            CacheKey::compute(b"x = 1\n", CONFIG_A),
-            CacheKey::compute(b"x = 1\n", CONFIG_A),
+            CacheKey::compute(b"x = 1\n", CONFIG_A, rules()),
+            CacheKey::compute(b"x = 1\n", CONFIG_A, rules()),
         );
     }
 
@@ -110,7 +144,7 @@ mod tests {
     fn clean_clears_every_entry_and_returns_report() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         cache.insert(&key, &entry("y = 1\n"));
         let report = cache.clean().expect("cleans");
         assert_eq!(report.entries, 1);
@@ -131,8 +165,8 @@ mod tests {
     fn compact_evicts_until_under_cap() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key_old = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        let key_new = CacheKey::compute(b"y = 2\n", CONFIG_A);
+        let key_old = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
+        let key_new = CacheKey::compute(b"y = 2\n", CONFIG_A, rules());
         cache.insert(&key_old, &entry("a = 1\n"));
         std::thread::sleep(std::time::Duration::from_millis(20));
         cache.insert(&key_new, &entry("b = 2\n"));
@@ -151,7 +185,7 @@ mod tests {
     fn compact_returns_zeros_when_under_cap() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         cache.insert(&key, &entry("y = 1\n"));
         let report = cache.compact();
         assert_eq!(report.entries, 0);
@@ -162,8 +196,14 @@ mod tests {
     fn info_counts_entries_and_byte_total() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        cache.insert(&CacheKey::compute(b"x = 1\n", CONFIG_A), &entry("y = 1\n"));
-        cache.insert(&CacheKey::compute(b"x = 2\n", CONFIG_A), &entry("y = 2\n"));
+        cache.insert(
+            &CacheKey::compute(b"x = 1\n", CONFIG_A, rules()),
+            &entry("y = 1\n"),
+        );
+        cache.insert(
+            &CacheKey::compute(b"x = 2\n", CONFIG_A, rules()),
+            &entry("y = 2\n"),
+        );
         let info = cache.info();
         assert_eq!(info.entries, 2);
         assert!(info.bytes > 0);
@@ -196,8 +236,8 @@ mod tests {
     fn insert_evicts_oldest_when_above_cap() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 0);
-        let key_old = CacheKey::compute(b"x = 1\n", CONFIG_A);
-        let key_new = CacheKey::compute(b"y = 2\n", CONFIG_A);
+        let key_old = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
+        let key_new = CacheKey::compute(b"y = 2\n", CONFIG_A, rules());
         cache.insert(&key_old, &entry("a = 1\n"));
         std::thread::sleep(std::time::Duration::from_millis(20));
         cache.insert(&key_new, &entry("b = 2\n"));
@@ -208,7 +248,7 @@ mod tests {
     fn insert_leaves_no_tmp_sidecar_on_success() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         cache.insert(&key, &entry("y = 1\n"));
         let tmp_count = fs_err::read_dir(&cache.root)
             .expect("read_dir")
@@ -222,7 +262,7 @@ mod tests {
     fn insert_then_lookup_round_trips_a_skipped_rewrite() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         let original = CacheEntry {
             diagnostics: Vec::new(),
             rewrite: Rewrite::Skipped,
@@ -235,7 +275,7 @@ mod tests {
     fn insert_then_lookup_round_trips_the_entry() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         let original = entry("y = 1\n");
         cache.insert(&key, &original);
         let recovered = cache.lookup(&key).expect("hit");
@@ -246,7 +286,7 @@ mod tests {
     fn lookup_returns_none_for_corrupt_entry() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         fs_err::write(cache.path_for(&key), b"not bincode bytes").expect("writes");
         assert!(cache.lookup(&key).is_none());
     }
@@ -255,7 +295,7 @@ mod tests {
     fn lookup_returns_none_for_missing_entry() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);
-        let key = CacheKey::compute(b"x = 1\n", CONFIG_A);
+        let key = CacheKey::compute(b"x = 1\n", CONFIG_A, rules());
         assert!(cache.lookup(&key).is_none());
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -141,6 +141,23 @@ mod tests {
     }
 
     #[test]
+    fn cache_key_separates_selections_that_concatenate_alike() {
+        // Without the per-id delimiter both selections would feed the
+        // hasher the same `abc` bytes and collide.
+        let key_a = CacheKey::compute(
+            b"x = 1\n",
+            CONFIG_A,
+            [RuleId::from("ab"), RuleId::from("c")],
+        );
+        let key_b = CacheKey::compute(
+            b"x = 1\n",
+            CONFIG_A,
+            [RuleId::from("a"), RuleId::from("bc")],
+        );
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
     fn clean_clears_every_entry_and_returns_report() {
         let tmp = TempDir::new().expect("tempdir");
         let cache = cache_in(&tmp, 100);

--- a/src/cache/records.rs
+++ b/src/cache/records.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::diagnostics::Diagnostic;
 
-/// Post-pipeline state cached per `(source, config, version)` key. The
+/// Post-pipeline state cached per `(source, config, rules, version)`
+/// key. The
 /// diagnostics are always anchored to the source as written, leaving any
 /// mode free to render them. The rewrite is `Skipped` unless the writing
 /// mode ran [`Pipeline::run`](crate::pipeline::Pipeline::run).

--- a/src/cache/records.rs
+++ b/src/cache/records.rs
@@ -7,10 +7,9 @@ use serde::{Deserialize, Serialize};
 use crate::diagnostics::Diagnostic;
 
 /// Post-pipeline state cached per `(source, config, rules, version)`
-/// key. The
-/// diagnostics are always anchored to the source as written, leaving any
-/// mode free to render them. The rewrite is `Skipped` unless the writing
-/// mode ran [`Pipeline::run`](crate::pipeline::Pipeline::run).
+/// key. The diagnostics are always anchored to the source as written,
+/// leaving any mode free to render them. The rewrite is `Skipped` unless
+/// the writing mode ran [`Pipeline::run`](crate::pipeline::Pipeline::run).
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CacheEntry {
     pub diagnostics: Vec<Diagnostic>,

--- a/src/cli/runner/process.rs
+++ b/src/cli/runner/process.rs
@@ -50,7 +50,12 @@ pub(super) fn process_path(path: &Path, setup: &RunSetup, pass: Pass) -> FileOut
         .cache
         .as_ref()
         .filter(|_| !matches!(pass, Pass::Rewrite | Pass::Diagnose { validate: true }))
-        .map(|c| (c, CacheKey::compute(&bytes, &resolved.config_toml)));
+        .map(|c| {
+            (
+                c,
+                CacheKey::compute(&bytes, &resolved.config_toml, resolved.pipeline.rule_ids()),
+            )
+        });
     if let Some(outcome) = keyed
         .as_ref()
         .and_then(|(c, k)| c.lookup(k))

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -176,7 +176,8 @@ impl Config {
             .map_or_else(|| self.code_width(), NonZeroUsize::get)
     }
 
-    /// The config serialized to TOML, the cache key for a file it governs.
+    /// The config serialized to TOML, one component of the cache key
+    /// for a file it governs.
     pub(crate) fn to_toml(&self) -> String {
         toml::to_string(self).expect("Config serializes")
     }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -79,6 +79,13 @@ impl Pipeline {
         crate::rule::KNOWN_IDS
     }
 
+    /// This pipeline's enabled rule ids in registration order, the
+    /// resolved selection that keys the check cache so two runs
+    /// differing only in `--select` / `--ignore` key separately.
+    pub(crate) fn rule_ids(&self) -> impl Iterator<Item = RuleId> + use<'_> {
+        self.rules.iter().map(|rule| rule.id())
+    }
+
     /// Runs each registered rule against `source` in order and
     /// returns the rewritten source paired with the diagnostics each
     /// rule emitted.
@@ -246,7 +253,7 @@ mod tests {
     }
 
     fn registered_slugs(pipeline: &Pipeline) -> Vec<&'static str> {
-        pipeline.rules.iter().map(|r| r.id().as_str()).collect()
+        pipeline.rule_ids().map(|id| id.as_str()).collect()
     }
 
     #[test]

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -352,8 +352,7 @@ mod tests {
     fn known_ids_matches_with_defaults_registration() {
         let config = Config::default();
         let pipeline = Pipeline::with_defaults(&config);
-        let mut registered: Vec<&'static str> =
-            pipeline.rules.iter().map(|r| r.id().as_str()).collect();
+        let mut registered = registered_slugs(&pipeline);
         registered.sort_unstable();
         let mut known: Vec<&'static str> =
             Pipeline::known_ids().iter().map(RuleId::as_str).collect();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -19,6 +19,37 @@ fn assert_cache_hit_matches_miss(name: &str, source: &str) {
     assert_warm_run_matches_cold(&[&path]);
 }
 
+/// Seeds an isolated cache by checking `path` under `seed_filter`, then
+/// re-checks it under `query_filter` against the warm cache and asserts
+/// the output matches a `--no-cache` run of the same query, so the
+/// seed's selection never replays under the query's.
+fn assert_reselect_misses(seed_filter: &[&str], query_filter: &[&str], path: &Path) {
+    let (mut seed, cache_dir) = prose_isolated();
+    let _ = seed
+        .args(["check", "--output-format", "json"])
+        .args(seed_filter)
+        .arg(path)
+        .assert();
+
+    let warm = prose()
+        .args(["check", "--output-format", "json"])
+        .args(query_filter)
+        .arg(path)
+        .env("PROSE_CACHE_DIR", cache_dir.path())
+        .assert();
+    let cold = prose()
+        .args(["check", "--no-cache", "--output-format", "json"])
+        .args(query_filter)
+        .arg(path)
+        .assert();
+
+    assert_eq!(
+        warm.get_output().stdout,
+        cold.get_output().stdout,
+        "warm reselect must match a no-cache run",
+    );
+}
+
 /// Runs `check` twice against one isolated cache, asserts the warm
 /// run reproduces the cold stdout byte for byte, and returns it.
 fn assert_warm_run_matches_cold(paths: &[&Path]) -> String {
@@ -130,6 +161,25 @@ fn cache_hit_renders_collapsing_literal_like_a_cold_run() {
 }
 
 #[test]
+fn cache_hits_when_a_selection_is_repeated() {
+    let (_dir, path) = fixture("repeat.py", "ab = 1\nx = 2\n");
+    let (mut cold, cache_dir) = prose_isolated();
+    let _ = cold
+        .args(["check", "--select", "align-equals"])
+        .arg(&path)
+        .assert();
+    let warm = prose()
+        .args(["--verbose", "check", "--select", "align-equals"])
+        .arg(&path)
+        .env("PROSE_CACHE_DIR", cache_dir.path())
+        .assert();
+    assert!(
+        stderr_utf8(&warm).contains("1 hits, 0 misses"),
+        "the repeated selection must stay warm",
+    );
+}
+
+#[test]
 fn cache_info_subcommand_prints_path_and_counts() {
     let (mut cmd, _cache_dir) = prose_isolated();
     let assert = cmd.args(["cache", "info"]).assert().success();
@@ -178,6 +228,18 @@ fn cache_keys_each_file_against_its_governing_config() {
     let summary = summary_line(&out);
     assert_eq!(summary["files_visited"], 2);
     assert_eq!(summary["files_changed"], 1);
+}
+
+#[rstest]
+#[case::narrow_select_after_full_set(&[], &["--select", "alphabetize"])]
+#[case::ignore_after_full_set(&[], &["--ignore", "align-equals"])]
+#[case::full_set_after_narrow_select(&["--select", "alphabetize"], &[])]
+fn cache_misses_when_selection_changes_between_runs(
+    #[case] seed_filter: &[&str],
+    #[case] query_filter: &[&str],
+) {
+    let (_dir, path) = fixture("reselect.py", "ab = 1\nx = 2\n");
+    assert_reselect_misses(seed_filter, query_filter, &path);
 }
 
 #[test]


### PR DESCRIPTION
### 🪻 Quick Summary

Keys the check cache on the resolved rule selection, closing the quiet bug where a `--select` or `--ignore` run hit a previously cached entry and replayed diagnostics from rules outside the selection. The key already folded the source bytes and the governing config, but not which rules actually ran, so a narrowed re-query of a warm file reported findings the selection excluded while `--no-cache` answered correctly off the live pipeline. The digest now folds the enabled rule set after config toggles and the CLI filters, the cache format version bumps so old-shape entries invalidate wholesale, and a re-query under a different selection misses and recomputes while a repeat of the same selection stays warm.

---

### 🗞️ Key Changes

- Folds the resolved rule selection into the `CacheKey` BLAKE3 digest, and bumps `CACHE_FORMAT_VERSION` so entries written under the old key shape invalidate wholesale rather than collide.

- Adds `Pipeline::rule_ids`, the enabled rule ids in registration order, and threads it through the runner's per-file cache-key computation so the digest reflects the selection that actually governed the file.

- Covers a narrow select after a full-set run, a full-set run after a narrow select, and an `--ignore` variant, each asserting the warm replay matches a `--no-cache` run, plus a repeated-selection warm hit that stays cached.

- Pins the key-level invariants with unit tests that a changed selection re-keys, an unchanged one stays stable, and the per-id delimiter separates two selections whose slugs would otherwise concatenate to the same bytes.

- Routes the registration-parity test through the existing `registered_slugs` helper, retiring the last hand-rolled rule-id collection so `rule_ids` is the single path to a pipeline's enabled ids.

- Syncs the cache key shape across the cache primitive page, the cache reference, the glossary entry, and the primitives-composition data, each now naming the rule selection among the key inputs.

---

### 🧵 Related Issues

- Closes #244