### PR TITLE
[316] Finalize `0.5.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.96"
-version      = "0.4.0"
+version      = "0.5.0"
 
 [dependencies]
 annotate-snippets  = "=0.12.13"


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes the fifth *Prose* release. Bumps `Cargo.toml` from `0.4.0` to `0.5.0` and regenerates `Cargo.lock` against the new version. The `0.5` cycle withdraws automatic parameter reordering to the report-only `unsorted-parameters` lint, hardens the alignment and ordering rules so a class never sorts a member above a dependency and a reorder carries each member's comment along, settles the layout rules on their final shape in a single `format` pass, adds the `shed-parentheses` and `strip-none-return` rules and the `signature-annotations` lint, and opens per-file configuration with `[[tool.prose.overrides]]` and PEP 723 script blocks.

---

### 🗞️ Key Changes

- Bumps `Cargo.toml` from `0.4.0` to `0.5.0` and regenerates `Cargo.lock` against the new version

---

### 🧵 Related Issues

- Closes #316