### PR TITLE
[308] Parallelize the Open Graph card render and skip its font scan

### DIFF
--- a/site/.vitepress/lib/og/build.ts
+++ b/site/.vitepress/lib/og/build.ts
@@ -1,18 +1,12 @@
 import fs   from 'node:fs'
 import path from 'node:path'
 
+import { ogImagePath }                                 from '../config/og-url'
 import { readCargoVersion }                            from '../shared/version'
 import { loadBrandAssets }                             from './assets'
 import { cardKeyer, pruneCards, readCard, writeCard }  from './cache'
-import { renderLanding }                               from './landing'
 import { enumeratePages }                              from './pages'
-import { renderPage }                                  from './template'
-
-interface CardJob {
-  key        : string
-  outputPath : string
-  render     : () => Promise<Buffer>
-}
+import { renderCards, type RenderTask }                from './pool'
 
 export async function buildOgCards(
   srcDir : string,
@@ -25,28 +19,35 @@ export async function buildOgCards(
   const cacheDir = path.join(repo, '.cache', 'og')
   const keyOf    = cardKeyer(version, brand)
 
-  const jobs: readonly CardJob[] = [
-    { key: keyOf('landing'), outputPath: 'og.png', render: () => renderLanding(brand, version) },
+  const tasks: readonly RenderTask[] = [
+    { key: keyOf('landing'), outputPath: ogImagePath('index.md'), page: 'landing' },
     ...enumeratePages(srcDir, pages).map(page => ({
       key        : keyOf(page),
       outputPath : page.outputPath,
-      render     : () => renderPage(page, brand, version)
+      page
     }))
   ]
 
-  await Promise.all(jobs.map(job => materialize(cacheDir, outDir, job)))
-  await pruneCards(cacheDir, jobs.map(job => job.key))
+  const misses: RenderTask[] = []
+  await Promise.all(tasks.map(async task => {
+    const png = await readCard(cacheDir, task.key)
+    if (png) writeDist(outDir, task.outputPath, png)
+    else misses.push(task)
+  }))
+
+  if (misses.length > 0) {
+    const rendered = await renderCards(brand, version, misses)
+    await Promise.all(rendered.map(async card => {
+      writeDist(outDir, card.outputPath, card.png)
+      await writeCard(cacheDir, card.key, Buffer.from(card.png))
+    }))
+  }
+
+  await pruneCards(cacheDir, tasks.map(task => task.key))
 }
 
-async function materialize(cacheDir: string, outDir: string, job: CardJob): Promise<void> {
-  const png  = await readCard(cacheDir, job.key) ?? await renderAndCache(cacheDir, job)
-  const dest = path.join(outDir, job.outputPath)
+function writeDist(outDir: string, outputPath: string, png: Uint8Array): void {
+  const dest = path.join(outDir, outputPath)
   fs.mkdirSync(path.dirname(dest), { recursive: true })
   fs.writeFileSync(dest, png)
-}
-
-async function renderAndCache(cacheDir: string, job: CardJob): Promise<Buffer> {
-  const png = await job.render()
-  await writeCard(cacheDir, job.key, png)
-  return png
 }

--- a/site/.vitepress/lib/og/cache.ts
+++ b/site/.vitepress/lib/og/cache.ts
@@ -11,7 +11,8 @@ const OG_DIR = import.meta.dirname
 
 // render sources folded into every cache key, so a change here re-renders all cards
 const TEMPLATE_FILES: readonly string[] = [
-  'assets.ts', 'landing.ts', 'parts.ts', 'template.ts', '../shared/registries.ts'
+  'assets.ts', 'landing.ts', 'parts.ts', 'resvg-worker.mjs',
+  'template.ts', '../shared/registries.ts'
 ]
 
 type CardInput = OgPage | 'landing'

--- a/site/.vitepress/lib/og/cache.ts
+++ b/site/.vitepress/lib/og/cache.ts
@@ -11,7 +11,7 @@ const OG_DIR = import.meta.dirname
 
 // render sources folded into every cache key, so a change here re-renders all cards
 const TEMPLATE_FILES: readonly string[] = [
-  'assets.ts', 'landing.ts', 'parts.ts', 'resvg-worker.mjs',
+  'assets.ts', 'landing.ts', 'parts.ts', 'pool.ts', 'resvg-worker.mjs',
   'template.ts', '../shared/registries.ts'
 ]
 

--- a/site/.vitepress/lib/og/landing.ts
+++ b/site/.vitepress/lib/og/landing.ts
@@ -3,7 +3,7 @@ import { createElement, type JSXNode }  from 'satori/jsx'
 import type { BrandAssets }             from './assets'
 import {
   CARD_WIDTH, META_LABEL, MONO_DIM,
-  cardShell, leftRail, monoLabel, panelDivider, panelRow, panelShell, rasterize, versionCallout
+  cardShell, leftRail, monoLabel, panelDivider, panelRow, panelShell, toSvg, versionCallout
 } from './parts'
 
 const ARTIFACT_LEFT = 120
@@ -13,8 +13,8 @@ const TITLE_TOP     = 246
 const TITLE_WIDTH   = 889
 const TRACK         = '0.28em'
 
-export async function renderLanding(brand: BrandAssets, version: string): Promise<Buffer> {
-  return rasterize(buildLandingCard(version, brand.titleWithTagline), brand.fonts)
+export function landingSvg(brand: BrandAssets, version: string): Promise<string> {
+  return toSvg(buildLandingCard(version, brand.titleWithTagline), brand.fonts)
 }
 
 function buildLandingCard(version: string, titleWithTagline: string): JSXNode {

--- a/site/.vitepress/lib/og/parts.ts
+++ b/site/.vitepress/lib/og/parts.ts
@@ -1,4 +1,3 @@
-import { Resvg }                        from '@resvg/resvg-js'
 import { createElement, type JSXNode }  from 'satori/jsx'
 import satori, { type Font }            from 'satori'
 
@@ -15,11 +14,6 @@ const PANEL_FILL = 'rgba(255, 255, 255, 0.04)'
 
 export function toSvg(node: JSXNode, fonts: Font[]): Promise<string> {
   return satori(node, { fonts, height: CARD_HEIGHT, width: CARD_WIDTH })
-}
-
-export function svgToPng(svg: string): Buffer {
-  // satori embeds every glyph as a vector path, so resvg needs no font lookup
-  return new Resvg(svg, { font: { loadSystemFonts: false } }).render().asPng()
 }
 
 export function cardShell(...children: JSXNode[]): JSXNode {

--- a/site/.vitepress/lib/og/parts.ts
+++ b/site/.vitepress/lib/og/parts.ts
@@ -13,9 +13,13 @@ const BORDER     = 'rgba(255, 255, 255, 0.10)'
 const META_VALUE = '#e8dec8'
 const PANEL_FILL = 'rgba(255, 255, 255, 0.04)'
 
-export async function rasterize(node: JSXNode, fonts: Font[]): Promise<Buffer> {
-  const svg = await satori(node, { fonts, height: CARD_HEIGHT, width: CARD_WIDTH })
-  return new Resvg(svg).render().asPng()
+export function toSvg(node: JSXNode, fonts: Font[]): Promise<string> {
+  return satori(node, { fonts, height: CARD_HEIGHT, width: CARD_WIDTH })
+}
+
+export function svgToPng(svg: string): Buffer {
+  // satori embeds every glyph as a vector path, so resvg needs no font lookup
+  return new Resvg(svg, { font: { loadSystemFonts: false } }).render().asPng()
 }
 
 export function cardShell(...children: JSXNode[]): JSXNode {

--- a/site/.vitepress/lib/og/pool.ts
+++ b/site/.vitepress/lib/og/pool.ts
@@ -1,10 +1,11 @@
 import os         from 'node:os'
 import { Worker } from 'node:worker_threads'
 
+import { Resvg } from '@resvg/resvg-js'
+
 import type { BrandAssets } from './assets'
 import { landingSvg }       from './landing'
 import type { OgPage }      from './pages'
-import { svgToPng }         from './parts'
 import { pageSvg }          from './template'
 
 interface CardId {
@@ -60,5 +61,7 @@ function runLane(jobs: readonly RasterJob[]): Promise<readonly RenderedCard[]> {
 }
 
 function rasterize(job: RasterJob): RenderedCard {
-  return { key: job.key, outputPath: job.outputPath, png: svgToPng(job.svg) }
+  // satori embeds every glyph as a vector path, so resvg needs no font lookup
+  const png = new Resvg(job.svg, { font: { loadSystemFonts: false } }).render().asPng()
+  return { key: job.key, outputPath: job.outputPath, png }
 }

--- a/site/.vitepress/lib/og/pool.ts
+++ b/site/.vitepress/lib/og/pool.ts
@@ -1,0 +1,64 @@
+import os         from 'node:os'
+import { Worker } from 'node:worker_threads'
+
+import type { BrandAssets } from './assets'
+import { landingSvg }       from './landing'
+import type { OgPage }      from './pages'
+import { svgToPng }         from './parts'
+import { pageSvg }          from './template'
+
+interface CardId {
+  key        : string
+  outputPath : string
+}
+
+export interface RenderTask extends CardId { page: OgPage | 'landing' }
+
+interface RasterJob extends CardId { svg: string }
+
+interface RenderedCard extends CardId { png: Uint8Array }
+
+const WORKER_URL = new URL('./resvg-worker.mjs', import.meta.url)
+
+// satori (text-to-vector) runs here, leaving the resvg rasterization to fan out across cores
+export async function renderCards(
+  brand   : BrandAssets,
+  version : string,
+  tasks   : readonly RenderTask[]
+): Promise<readonly RenderedCard[]> {
+  const jobs = await Promise.all(tasks.map(async task => ({
+    key        : task.key,
+    outputPath : task.outputPath,
+    svg        : task.page === 'landing'
+      ? await landingSvg(brand, version)
+      : await pageSvg(task.page, brand, version)
+  })))
+
+  try {
+    const lanes   = Math.min(jobs.length, Math.max(1, os.availableParallelism() - 1))
+    const batches = await Promise.all(partition(jobs, lanes).map(lane => runLane(lane)))
+    return batches.flat()
+  }
+  catch {
+    // a runtime without worker support still rasterizes every card, serially
+    return jobs.map(rasterize)
+  }
+}
+
+function partition<T>(items: readonly T[], lanes: number): T[][] {
+  const buckets: T[][] = Array.from({ length: lanes }, () => [])
+  items.forEach((item, index) => buckets[index % lanes].push(item))
+  return buckets
+}
+
+function runLane(jobs: readonly RasterJob[]): Promise<readonly RenderedCard[]> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(WORKER_URL, { workerData: { jobs } })
+    worker.once('message', cards => { void worker.terminate(); resolve(cards as RenderedCard[]) })
+    worker.once('error',   error => { void worker.terminate(); reject(error) })
+  })
+}
+
+function rasterize(job: RasterJob): RenderedCard {
+  return { key: job.key, outputPath: job.outputPath, png: svgToPng(job.svg) }
+}

--- a/site/.vitepress/lib/og/resvg-worker.mjs
+++ b/site/.vitepress/lib/og/resvg-worker.mjs
@@ -1,0 +1,14 @@
+import { parentPort, workerData } from 'node:worker_threads'
+
+import { Resvg } from '@resvg/resvg-js'
+
+// satori embeds every glyph as a vector path, so resvg needs no font lookup
+const NO_FONTS = { font: { loadSystemFonts: false } }
+
+const cards = workerData.jobs.map(job => ({
+  key        : job.key,
+  outputPath : job.outputPath,
+  png        : new Resvg(job.svg, NO_FONTS).render().asPng()
+}))
+
+parentPort.postMessage(cards)

--- a/site/.vitepress/lib/og/template.ts
+++ b/site/.vitepress/lib/og/template.ts
@@ -6,7 +6,7 @@ import type { BrandAssets }     from './assets'
 import type { OgKind, OgPage }  from './pages'
 import {
   CARD_HEIGHT, CARD_WIDTH, META_LABEL, MONO_DIM,
-  cardShell, leftRail, monoLabel, panelDivider, panelRow, panelShell, rasterize, versionCallout
+  cardShell, leftRail, monoLabel, panelDivider, panelRow, panelShell, toSvg, versionCallout
 } from './parts'
 
 const BODY            = '#d4c8b5'
@@ -25,12 +25,12 @@ const TITLE_SIZES = {
   cap  : [[12, 108], [17, 100], [22, 84], [Infinity, 76]]
 } as const
 
-export async function renderPage(
+export function pageSvg(
   page    : OgPage,
   brand   : BrandAssets,
   version : string
-): Promise<Buffer> {
-  return rasterize(buildCard(page, version, brand.wordmark, brand.glyph), brand.fonts)
+): Promise<string> {
+  return toSvg(buildCard(page, version, brand.wordmark, brand.glyph), brand.fonts)
 }
 
 function buildCard(page: OgPage, version: string, wordmark: string, glyph: string): JSXNode {


### PR DESCRIPTION
### 🪻 Quick Summary

Parallelizes the Open Graph card render that #192 left serial, cutting the bill a full render pays whenever a version bump rekeys every card, a template edit invalidates the set, or a fresh CI runner restores no prior cache. The render was slow along two independent axes, resvg scanning the host's system font database on every `Resvg` construction even though Satori hands it pure vector paths with no `<text>` to resolve, and resvg's synchronous native render leaving the `Promise.all` over the page set rasterizing one card after another on the build's single JavaScript thread.

Satori still runs on the main thread where it stays bound to the page-template TypeScript, building each card's SVG, after which the resvg rasterization fans out across a worker pool sized to the host's available cores so the cards rasterize concurrently. A cache hit writes straight to the output directory and only a miss renders, caches, and writes, extending #192's cache rather than replacing it. The full card set renders byte-identical to its pre-change bytes, reusing the resvg binding already in the tree with no new dependency.

---

### 🗞️ Key Changes

- Skips resvg's system-font scan by passing `loadSystemFonts: false` on every `Resvg` construction, since Satori embeds each glyph as a vector path and the SVG carries no `<text>` to resolve, dropping a card from roughly 100ms to under 20ms.

- Keeps Satori on the main thread building each card's SVG, then fans the resvg rasterization across a worker pool sized to `os.availableParallelism()`, partitioning the jobs round-robin so the cards rasterize concurrently rather than one after another.

- Renders through `resvg-worker.mjs`, which imports only the resvg binding and carries no project TypeScript so it resolves under the build's Node runtime, with a `try`/`catch` that degrades to a serial in-thread render whenever a worker fails to spawn.

- Extends #192's cache so a hit writes straight to the output directory and only a miss renders, caches, and writes, retaining the prune pass that evicts cards no longer in the live set.

- Houses the resvg rasterization in the worker-pool module rather than the Satori builders, leaving `parts.ts` to build SVGs and `pool.ts` to own both the worker and serial rasterization paths, with `pool.ts` folded into the cache-key digest so the relocated render code stays hashed.

- Mirrors the `loadSystemFonts: false` configuration across `resvg-worker.mjs` and the `pool.ts` serial fallback rather than factoring a shared helper, because the worker imports only the resvg binding to resolve under the build's Node runtime without a TypeScript loader.

---

### 🧵 Related Issues

- Closes #308