### PR TITLE
[358] Finalize `0.6.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "../README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.96"
-version      = "0.5.0"
+version      = "0.6.0"
 
 [dependencies]
 annotate-snippets  = "=0.12.16"


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes the sixth *Prose* release. Bumps `crate/Cargo.toml` from `0.5.0` to `0.6.0` and regenerates `Cargo.lock` against the new version. The `0.6` cycle settles the config-key naming convention, splits `group-imports` and `band-constants` out of `alphabetize`, lifts the shape rules into a `layout` family, adds per-facet controls to `alphabetize` and `collection-layout`, unifies the inline caps into a `max-<element>` family, brings `.ipynb` notebooks under formatting, and relocates the crate into `crate/`.

---

### 🗞️ Key Changes

- Bumps `crate/Cargo.toml` from `0.5.0` to `0.6.0` and regenerates `Cargo.lock` against the new version

---

### 🧵 Related Issues

- Closes #358
