### PR TITLE
[342] Add `.config/prose.toml` as a config-discovery location

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ prose server                   # language server over stdio
 The full edition lives at [prose.fyi](https://prose.fyi/):
 
 - The [**rule catalog**](https://prose.fyi/rules/) walks every rule with before/after fixtures and per-facet configuration.
-- The [**configuration reference**](https://prose.fyi/reference/configuration) covers the `prose.toml` and `pyproject.toml` config files, every key, and the `[rules]` toggles.
+- The [**configuration reference**](https://prose.fyi/reference/configuration) covers the `prose.toml`, `.config/prose.toml`, and `pyproject.toml` config files, every key, and the `[rules]` toggles.
 - The [**cache reference**](https://prose.fyi/reference/cache) covers the cache directory, `--no-cache`, the `[cache]` table, and the `prose cache` subcommands.
 - The [**exit-code matrix**](https://prose.fyi/reference/exit-codes) is the contract CI gates and pre-commit hooks compile against.
 - [**Suppression directives**](https://prose.fyi/usage/suppression) cover `# prose: off`, `# prose: skip`, and the rest of the directive surface.

--- a/crate/src/config/load.rs
+++ b/crate/src/config/load.rs
@@ -29,8 +29,8 @@ impl ConfigForm {
     /// How this form names itself in a precedence notice.
     fn label(self) -> &'static str {
         match self {
-            Self::PyprojectTable => "the [tool.prose] table",
             Self::DotConfigProseToml | Self::ProseToml => self.rel_path(),
+            Self::PyprojectTable => "the [tool.prose] table",
         }
     }
 
@@ -41,8 +41,8 @@ impl ConfigForm {
             return Ok(None);
         };
         match self {
-            Self::PyprojectTable => prose_table_from_str(&contents),
             Self::DotConfigProseToml | Self::ProseToml => Ok(Some(toml::from_str(&contents)?)),
+            Self::PyprojectTable => prose_table_from_str(&contents),
         }
     }
 
@@ -72,7 +72,7 @@ pub(super) enum ConfigNotice<'a> {
 
 /// The directory-relative path of every recognized config form, the
 /// set the server's file watcher registers against.
-pub(crate) fn config_rel_paths() -> [&'static str; 3] {
+pub(crate) fn config_rel_paths() -> [&'static str; ConfigForm::PRECEDENCE.len()] {
     ConfigForm::PRECEDENCE.map(ConfigForm::rel_path)
 }
 

--- a/crate/src/config/load.rs
+++ b/crate/src/config/load.rs
@@ -8,13 +8,63 @@ use std::{
 
 use serde::{Deserialize, de::IntoDeserializer};
 
-use super::{ConfigError, PROSE_TOML, PYPROJECT_TOML};
+use super::ConfigError;
+
+/// A recognized prose-config source within a directory.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ConfigForm {
+    DotConfigProseToml,
+    ProseToml,
+    PyprojectTable,
+}
+
+impl ConfigForm {
+    /// The forms in the precedence order the walk applies, highest first.
+    const PRECEDENCE: [Self; 3] = [
+        Self::ProseToml,
+        Self::DotConfigProseToml,
+        Self::PyprojectTable,
+    ];
+
+    /// How this form names itself in a precedence notice.
+    fn label(self) -> &'static str {
+        match self {
+            Self::PyprojectTable => "the [tool.prose] table",
+            _ => self.rel_path(),
+        }
+    }
+
+    /// Reads this form's prose table from `dir`, yielding `None` when the
+    /// file is absent or a `pyproject.toml` carries no `[tool.prose]`.
+    fn read(self, dir: &Path) -> Result<Option<toml::Table>, ConfigError> {
+        let Some(contents) = read_optional(dir.join(self.rel_path()))? else {
+            return Ok(None);
+        };
+        match self {
+            Self::PyprojectTable => prose_table_from_str(&contents),
+            _ => Ok(Some(toml::from_str(&contents)?)),
+        }
+    }
+
+    /// This form's directory-relative path.
+    fn rel_path(self) -> &'static str {
+        match self {
+            Self::DotConfigProseToml => ".config/prose.toml",
+            Self::ProseToml => "prose.toml",
+            Self::PyprojectTable => "pyproject.toml",
+        }
+    }
+}
 
 /// A diagnostic surfaced while resolving configuration.
 pub(super) enum ConfigNotice<'a> {
-    /// A `prose.toml` outranked a `[tool.prose]` table in a
-    /// `pyproject.toml` sharing its directory. Carries that directory.
-    ProseTomlPrecedence(&'a Path),
+    /// A higher-precedence config form shadowed a lower one present in
+    /// the same directory. Carries that directory and the two forms.
+    Precedence {
+        dir: &'a Path,
+        shadowed: ConfigForm,
+        winner: ConfigForm,
+    },
     /// An unrecognized key under the prose table. Carries the dotted
     /// key path.
     UnknownKey(&'a str),
@@ -22,9 +72,15 @@ pub(super) enum ConfigNotice<'a> {
 
 pub(super) fn emit_notice(notice: ConfigNotice<'_>) {
     match notice {
-        ConfigNotice::ProseTomlPrecedence(dir) => eprintln!(
-            "note: prose.toml takes precedence over the [tool.prose] table in {}",
-            dir.join(PYPROJECT_TOML).display(),
+        ConfigNotice::Precedence {
+            dir,
+            shadowed,
+            winner,
+        } => eprintln!(
+            "note: {} takes precedence over {} in {}",
+            winner.label(),
+            shadowed.label(),
+            dir.display(),
         ),
         ConfigNotice::UnknownKey(key) => {
             eprintln!("warning: unknown key `{key}` in [tool.prose]");
@@ -62,9 +118,11 @@ fn read_optional(path: PathBuf) -> Result<Option<String>, ConfigError> {
 }
 
 /// Walks upward from `from`, returning the directory and prose table of
-/// the nearest `prose.toml` or `pyproject.toml` `[tool.prose]`, or `None`
-/// when the chain to the root carries neither. A `prose.toml` outranks a
-/// same-directory `pyproject.toml` and stops the walk.
+/// the nearest directory carrying a recognized config form, or `None`
+/// when the chain to the root carries none. Within a directory the order
+/// is `prose.toml`, then `.config/prose.toml`, then a `pyproject.toml`
+/// `[tool.prose]` table, and each lower form present alongside the winner
+/// raises a precedence notice.
 ///
 /// # Errors
 ///
@@ -78,15 +136,22 @@ where
     F: FnMut(ConfigNotice<'_>),
 {
     for dir in from.ancestors() {
-        if let Some(contents) = read_optional(dir.join(PROSE_TOML))? {
-            if pyproject_declares_prose(dir) {
-                on_notice(ConfigNotice::ProseTomlPrecedence(dir));
+        let mut resolved: Option<(ConfigForm, toml::Table)> = None;
+        for form in ConfigForm::PRECEDENCE {
+            let Some(table) = form.read(dir)? else {
+                continue;
+            };
+            if let Some((winner, _)) = &resolved {
+                on_notice(ConfigNotice::Precedence {
+                    dir,
+                    shadowed: form,
+                    winner: *winner,
+                });
+            } else {
+                resolved = Some((form, table));
             }
-            return Ok(Some((dir.to_path_buf(), toml::from_str(&contents)?)));
         }
-        if let Some(contents) = read_optional(dir.join(PYPROJECT_TOML))?
-            && let Some(table) = prose_table_from_str(&contents)?
-        {
+        if let Some((_, table)) = resolved {
             return Ok(Some((dir.to_path_buf(), table)));
         }
     }
@@ -95,12 +160,4 @@ where
 
 fn prose_value(value: &toml::Value) -> Option<&toml::Value> {
     value.get("tool").and_then(|tool| tool.get("prose"))
-}
-
-fn pyproject_declares_prose(dir: &Path) -> bool {
-    read_optional(dir.join(PYPROJECT_TOML))
-        .ok()
-        .flatten()
-        .and_then(|contents| prose_table_from_str(&contents).ok().flatten())
-        .is_some()
 }

--- a/crate/src/config/load.rs
+++ b/crate/src/config/load.rs
@@ -30,7 +30,7 @@ impl ConfigForm {
     fn label(self) -> &'static str {
         match self {
             Self::PyprojectTable => "the [tool.prose] table",
-            _ => self.rel_path(),
+            Self::DotConfigProseToml | Self::ProseToml => self.rel_path(),
         }
     }
 
@@ -42,7 +42,7 @@ impl ConfigForm {
         };
         match self {
             Self::PyprojectTable => prose_table_from_str(&contents),
-            _ => Ok(Some(toml::from_str(&contents)?)),
+            Self::DotConfigProseToml | Self::ProseToml => Ok(Some(toml::from_str(&contents)?)),
         }
     }
 
@@ -68,6 +68,12 @@ pub(super) enum ConfigNotice<'a> {
     /// An unrecognized key under the prose table. Carries the dotted
     /// key path.
     UnknownKey(&'a str),
+}
+
+/// The directory-relative path of every recognized config form, the
+/// set the server's file watcher registers against.
+pub(crate) fn config_rel_paths() -> [&'static str; 3] {
+    ConfigForm::PRECEDENCE.map(ConfigForm::rel_path)
 }
 
 pub(super) fn emit_notice(notice: ConfigNotice<'_>) {

--- a/crate/src/config/load_tests.rs
+++ b/crate/src/config/load_tests.rs
@@ -8,6 +8,20 @@ use super::load::ConfigForm;
 use super::*;
 use crate::testing::{write_dotconfig_prose_toml, write_prose_toml, write_pyproject};
 
+fn load_collecting_precedence(dir: &Path) -> (Config, Vec<(ConfigForm, ConfigForm)>) {
+    let mut precedence = Vec::new();
+    let config = Config::load_with_notices(dir, |notice| {
+        if let ConfigNotice::Precedence {
+            winner, shadowed, ..
+        } = notice
+        {
+            precedence.push((winner, shadowed));
+        }
+    })
+    .expect("loads");
+    (config, precedence)
+}
+
 #[test]
 fn load_absent_file_returns_defaults() {
     let tmp = TempDir::new().expect("tempdir");
@@ -34,16 +48,13 @@ fn load_emits_precedence_notice_when_both_present() {
     write_prose_toml(tmp.path(), "code-line-length = 120\n");
     write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
 
-    let mut precedence_notices = 0;
-    let config = Config::load_with_notices(tmp.path(), |notice| {
-        if matches!(notice, ConfigNotice::Precedence { .. }) {
-            precedence_notices += 1;
-        }
-    })
-    .expect("loads");
+    let (config, precedence) = load_collecting_precedence(tmp.path());
 
     assert_eq!(config.code_line_length, NonZeroUsize::new(120));
-    assert_eq!(precedence_notices, 1);
+    assert_eq!(
+        precedence,
+        [(ConfigForm::ProseToml, ConfigForm::PyprojectTable)]
+    );
 }
 
 #[test]
@@ -152,21 +163,23 @@ fn load_picks_nearest_prose_toml_over_ancestor_pyproject() {
 }
 
 #[test]
+fn load_precedence_routes_through_default_notice() {
+    let tmp = TempDir::new().expect("tempdir");
+    write_prose_toml(tmp.path(), "code-line-length = 120\n");
+    write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+
+    let config = Config::load(tmp.path()).expect("loads");
+
+    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+}
+
+#[test]
 fn load_prefers_dotconfig_over_sibling_pyproject() {
     let tmp = TempDir::new().expect("tempdir");
     write_dotconfig_prose_toml(tmp.path(), "code-line-length = 120\n");
     write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
 
-    let mut precedence = Vec::new();
-    let config = Config::load_with_notices(tmp.path(), |notice| {
-        if let ConfigNotice::Precedence {
-            winner, shadowed, ..
-        } = notice
-        {
-            precedence.push((winner, shadowed));
-        }
-    })
-    .expect("loads");
+    let (config, precedence) = load_collecting_precedence(tmp.path());
 
     assert_eq!(config.code_line_length, NonZeroUsize::new(120));
     assert_eq!(
@@ -181,33 +194,13 @@ fn load_prefers_prose_toml_over_sibling_dotconfig() {
     write_prose_toml(tmp.path(), "code-line-length = 120\n");
     write_dotconfig_prose_toml(tmp.path(), "code-line-length = 80\n");
 
-    let mut precedence = Vec::new();
-    let config = Config::load_with_notices(tmp.path(), |notice| {
-        if let ConfigNotice::Precedence {
-            winner, shadowed, ..
-        } = notice
-        {
-            precedence.push((winner, shadowed));
-        }
-    })
-    .expect("loads");
+    let (config, precedence) = load_collecting_precedence(tmp.path());
 
     assert_eq!(config.code_line_length, NonZeroUsize::new(120));
     assert_eq!(
         precedence,
         [(ConfigForm::ProseToml, ConfigForm::DotConfigProseToml)]
     );
-}
-
-#[test]
-fn load_prefers_prose_toml_over_sibling_pyproject() {
-    let tmp = TempDir::new().expect("tempdir");
-    write_prose_toml(tmp.path(), "code-line-length = 120\n");
-    write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
-
-    let config = Config::load(tmp.path()).expect("loads");
-
-    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
 }
 
 #[test]

--- a/crate/src/config/load_tests.rs
+++ b/crate/src/config/load_tests.rs
@@ -4,8 +4,9 @@ use assert_matches::assert_matches;
 use indoc::indoc;
 use tempfile::TempDir;
 
+use super::load::ConfigForm;
 use super::*;
-use crate::testing::{write_prose_toml, write_pyproject};
+use crate::testing::{write_dotconfig_prose_toml, write_prose_toml, write_pyproject};
 
 #[test]
 fn load_absent_file_returns_defaults() {
@@ -35,7 +36,7 @@ fn load_emits_precedence_notice_when_both_present() {
 
     let mut precedence_notices = 0;
     let config = Config::load_with_notices(tmp.path(), |notice| {
-        if matches!(notice, ConfigNotice::ProseTomlPrecedence(_)) {
+        if matches!(notice, ConfigNotice::Precedence { .. }) {
             precedence_notices += 1;
         }
     })
@@ -68,6 +69,14 @@ fn load_from_a_file_path_walks_from_its_directory() {
     let config = Config::load(&file).expect("loads");
 
     assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+}
+
+#[test]
+fn load_malformed_dotconfig_prose_toml_returns_toml_error() {
+    let tmp = TempDir::new().expect("tempdir");
+    write_dotconfig_prose_toml(tmp.path(), "[this is not valid TOML");
+
+    assert_matches!(Config::load(tmp.path()), Err(ConfigError::Toml(_)));
 }
 
 #[test]
@@ -143,10 +152,68 @@ fn load_picks_nearest_prose_toml_over_ancestor_pyproject() {
 }
 
 #[test]
+fn load_prefers_dotconfig_over_sibling_pyproject() {
+    let tmp = TempDir::new().expect("tempdir");
+    write_dotconfig_prose_toml(tmp.path(), "code-line-length = 120\n");
+    write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+
+    let mut precedence = Vec::new();
+    let config = Config::load_with_notices(tmp.path(), |notice| {
+        if let ConfigNotice::Precedence {
+            winner, shadowed, ..
+        } = notice
+        {
+            precedence.push((winner, shadowed));
+        }
+    })
+    .expect("loads");
+
+    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+    assert_eq!(
+        precedence,
+        [(ConfigForm::DotConfigProseToml, ConfigForm::PyprojectTable)]
+    );
+}
+
+#[test]
+fn load_prefers_prose_toml_over_sibling_dotconfig() {
+    let tmp = TempDir::new().expect("tempdir");
+    write_prose_toml(tmp.path(), "code-line-length = 120\n");
+    write_dotconfig_prose_toml(tmp.path(), "code-line-length = 80\n");
+
+    let mut precedence = Vec::new();
+    let config = Config::load_with_notices(tmp.path(), |notice| {
+        if let ConfigNotice::Precedence {
+            winner, shadowed, ..
+        } = notice
+        {
+            precedence.push((winner, shadowed));
+        }
+    })
+    .expect("loads");
+
+    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+    assert_eq!(
+        precedence,
+        [(ConfigForm::ProseToml, ConfigForm::DotConfigProseToml)]
+    );
+}
+
+#[test]
 fn load_prefers_prose_toml_over_sibling_pyproject() {
     let tmp = TempDir::new().expect("tempdir");
     write_prose_toml(tmp.path(), "code-line-length = 120\n");
     write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+
+    let config = Config::load(tmp.path()).expect("loads");
+
+    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+}
+
+#[test]
+fn load_reads_dotconfig_prose_toml() {
+    let tmp = TempDir::new().expect("tempdir");
+    write_dotconfig_prose_toml(tmp.path(), "code-line-length = 120\n");
 
     let config = Config::load(tmp.path()).expect("loads");
 

--- a/crate/src/config/load_tests.rs
+++ b/crate/src/config/load_tests.rs
@@ -43,21 +43,6 @@ fn load_absent_prose_section_returns_defaults() {
 }
 
 #[test]
-fn load_emits_precedence_notice_when_both_present() {
-    let tmp = TempDir::new().expect("tempdir");
-    write_prose_toml(tmp.path(), "code-line-length = 120\n");
-    write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
-
-    let (config, precedence) = load_collecting_precedence(tmp.path());
-
-    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
-    assert_eq!(
-        precedence,
-        [(ConfigForm::ProseToml, ConfigForm::PyprojectTable)]
-    );
-}
-
-#[test]
 fn load_empty_prose_toml_returns_defaults_and_stops_walk() {
     let tmp = TempDir::new().expect("tempdir");
     let nested = tmp.path().join("child");
@@ -204,6 +189,21 @@ fn load_prefers_prose_toml_over_sibling_dotconfig() {
 }
 
 #[test]
+fn load_prefers_prose_toml_over_sibling_pyproject() {
+    let tmp = TempDir::new().expect("tempdir");
+    write_prose_toml(tmp.path(), "code-line-length = 120\n");
+    write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+
+    let (config, precedence) = load_collecting_precedence(tmp.path());
+
+    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+    assert_eq!(
+        precedence,
+        [(ConfigForm::ProseToml, ConfigForm::PyprojectTable)]
+    );
+}
+
+#[test]
 fn load_reads_dotconfig_prose_toml() {
     let tmp = TempDir::new().expect("tempdir");
     write_dotconfig_prose_toml(tmp.path(), "code-line-length = 120\n");
@@ -221,6 +221,25 @@ fn load_reads_pure_prose_toml() {
     let config = Config::load(tmp.path()).expect("loads");
 
     assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+}
+
+#[test]
+fn load_shadows_both_lower_forms_when_all_present() {
+    let tmp = TempDir::new().expect("tempdir");
+    write_prose_toml(tmp.path(), "code-line-length = 120\n");
+    write_dotconfig_prose_toml(tmp.path(), "code-line-length = 100\n");
+    write_pyproject(tmp.path(), "[tool.prose]\ncode-line-length = 80\n");
+
+    let (config, precedence) = load_collecting_precedence(tmp.path());
+
+    assert_eq!(config.code_line_length, NonZeroUsize::new(120));
+    assert_eq!(
+        precedence,
+        [
+            (ConfigForm::ProseToml, ConfigForm::DotConfigProseToml),
+            (ConfigForm::ProseToml, ConfigForm::PyprojectTable),
+        ]
+    );
 }
 
 #[test]

--- a/crate/src/config/mod.rs
+++ b/crate/src/config/mod.rs
@@ -35,6 +35,7 @@ mod source;
 
 pub(crate) use de::deserialize_rule;
 use de::{deserialize_import_line_length, deserialize_prose};
+pub(crate) use load::config_rel_paths;
 use load::{ConfigNotice, emit_notice, prose_table_from_str, walk_prose_table};
 pub use schema::*;
 pub(crate) use source::ConfigSource;

--- a/crate/src/config/mod.rs
+++ b/crate/src/config/mod.rs
@@ -40,8 +40,9 @@ use load::{ConfigNotice, emit_notice, prose_table_from_str, walk_prose_table};
 pub use schema::*;
 pub(crate) use source::ConfigSource;
 
-/// The resolved `prose` configuration, read from a `prose.toml` root
-/// or a `pyproject.toml` `[tool.prose]` table.
+/// The resolved `prose` configuration, read from a `prose.toml` or
+/// `.config/prose.toml` document root, or a `pyproject.toml`
+/// `[tool.prose]` table.
 ///
 /// `code_line_length` defaults to `Some(88)`. `docstring_line_length`
 /// defaults to `Some(76)`. `import_line_length` defaults to `Some(120)`,

--- a/crate/src/config/mod.rs
+++ b/crate/src/config/mod.rs
@@ -1,10 +1,11 @@
-//! Resolves `prose` configuration from `prose.toml` or the
-//! `[tool.prose]` table of `pyproject.toml`.
+//! Resolves `prose` configuration from `prose.toml`, `.config/prose.toml`,
+//! or the `[tool.prose]` table of `pyproject.toml`.
 //!
 //! `Config::load` walks upward from a starting path toward the
-//! filesystem root. In each directory a `prose.toml` outranks a
-//! `pyproject.toml`, and the nearest directory carrying either wins.
-//! A `prose.toml` holds the config at its document root, whereas a
+//! filesystem root. In each directory `prose.toml` outranks
+//! `.config/prose.toml`, which outranks a `pyproject.toml`, and the
+//! nearest directory carrying any of them wins. A `prose.toml` or
+//! `.config/prose.toml` holds the config at its document root, whereas a
 //! `pyproject.toml` nests it under `[tool.prose]`. Reaching the root
 //! without a match resolves to full defaults, so prose works on a
 //! fresh project with no configuration step.
@@ -37,14 +38,6 @@ use de::{deserialize_import_line_length, deserialize_prose};
 use load::{ConfigNotice, emit_notice, prose_table_from_str, walk_prose_table};
 pub use schema::*;
 pub(crate) use source::ConfigSource;
-
-/// Filename of the dedicated config, parsed with its keys at the
-/// document root.
-const PROSE_TOML: &str = "prose.toml";
-
-/// Filename of the shared manifest, parsed under its `[tool.prose]`
-/// table.
-const PYPROJECT_TOML: &str = "pyproject.toml";
 
 /// The resolved `prose` configuration, read from a `prose.toml` root
 /// or a `pyproject.toml` `[tool.prose]` table.
@@ -112,10 +105,11 @@ impl Config {
     }
 
     /// Walks upward from `from`, returning the config from the nearest
-    /// directory that carries a `prose.toml` or a `pyproject.toml` with
-    /// a `[tool.prose]` table, or `Config::default()` if neither exists
-    /// on the chain. A `prose.toml` outranks a same-directory
-    /// `pyproject.toml`.
+    /// directory that carries a `prose.toml`, a `.config/prose.toml`, or
+    /// a `pyproject.toml` with a `[tool.prose]` table, or
+    /// `Config::default()` if none exists on the chain. Within a directory
+    /// `prose.toml` outranks `.config/prose.toml`, which outranks the
+    /// `pyproject.toml` table.
     ///
     /// Unknown keys and the precedence outcome are logged to stderr and
     /// ignored, keeping the loader forward-compatible with rules added

--- a/crate/src/config/source.rs
+++ b/crate/src/config/source.rs
@@ -22,9 +22,9 @@ pub(crate) struct ConfigSource {
 }
 
 impl ConfigSource {
-    /// Walks `from`'s ancestors for the nearest `prose.toml` or
-    /// `pyproject.toml` carrying `[tool.prose]`, returning its source or
-    /// `None` when the chain holds none.
+    /// Walks `from`'s ancestors for the nearest `prose.toml`,
+    /// `.config/prose.toml`, or `pyproject.toml` carrying `[tool.prose]`,
+    /// returning its source or `None` when the chain holds none.
     ///
     /// # Errors
     ///

--- a/crate/src/server/dispatch/mod.rs
+++ b/crate/src/server/dispatch/mod.rs
@@ -396,7 +396,9 @@ mod tests {
                 GlobPattern::Relative(_) => unreachable!("prose registers string globs"),
             })
             .collect();
+        assert!(globs.contains(&"**/prose.toml".to_owned()));
         assert!(globs.contains(&"**/.config/prose.toml".to_owned()));
+        assert!(globs.contains(&"**/pyproject.toml".to_owned()));
         client
             .sender
             .send(Message::Response(Response::new_ok(

--- a/crate/src/server/dispatch/mod.rs
+++ b/crate/src/server/dispatch/mod.rs
@@ -12,6 +12,7 @@ use lsp_types::{
 use ruff_source_file::PositionEncoding;
 
 use super::{capabilities, config_cache::ConfigCache, documents::DocumentStore};
+use crate::config::config_rel_paths;
 
 mod notifications;
 mod requests;
@@ -103,9 +104,9 @@ fn main_loop(
 }
 
 /// Registers a `workspace/didChangeWatchedFiles` watcher for prose's config
-/// files when the client supports dynamic registration, so a `pyproject.toml`
-/// or `prose.toml` edit refreshes every open buffer. Clients without dynamic
-/// registration still pick up config changes on the next edit.
+/// files when the client supports dynamic registration, so editing any of
+/// them refreshes every open buffer. Clients without dynamic registration
+/// still pick up config changes on the next edit.
 fn register_config_watchers(
     connection: &Connection,
     capabilities: &ClientCapabilities,
@@ -120,10 +121,10 @@ fn register_config_watchers(
         return Ok(false);
     }
     let options = DidChangeWatchedFilesRegistrationOptions {
-        watchers: ["**/pyproject.toml", "**/prose.toml"]
+        watchers: config_rel_paths()
             .into_iter()
-            .map(|glob| FileSystemWatcher {
-                glob_pattern: GlobPattern::String(glob.to_owned()),
+            .map(|path| FileSystemWatcher {
+                glob_pattern: GlobPattern::String(format!("**/{path}")),
                 kind: None,
             })
             .collect(),
@@ -378,6 +379,24 @@ mod tests {
             panic!("expected registerCapability request");
         };
         assert_eq!(registration.method, "client/registerCapability");
+        let params: RegistrationParams = serde_json::from_value(registration.params.clone())
+            .expect("decodes registration params");
+        let options: DidChangeWatchedFilesRegistrationOptions = serde_json::from_value(
+            params.registrations[0]
+                .register_options
+                .clone()
+                .expect("watcher options"),
+        )
+        .expect("decodes watcher options");
+        let globs: Vec<String> = options
+            .watchers
+            .into_iter()
+            .map(|watcher| match watcher.glob_pattern {
+                GlobPattern::String(glob) => glob,
+                GlobPattern::Relative(_) => unreachable!("prose registers string globs"),
+            })
+            .collect();
+        assert!(globs.contains(&"**/.config/prose.toml".to_owned()));
         client
             .sender
             .send(Message::Response(Response::new_ok(

--- a/crate/src/testing.rs
+++ b/crate/src/testing.rs
@@ -98,6 +98,12 @@ pub(crate) fn uri(s: &str) -> Uri {
     Uri::from_str(s).expect("valid uri")
 }
 
+pub(crate) fn write_dotconfig_prose_toml(dir: &Path, contents: &str) {
+    let config_dir = dir.join(".config");
+    std::fs::create_dir_all(&config_dir).expect(".config dir creates");
+    std::fs::write(config_dir.join("prose.toml"), contents).expect(".config/prose.toml writes");
+}
+
 pub(crate) fn write_prose_toml(dir: &Path, contents: &str) {
     std::fs::write(dir.join("prose.toml"), contents).expect("prose.toml writes");
 }

--- a/site/.vitepress/data/landing.data.ts
+++ b/site/.vitepress/data/landing.data.ts
@@ -57,7 +57,7 @@ const STEP_SOURCES: readonly StepSource[] = [
     title    : 'Install'
   },
   {
-    body     : 'Drop a `prose.toml` at the project root, or a `[tool.prose]` table in `pyproject.toml`. The defaults already work.',
+    body     : 'Drop a `prose.toml` at the project root, a `.config/prose.toml`, or a `[tool.prose]` table in `pyproject.toml`. The defaults already work.',
     code     : 'target-version = "3.13"',
     language : 'toml',
     number   : '02',

--- a/site/integrations/github-actions.md
+++ b/site/integrations/github-actions.md
@@ -67,7 +67,7 @@ Repeat runs hit the user-level [**cache**](/reference/cache) on by default, but 
 - uses: actions/cache@v4
   with:
     path: ~/.cache/prose
-    key: prose-${{ runner.os }}-${{ hashFiles('prose.toml', 'pyproject.toml') }}
+    key: prose-${{ runner.os }}-${{ hashFiles('prose.toml', '.config/prose.toml', 'pyproject.toml') }}
 - run: prose check .
 ```
 

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -1,8 +1,8 @@
 # Configuration
 
-*Prose* loads its configuration from a `prose.toml` file or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically.
+*Prose* loads its configuration from a `prose.toml` file, a `.config/prose.toml`, or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically.
 
-A `prose.toml` keeps its keys at the document root, the form this page shows throughout. A `pyproject.toml` carries the same keys under a `[tool.prose]` prefix so the manifest can house other tools too, leaving every key below a `[tool.prose.<…>]` equivalent for projects that prefer one file.
+A `prose.toml` keeps its keys at the document root, the form this page shows throughout, and a `.config/prose.toml` reads the same way for a project that keeps its tool config under a `.config/` directory. A `pyproject.toml` carries the same keys under a `[tool.prose]` prefix so the manifest can house other tools too, leaving every key below a `[tool.prose.<…>]` equivalent for projects that prefer one file.
 
 `target-version` carries the bare `major.minor` form *(`"3.13"`, `"3.14"`)* used by `mypy`'s `python_version` setting, with rules whose safety depends on the runtime reading the field directly. The docstring-budget duality *(`code-line-length` for Title-case-headed structured sections, `docstring-line-length` for description prose)* lets a project keep code-shaped tables wide while keeping description prose at a comfortable reading measure, and `docstring-structured-policy` collapses both to a single budget when a project prefers a uniform width.
 
@@ -21,9 +21,9 @@ A bare `false` disables a rule, an inline table sets its facets while leaving th
 
 ## Where *Prose* Looks
 
-*Prose* walks upward from each input file's own directory toward the filesystem root, so a file answers to its own project's config even when one invocation names files across several projects. Stdin input walks from the working directory, the one input with no path of its own. In each directory a `prose.toml` outranks a `pyproject.toml`, and the nearest directory carrying either wins, in that *Prose* reads only that one file and never merges across matches up the tree. A `pyproject.toml` lacking a `[tool.prose]` table is passed over, leaving the walk to continue upward. A standalone script the walk never resolves to a project reads its own `[tool.prose]` from a leading PEP 723 `# /// script` block, the one configuration home a single-file script has, whereas a script under a project ignores its block and answers to the project. When neither an ancestor nor a block carries config, every default applies as if the config were empty.
+*Prose* walks upward from each input file's own directory toward the filesystem root, so a file answers to its own project's config even when one invocation names files across several projects. Stdin input walks from the working directory, the one input with no path of its own. In each directory a `prose.toml` outranks a `.config/prose.toml`, which outranks a `pyproject.toml`, and the nearest directory carrying any of them wins, in that *Prose* reads only that one file and never merges across matches up the tree. A `pyproject.toml` lacking a `[tool.prose]` table is passed over, leaving the walk to continue upward. A standalone script the walk never resolves to a project reads its own `[tool.prose]` from a leading PEP 723 `# /// script` block, the one configuration home a single-file script has, whereas a script under a project ignores its block and answers to the project. When neither an ancestor nor a block carries config, every default applies as if the config were empty.
 
-When a `prose.toml` and a `pyproject.toml` `[tool.prose]` table share a directory, the `prose.toml` wins and *Prose* notes the precedence to stderr, so the file that took effect is never ambiguous.
+When more than one of these forms share a directory, the higher-precedence one wins and *Prose* notes the precedence to stderr, so the file that took effect is never ambiguous.
 
 ## Top-Level Keys
 

--- a/site/reference/index.md
+++ b/site/reference/index.md
@@ -14,7 +14,7 @@ Every CLI flag, configuration key, exit code, output format, subcommand, and sup
 
 - [**Cache**](/reference/cache) covers the user-level cache, the `[cache]` facets, the `--no-cache` flag, and the `prose cache clean` subcommand.
 - [**CLI**](/reference/cli) covers every flag, its precedence, and the subcommand it belongs to.
-- [**Configuration**](/reference/configuration) covers the `prose.toml` and `pyproject.toml` config files and per-rule facets.
+- [**Configuration**](/reference/configuration) covers the `prose.toml`, `.config/prose.toml`, and `pyproject.toml` config files and per-rule facets.
 - [**Exit Codes**](/reference/exit-codes) covers the five-code contract CI gates compile against.
 - [**Output Formats**](/reference/output-formats) covers `text`, `json`, `github`, and `sarif` shapes.
 - [**Pipeline Order**](/reference/pipeline-order) covers the deterministic order rules fire in, with rationale per rule.


### PR DESCRIPTION
### 🪻 Quick Summary

Adds `.config/prose.toml` as a third config-discovery form, read in full the way a root `prose.toml` is, so a project can keep its *Prose* config under the conventional `.config/` directory beside its other per-tool files. The ancestor walk now recognizes three forms per directory, a `prose.toml` outranking a `.config/prose.toml` outranking a `pyproject.toml` `[tool.prose]` table, with the nearest ancestor still winning across directories and *Prose* reading only the one form that took effect. Reading the new form in full reuses the existing reader, unknown-key warnings, and schema unchanged, so only discovery and precedence needed defining. The precedence notice that fired when a `prose.toml` shadowed a same-directory `[tool.prose]` table generalizes to name whichever higher form shadows a lower one, and the LSP config-file watcher derives its globs from the same form set, so editing any of the three refreshes open buffers.

---

### 🗞️ Key Changes

- Adds a `.config/prose.toml` form to the ancestor walk, ranked between `prose.toml` and the `pyproject.toml` `[tool.prose]` table, modeled alongside the other two as a `ConfigForm` enum that owns each form's relative path, TOML read, and precedence label. Each visited directory checks all three, a `.config/prose.toml` and a `prose.toml` holding their config at the document root whereas a `pyproject.toml` nests it under `[tool.prose]`.

- Generalizes the precedence notice from the fixed prose-toml-shadows-pyproject case to name whichever higher form shadowed a lower one, so a directory holding two or three forms side by side reports each shadow with the form that took effect.

- Derives the LSP config-file watcher globs from the discovery forms through a new `config_rel_paths`, replacing a hardcoded `["**/pyproject.toml", "**/prose.toml"]` list, so editing a `.config/prose.toml` refreshes open buffers and the watched set stays in lockstep with what the walk discovers.

- Pins discovery, all three pairwise precedence rungs, the all-three-forms multi-shadow case, and a `.config/prose.toml` parse-error path with inline tests, and asserts the watcher registers a glob for every form.

- Documents the form and its rung in the configuration reference's discovery section and reference index, the README config-file pointer, the landing onboarding card, and the CI cache-key `hashFiles` example.

---

### 🧵 Related Issues

- Closes #342