### PR TITLE
[361] Land the shared build-time render and token primitives

### DIFF
--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -1,11 +1,13 @@
-// @ts-check
 import { defineConfig }        from 'astro/config';
 import starlight               from '@astrojs/starlight';
 import starlightLinksValidator from 'starlight-links-validator';
 
+import { markdownConfig } from './src/lib/markdown/config';
+
 export default defineConfig({
-  site         : 'https://prose.fyi',
-  integrations : [
+  site     : 'https://prose.fyi',
+  markdown : markdownConfig,
+  integrations: [
     starlight({
       title   : 'Prose',
       plugins : [starlightLinksValidator()],

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "prose-site",
       "dependencies": {
+        "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/starlight": "0.41.1",
         "astro": "7.0.3",
       },

--- a/site/package.json
+++ b/site/package.json
@@ -4,8 +4,9 @@
   "private" : true,
 
   "dependencies": {
-    "@astrojs/starlight" : "0.41.1",
-    "astro"              : "7.0.3"
+    "@astrojs/markdown-remark" : "7.2.0",
+    "@astrojs/starlight"       : "0.41.1",
+    "astro"                    : "7.0.3"
   },
 
   "devDependencies": {

--- a/site/src/lib/markdown/config.ts
+++ b/site/src/lib/markdown/config.ts
@@ -1,0 +1,10 @@
+import type { AstroMarkdownOptions } from '@astrojs/markdown-remark'
+
+import { SHIKI_THEMES } from '../shared/constants'
+
+// The one Shiki pipeline both render paths share. `astro.config` reads it as
+// the site `markdown` config, so the loader-context `renderMarkdown` and the
+// standalone processor highlight with the same dual-theme set.
+export const markdownConfig: AstroMarkdownOptions = {
+  shikiConfig: { themes: SHIKI_THEMES },
+}

--- a/site/src/lib/markdown/render.ts
+++ b/site/src/lib/markdown/render.ts
@@ -1,0 +1,30 @@
+import { createMarkdownProcessor, type MarkdownRenderer } from '@astrojs/markdown-remark'
+
+import { markdownConfig } from './config'
+
+// The processor is the non-loader render path. Reads inside a Content Layer
+// loader take the loader context's own `renderMarkdown` instead, then pass its
+// `html` through `stripParagraph` for the inline shape.
+let cachedProcessor: Promise<MarkdownRenderer> | null = null
+
+function processor(): Promise<MarkdownRenderer> {
+  return (cachedProcessor ??= createMarkdownProcessor(markdownConfig))
+}
+
+export async function renderMarkdown(markdown: string): Promise<string> {
+  const { code } = await (await processor()).render(markdown)
+  return code
+}
+
+export async function renderInline(markdown: string): Promise<string> {
+  return stripParagraph(await renderMarkdown(markdown))
+}
+
+// Drops the single paragraph the block renderer wraps an inline field in,
+// leaving content that is not one wrapping paragraph untouched.
+export function stripParagraph(html: string): string {
+  const trimmed = html.trim()
+  return trimmed.startsWith('<p>') && trimmed.endsWith('</p>')
+    ? trimmed.slice(3, -4)
+    : trimmed
+}

--- a/site/src/lib/shared/constants.ts
+++ b/site/src/lib/shared/constants.ts
@@ -1,0 +1,1 @@
+export const SHIKI_THEMES = { dark: 'github-dark', light: 'github-light' } as const

--- a/site/src/lib/tokens/resolve.ts
+++ b/site/src/lib/tokens/resolve.ts
@@ -1,8 +1,6 @@
-import fs   from 'node:fs'
-import path from 'node:path'
+import fs from 'node:fs'
 
-const TOKENS_CSS = path.join(import.meta.dirname, '..', '..', 'styles', 'tokens.css')
-const css        = fs.readFileSync(TOKENS_CSS, 'utf8')
+const css = fs.readFileSync(new URL('../../styles/tokens.css', import.meta.url), 'utf8')
 
 function declared(name: string): string {
   return css.match(new RegExp(`--${name}\\s*:\\s*([^;]+);`))?.[1].trim() ?? ''
@@ -12,6 +10,7 @@ function declared(name: string): string {
 // time, following one `var()` alias. A `color-mix()` value resolves to its
 // first referenced token, leaving the concrete blend to the color consumer.
 export function resolveToken(token: string): string {
-  const alias = declared(token).match(/var\(--(.+?)\)/)?.[1]
-  return alias ? declared(alias) : declared(token)
+  const value = declared(token)
+  const alias = value.match(/var\(--(.+?)\)/)?.[1]
+  return alias ? declared(alias) : value
 }

--- a/site/src/lib/tokens/resolve.ts
+++ b/site/src/lib/tokens/resolve.ts
@@ -1,6 +1,4 @@
-import fs from 'node:fs'
-
-const css = fs.readFileSync(new URL('../../styles/tokens.css', import.meta.url), 'utf8')
+import css from '../../styles/tokens.css?raw'
 
 function declared(name: string): string {
   return css.match(new RegExp(`--${name}\\s*:\\s*([^;]+);`))?.[1].trim() ?? ''

--- a/site/src/lib/tokens/resolve.ts
+++ b/site/src/lib/tokens/resolve.ts
@@ -1,0 +1,17 @@
+import fs   from 'node:fs'
+import path from 'node:path'
+
+const TOKENS_CSS = path.join(import.meta.dirname, '..', '..', 'styles', 'tokens.css')
+const css        = fs.readFileSync(TOKENS_CSS, 'utf8')
+
+function declared(name: string): string {
+  return css.match(new RegExp(`--${name}\\s*:\\s*([^;]+);`))?.[1].trim() ?? ''
+}
+
+// Reads a `--prose-*` custom property's value from the token source at build
+// time, following one `var()` alias. A `color-mix()` value resolves to its
+// first referenced token, leaving the concrete blend to the color consumer.
+export function resolveToken(token: string): string {
+  const alias = declared(token).match(/var\(--(.+?)\)/)?.[1]
+  return alias ? declared(alias) : declared(token)
+}

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -1,0 +1,45 @@
+:root {
+  --prose-font-display           : 'Fraunces Variable', Georgia, "Times New Roman", serif;
+  --prose-font-base              : 'Lora Variable', Georgia, "Times New Roman", serif;
+  --prose-font-mono              : 'JetBrains Mono Variable', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  --prose-c-apricot              : #e8876f;
+  --prose-c-casper               : #adbdcd;
+  --prose-c-celadon              : #8cc5a3;
+  --prose-c-chambray             : #7db3e0;
+  --prose-c-champagne            : #f0e9bc;
+  --prose-c-dexter               : #6db0b5;
+  --prose-c-eureka               : #e8c840;
+  --prose-c-grams-hair           : #f6f8fa;
+  --prose-c-heath                : #c08597;
+  --prose-c-oat                  : #cdbda5;
+  --prose-c-rainee               : #b8c8a8;
+  --prose-c-toronto              : #5069ad;
+  --prose-c-whiskey              : #d4a574;
+  --prose-c-woodsmoke            : #17171b;
+
+  --prose-c-ube                  : #8a80cb;
+  --prose-c-ube-mid              : color-mix(in oklch, var(--prose-c-ube), white 18%);
+  --prose-c-ube-pale             : color-mix(in oklch, var(--prose-c-ube), white 36%);
+  --prose-c-ube-deep             : color-mix(in oklch, var(--prose-c-ube), black 22%);
+  --prose-c-ube-night            : color-mix(in oklch, var(--prose-c-ube), black 45%);
+
+  --prose-c-accent               : var(--prose-c-chambray);
+  --prose-c-error                : var(--prose-c-apricot);
+  --prose-c-warning              : var(--prose-c-eureka);
+  --prose-link-hover             : var(--prose-c-ube-deep);
+
+  --prose-c-family-alignment     : var(--prose-c-eureka);
+  --prose-c-family-cli           : var(--prose-c-ube-night);
+  --prose-c-family-docs          : var(--prose-c-celadon);
+  --prose-c-family-engine        : var(--prose-c-ube);
+  --prose-c-family-formatting    : var(--prose-c-heath);
+  --prose-c-family-layout        : var(--prose-c-toronto);
+  --prose-c-family-lint          : var(--prose-c-apricot);
+  --prose-c-family-ordering      : var(--prose-c-chambray);
+
+  --prose-c-section-integrations : var(--prose-c-rainee);
+  --prose-c-section-primitives   : var(--prose-c-dexter);
+  --prose-c-section-reference    : var(--prose-c-casper);
+  --prose-c-section-usage        : var(--prose-c-oat);
+}


### PR DESCRIPTION
### 🪻 Quick Summary

Establishes the two build-time primitives the rest of the migration cycle reads, landing both early so the content collections, the markdown engine, and the SEO and theme surfaces each read a primitive that no longer moves beneath them. The first is a markdown renderer over `@astrojs/markdown-remark` exposing `renderMarkdown` and `renderInline` on a shared Shiki pipeline, and the second a token source that resolves the `--prose-*` custom properties from `tokens.css` at build time.

---

### 🗞️ Key Changes

- Adds the build-time markdown renderer in `site/src/lib/markdown/render.ts` over `@astrojs/markdown-remark`'s `createMarkdownProcessor`, the non-loader render path, exposing `renderMarkdown` for fenced code and `renderInline` for inline fields, the latter through `stripParagraph` so the single wrapping paragraph the block renderer adds is dropped.

- Shares one `markdownConfig` across `astro.config.ts` and the standalone processor, declared in `site/src/lib/markdown/config.ts` on the `SHIKI_THEMES` pair, so the loader-context renderer and the build-time processor highlight against the same dual-theme set.

- Adds the `--prose-*` color-and-type token source in `site/src/styles/tokens.css`, read at build time by `resolveToken` in `site/src/lib/tokens/resolve.ts`, which follows one `var()` alias and resolves a `color-mix()` value to its first referenced token, reading the source through Vite's `?raw` import so the bundler tracks `tokens.css` as a module dependency.

- Hoists `@astrojs/markdown-remark` to a direct `site` dependency, the sanctioned non-loader render API, and converts `astro.config` from `.mjs` to `.ts` so it imports the shared `markdownConfig`.

---

### 🧵 Related Issues

- Closes #361