### PR TITLE
[338] Harden `emit-tag.py` against an absent previous manifest

### DIFF
--- a/.github/scripts/emit-tag.py
+++ b/.github/scripts/emit-tag.py
@@ -6,27 +6,40 @@
 Emit the release tag for `draft.yml` to consume.
 
 Reads `[package].version` from `crate/Cargo.toml` at HEAD and HEAD~1, writes
-`version=<tag>` and `changed=<true|false>` to `$GITHUB_OUTPUT`. The
-`changed` flag lets push-triggered runs short-circuit when the bump
-didn't actually land.
+`version=<tag>` and `changed=<true|false>` to `$GITHUB_OUTPUT`. The `changed`
+flag holds when the two versions differ, counting a HEAD~1 that lacks the
+manifest or carries no parseable version as changed.
 """
 
 from os         import environ
 from pathlib    import Path
 from subprocess import run
-from tomllib    import loads
+from tomllib    import TOMLDecodeError, loads
+
+
+def previous_version() -> str | None:
+    """
+    Return `[package].version` from `crate/Cargo.toml` at HEAD~1, or `None`
+    when HEAD~1 lacks the manifest or carries no parseable version.
+    """
+    show = run(
+        ["git", "show", "HEAD~1:crate/Cargo.toml"],
+        capture_output = True,
+        text           = True
+    )
+    if show.returncode != 0:
+        return None
+    try:
+        return loads(show.stdout)["package"]["version"]
+    except (KeyError, TOMLDecodeError):
+        return None
 
 
 if __name__ == "__main__":
 
     head = loads(Path("crate/Cargo.toml").read_text())["package"]["version"]
-    prev = loads(run(
-        ["git", "show", "HEAD~1:crate/Cargo.toml"],
-        capture_output = True,
-        check          = True,
-        text           = True
-    ).stdout)["package"]["version"]
+    prev = previous_version()
 
     with open(environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
         f.write(f"version={head}\n")
-        f.write(f"changed={'true' if head != prev else 'false'}\n")
+        f.write(f"changed={'true' if prev != head else 'false'}\n")


### PR DESCRIPTION
### 🪻 Quick Summary

Hardens `emit-tag.py` against a previous manifest it cannot read. The `🪻 Draft` workflow went red on the first push to `main` after the #332 relocation, its `Emit release tag` step crashing on `git show HEAD~1:crate/Cargo.toml` (*exit `128`*) because the manifest had just moved from the root `Cargo.toml` into `crate/`, so the path did not yet exist at `HEAD~1` and the read failed under `check=True`. The fix reads the prior version through a `previous_version()` helper that swaps `check=True` for an explicit return-code check and treats an absent or unparseable `HEAD~1` manifest as a version change, leaving the draft free to proceed rather than crashing on a prior it cannot find. The `HEAD` read stays strict, because a manifest absent at `HEAD` is a genuine error worth surfacing.

---

### 🗞️ Key Changes

- Replaces the `HEAD~1` manifest read's `check=True` with an explicit `returncode` check inside a new `previous_version()` helper, so a `git show` that fails on a path absent from that revision returns `None` rather than raising and crashing the `Emit release tag` step.

- Catches `KeyError` and `TOMLDecodeError` so a present-but-malformed `HEAD~1` manifest also resolves to `None`, and computes `changed` as `prev != head` such that an unreadable prior version counts as a change, while the `HEAD` read stays strict against a genuinely missing current manifest.

---

### 🧵 Related Issues

- Closes #338