### PR TITLE
[340] Guard the `🪻 Draft` manual dispatch against an existing release

### DIFF
--- a/.github/scripts/cut-draft.py
+++ b/.github/scripts/cut-draft.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""
+Cut a draft release for `$VERSION`, or report when one already exists.
+
+Probes `gh release view` for the version. A missing release is cut with
+`gh release create --draft`, an existing draft is left untouched, and an
+existing published release is skipped. Writes `state` (one of `cut`,
+`drafted`, `published`) and the release `url` to `$GITHUB_OUTPUT`.
+"""
+
+from json       import loads
+from os         import environ
+from subprocess import run
+
+
+def cut_draft(version: str, repo: str) -> str:
+    """
+    Create a draft release for the version and return its URL.
+    """
+    return run(
+        [
+            "gh", "release", "create", version, "--repo", repo,
+            "--target", "main", "--generate-notes", "--draft"
+        ],
+        capture_output = True,
+        check          = True,
+        text           = True
+    ).stdout.strip()
+
+
+def existing_release(version: str, repo: str) -> dict | None:
+    """
+    Return the `isDraft`/`url` record for the version's release, or `None`
+    when no release exists for it.
+    """
+    probe = run(
+        ["gh", "release", "view", version, "--repo", repo, "--json", "isDraft,url"],
+        capture_output = True,
+        text           = True
+    )
+    return loads(probe.stdout) if probe.returncode == 0 else None
+
+
+if __name__ == "__main__":
+
+    version = environ["VERSION"]
+    repo    = environ["GITHUB_REPOSITORY"]
+    release = existing_release(version, repo)
+
+    if release is None:
+        state = "cut"
+        url   = cut_draft(version, repo)
+    elif release["isDraft"]:
+        state = "drafted"
+        url   = release["url"]
+        print(f"::notice::Draft for {version} already exists, leaving it untouched.")
+    else:
+        state = "published"
+        url   = release["url"]
+        print(f"::warning::{version} is already published, skipping the draft cut.")
+
+    with open(environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+        f.write(f"state={state}\n")
+        f.write(f"url={url}\n")

--- a/.github/scripts/summary.py
+++ b/.github/scripts/summary.py
@@ -12,8 +12,9 @@ Subcommands:
     deploy   Render the Deploy gate summary. Reads `DEPLOY` and `URL`
              plus the GitHub-runner defaults. Exits 0 when `DEPLOY` is
              success.
-    draft    Render the Draft summary. Reads `DRAFT_URL` and
-             `VERSION`, plus the GitHub-runner defaults.
+    draft    Render the Draft summary. Reads `DRAFT_STATE`,
+             `DRAFT_URL`, and `VERSION`, plus the GitHub-runner
+             defaults.
     release  Render the Release gate summary. Reads `BUILD`, `SDIST`,
              `VALIDATE`, `PUBLISH`, plus the GitHub-runner defaults.
              Exits 0 when every required job succeeded. `PUBLISH` is
@@ -90,11 +91,12 @@ class Summary:
 
     def draft(self):
         """
-        Render the Draft summary, either the cut URL or the no-bump no-op.
+        Render the Draft summary across the cut, existing, and no-op states.
         """
         self._emit(
             "draft-summary.md.j2",
             draft_url = environ.get("DRAFT_URL", ""),
+            state     = environ.get("DRAFT_STATE", ""),
             version   = environ["VERSION"]
         )
 

--- a/.github/scripts/templates/draft-summary.md.j2
+++ b/.github/scripts/templates/draft-summary.md.j2
@@ -1,7 +1,11 @@
 ## 🪻 Prose Draft
 
-{% if draft_url -%}
+{% if state == "cut" -%}
 Cut [*Prose* {{ version }}]({{ draft_url }}) draft from {{ commit_link }}.
+{% elif state == "drafted" -%}
+A draft for [*Prose* {{ version }}]({{ draft_url }}) already exists, left untouched.
+{% elif state == "published" -%}
+[*Prose* {{ version }}]({{ draft_url }}) is already published. No draft cut.
 {% else -%}
 No version bump in {{ commit_link }}. Draft not cut.
 {% endif %}

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -40,14 +40,13 @@ jobs:
         env:
           GH_TOKEN : ${{ github.token }}
           VERSION  : ${{ steps.tag.outputs.version }}
-        run  : |
-          url=$(gh release create "$VERSION" --target main --generate-notes --draft --repo "$GITHUB_REPOSITORY")
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+        run  : ./.github/scripts/cut-draft.py
 
       - name : 🗞️ Brief
         env:
-          DRAFT_URL : ${{ steps.cut.outputs.url }}
-          REF       : ${{ github.ref_name }}
-          SHA       : ${{ github.sha }}
-          VERSION   : ${{ steps.tag.outputs.version }}
+          DRAFT_STATE : ${{ steps.cut.outputs.state }}
+          DRAFT_URL   : ${{ steps.cut.outputs.url }}
+          REF         : ${{ github.ref_name }}
+          SHA         : ${{ github.sha }}
+          VERSION     : ${{ steps.tag.outputs.version }}
         run  : ./.github/scripts/summary.py draft


### PR DESCRIPTION
### 🪻 Quick Summary

Guards the `🪻 Draft` workflow's manual dispatch against a release that already exists. The `Cut draft` step forces on `workflow_dispatch` regardless of the version-bump check, so a manual run previously called `gh release create "$VERSION" --draft` unconditionally and failed with HTTP `422` (*tag already taken*) whenever a release for that version was already published or already drafted. A new `cut-draft.py` probes `gh release view` first and branches on the result, so the dispatch reports cleanly and still cuts a fresh draft for the genuine gap the override exists to serve, rather than crashing on a release it could have checked for.

---

### 🗞️ Key Changes

- Adds a `cut-draft.py` that probes `gh release view "$VERSION"` and branches three ways, cutting the draft when none exists, leaving an existing draft untouched with a `::notice::`, and skipping an already-published release with a `::warning::`, writing `state` and `url` to `$GITHUB_OUTPUT`.

- Replaces the `Cut draft` step's inline `gh release create` with a thin call to the new script, leaving its `if:` condition unchanged, and wires the new `state` output into the `🗞️ Brief` step's environment.

- Renders the `🗞️ Brief` panel across all three outcomes plus the existing no-bump no-op, `summary.py`'s `draft()` reading a `DRAFT_STATE` and the `draft-summary.md.j2` template branching on it.

---

### 🧵 Related Issues

- Closes #340