### PR TITLE
[362] Define the Astro content collections and cross-record integrity hook

### DIFF
--- a/site/bun.lock
+++ b/site/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/markdown-remark": "7.2.0",
         "@astrojs/starlight": "0.41.1",
         "astro": "7.0.3",
+        "smol-toml": "1.7.0",
       },
       "devDependencies": {
         "@astrojs/check": "0.9.9",

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@astrojs/markdown-remark" : "7.2.0",
     "@astrojs/starlight"       : "0.41.1",
-    "astro"                    : "7.0.3"
+    "astro"                    : "7.0.3",
+    "smol-toml"                : "1.7.0"
   },
 
   "devDependencies": {

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,7 +1,31 @@
-import { defineCollection } from 'astro:content';
-import { docsLoader }       from '@astrojs/starlight/loaders';
-import { docsSchema }       from '@astrojs/starlight/schema';
+import { defineCollection } from 'astro:content'
+import { file, glob }       from 'astro/loaders'
+import { docsSchema }       from '@astrojs/starlight/schema'
+
+import { docsLoaderWithIntegrity } from './lib/content/docs-loader'
+import { fixturesLoader }          from './lib/content/fixtures'
+import * as schema                 from './lib/content/schemas'
+
+const data = (name: string): string => `src/data/${name}.yaml`
+
+const compositionLoader = glob({
+  base       : '../crate/tests/fixtures/composition',
+  generateId : ({ entry }) => entry.replace(/\/config\.toml$/, ''),
+  pattern    : '*/config.toml'
+})
 
 export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
-};
+  composition       : defineCollection({ loader: compositionLoader,                  schema: schema.composition }),
+  directives        : defineCollection({ loader: file(data('directives')),           schema: schema.directive }),
+  docs              : defineCollection({ loader: docsLoaderWithIntegrity(),          schema: docsSchema({ extend: schema.docsExtension }) }),
+  editorConfigs     : defineCollection({ loader: file(data('editor-configs')),       schema: schema.editorConfig }),
+  exitCodes         : defineCollection({ loader: file(data('exit-codes')),           schema: schema.exitCode }),
+  fixtures          : defineCollection({ loader: fixturesLoader(),                   schema: schema.fixture }),
+  glossary          : defineCollection({ loader: file(data('glossary')),             schema: schema.glossary }),
+  landingSurfaces   : defineCollection({ loader: file(data('landing-surfaces')),     schema: schema.landingSurface }),
+  landingWorkflow   : defineCollection({ loader: file(data('landing-workflow')),     schema: schema.landingStep }),
+  ruleConfigPresets : defineCollection({ loader: file(data('rule-config-presets')),  schema: schema.ruleConfigPreset }),
+  shellCompletions  : defineCollection({ loader: file(data('shell-completions')),    schema: schema.shellCompletion }),
+  tokenIndex        : defineCollection({ loader: file(data('token-index')),          schema: schema.tokenIndex }),
+  tools             : defineCollection({ loader: file(data('tools')),                schema: schema.tool })
+}

--- a/site/src/content/docs/integrations/editor.md
+++ b/site/src/content/docs/integrations/editor.md
@@ -1,0 +1,5 @@
+---
+title: Editor
+---
+
+*Prose* reaches an editor through a language server or a shellout. The **`prose server`** language server is the richest, giving format-on-save and live diagnostics over the protocol an editor already speaks. For editors without a language-server client, `prose format ` rewrites on save and `prose check --output-format json --stdin` emits one **Ruff-shaped** diagnostic record per line. The shellout paths read from disk or stdin, where the server tracks the editor's live buffer directly.

--- a/site/src/content/docs/integrations/github-actions.md
+++ b/site/src/content/docs/integrations/github-actions.md
@@ -1,0 +1,5 @@
+---
+title: GitHub Actions
+---
+
+*Prose* compiles cleanly against the standard `ubuntu-latest` runner. The install step fetches the wheel through , the check step runs `prose check`, and the exit code drives the gate. The shapes below trade verbosity for richer surfacing on the PR diff: minimal check, inline workflow-command annotations, and SARIF upload for **Code Scanning**.

--- a/site/src/content/docs/integrations/index.md
+++ b/site/src/content/docs/integrations/index.md
@@ -1,0 +1,5 @@
+---
+title: Integrations
+---
+
+Every integration on the pages below is a thin wrapper around `prose format` or `prose check`, wired into a different boundary in the development loop. The editor wraps the save event, the pre-commit hook wraps the staging boundary, the CI workflow wraps the merge gate. Each layer runs the same CLI against the same [`[tool.prose]`](/reference/configuration) table and surfaces the same exit codes, so adopting a second integration is configuration rather than a new mental model.

--- a/site/src/content/docs/integrations/pre-commit.md
+++ b/site/src/content/docs/integrations/pre-commit.md
@@ -1,0 +1,5 @@
+---
+title: Pre-Commit
+---
+
+Add a `local` hook to your `.pre-commit-config.yaml`:

--- a/site/src/content/docs/integrations/ruff.md
+++ b/site/src/content/docs/integrations/ruff.md
@@ -1,0 +1,5 @@
+---
+title: Ruff
+---
+
+ruff format && prose format

--- a/site/src/content/docs/integrations/shell-completions.md
+++ b/site/src/content/docs/integrations/shell-completions.md
@@ -1,0 +1,5 @@
+---
+title: Shell Completions
+---
+
+`prose completions ` prints a shell-completion script to stdout, ready to redirect into the shell's completion search path. Each supported shell carries the canonical install path it expects, meaning the install reduces to a single redirect on every supported platform.

--- a/site/src/content/docs/primitives/aligner.md
+++ b/site/src/content/docs/primitives/aligner.md
@@ -1,0 +1,18 @@
+---
+title: Aligner
+consumedBy:
+  - align-colons
+  - align-comparisons
+  - align-equals
+  - align-imports
+  - align-match-case
+consumes:
+  - edit
+  - source
+layer: orchestration
+stability: internal
+summary: Computes padding widths and emits the alignment edits every alignment rule consumes.
+tagline: shared alignment math
+---
+
+Computes padding widths and emits the alignment edits every alignment rule consumes.

--- a/site/src/content/docs/primitives/binding-analysis.md
+++ b/site/src/content/docs/primitives/binding-analysis.md
@@ -1,0 +1,14 @@
+---
+title: BindingAnalysis
+consumedBy:
+  - single-use-variables
+  - unused-future-annotations
+consumes:
+  - source
+layer: analysis
+stability: internal
+summary: Per-source table indexing every write and read of every name in every lexical scope.
+tagline: name binding index
+---
+
+Per-source table indexing every write and read of every name in every lexical scope.

--- a/site/src/content/docs/primitives/cache.md
+++ b/site/src/content/docs/primitives/cache.md
@@ -1,0 +1,13 @@
+---
+title: Cache
+consumedBy:
+  - cli
+consumes:
+  - source
+layer: analysis
+stability: internal
+summary: User-level on-disk cache keyed on `(source ++ config ++ rules ++ version)`, collapsing repeat runs to a stat plus a hash plus a deserialize.
+tagline: content-addressed result cache
+---
+
+User-level on-disk cache keyed on `(source ++ config ++ rules ++ version)`, collapsing repeat runs to a stat plus a hash plus a deserialize.

--- a/site/src/content/docs/primitives/colon-targets.md
+++ b/site/src/content/docs/primitives/colon-targets.md
@@ -1,0 +1,15 @@
+---
+title: ColonTargets
+consumedBy:
+  - align-colons
+  - strip-align-padding
+consumes:
+  - aligner
+  - source
+layer: analysis
+stability: internal
+summary: Walks the five `:` contexts in Python and emits alignment members for each.
+tagline: five-context colon walker
+---
+
+Walks the five `:` contexts in Python and emits alignment members for each.

--- a/site/src/content/docs/primitives/docstring.md
+++ b/site/src/content/docs/primitives/docstring.md
@@ -1,0 +1,16 @@
+---
+title: Docstring
+consumedBy:
+  - docstring-wrap
+  - docstring-frame
+  - docstring-expand
+consumes:
+  - edit
+  - source
+layer: analysis
+stability: internal
+summary: PEP 257 walker reaching every module, class, and function docstring in source order.
+tagline: PEP 257 docstring walker
+---
+
+PEP 257 walker reaching every module, class, and function docstring in source order.

--- a/site/src/content/docs/primitives/edit.md
+++ b/site/src/content/docs/primitives/edit.md
@@ -1,0 +1,16 @@
+---
+title: Edit
+consumedBy:
+  - aligner
+  - docstring
+  - orderer
+  - pipeline
+consumes:
+  - source
+layer: base
+stability: internal
+summary: The `Edit { range, content }` unit every rule emits and the pipeline applies.
+tagline: rewrite unit
+---
+
+The `Edit { range, content }` unit every rule emits and the pipeline applies.

--- a/site/src/content/docs/primitives/index.md
+++ b/site/src/content/docs/primitives/index.md
@@ -1,0 +1,5 @@
+---
+title: Primitives
+---
+
+*Prose* is built from a small set of shared primitives that each carry a single responsibility. A rule reads source through source, walks the AST through one of the shared walkers, emits edit lists, and surfaces diagnostics through the pipeline. Every rule in the catalog composes from the named pieces below, so a new rule lands as a thin walker plus the per-rule decision rather than a from-scratch implementation. The padding math, the comment-attachment, and the conflict discipline live once and downstream rules consume them.

--- a/site/src/content/docs/primitives/orderer.md
+++ b/site/src/content/docs/primitives/orderer.md
@@ -1,0 +1,14 @@
+---
+title: Orderer
+consumedBy:
+  - alphabetize
+consumes:
+  - edit
+  - source
+layer: orchestration
+stability: internal
+summary: Reorders sibling AST nodes by a classifier while preserving attached comments.
+tagline: sibling reorder helper
+---
+
+Reorders sibling AST nodes by a classifier while preserving attached comments.

--- a/site/src/content/docs/primitives/pipeline.md
+++ b/site/src/content/docs/primitives/pipeline.md
@@ -1,0 +1,16 @@
+---
+title: Pipeline
+consumedBy:
+  - cli
+consumes:
+  - edit
+  - rule-id
+  - source
+  - suppression-map
+layer: orchestration
+stability: public
+summary: Runs registered rules in deterministic order, reparses between rules, returns the final source.
+tagline: deterministic rule runner
+---
+
+Runs registered rules in deterministic order, reparses between rules, returns the final source.

--- a/site/src/content/docs/primitives/rule-id.md
+++ b/site/src/content/docs/primitives/rule-id.md
@@ -1,0 +1,13 @@
+---
+title: RuleId
+consumedBy:
+  - pipeline
+  - suppression-map
+consumes: []
+layer: base
+stability: public
+summary: Canonical kebab-case slug identifying each rule across CLI, config, suppressions, and diagnostics.
+tagline: canonical rule slug
+---
+
+Canonical kebab-case slug identifying each rule across CLI, config, suppressions, and diagnostics.

--- a/site/src/content/docs/primitives/source.md
+++ b/site/src/content/docs/primitives/source.md
@@ -1,0 +1,20 @@
+---
+title: Source
+consumedBy:
+  - aligner
+  - binding-analysis
+  - colon-targets
+  - docstring
+  - edit
+  - orderer
+  - pipeline
+  - suppression-map
+  - walker
+consumes: []
+layer: base
+stability: public
+summary: Owned wrapper bundling the original text, AST, tokens, line index, and supporting tables.
+tagline: parsed-text wrapper
+---
+
+Owned wrapper bundling the original text, AST, tokens, line index, and supporting tables.

--- a/site/src/content/docs/primitives/suppression-map.md
+++ b/site/src/content/docs/primitives/suppression-map.md
@@ -1,0 +1,14 @@
+---
+title: SuppressionMap
+consumedBy:
+  - pipeline
+consumes:
+  - rule-id
+  - source
+layer: analysis
+stability: internal
+summary: 'Per-source index of `# fmt: off` / `# fmt: skip` / `# prose: ignore[...]` directives.'
+tagline: directive index
+---
+
+Per-source index of `# fmt: off` / `# fmt: skip` / `# prose: ignore[...]` directives.

--- a/site/src/content/docs/primitives/walker.md
+++ b/site/src/content/docs/primitives/walker.md
@@ -1,0 +1,13 @@
+---
+title: Walker
+consumedBy:
+  - cli
+consumes:
+  - source
+layer: analysis
+stability: internal
+summary: Ignore-aware filesystem walker yielding every `.py` / `.pyi` / `.pyw` source and `.ipynb` notebook under given paths.
+tagline: ignore-aware path walker
+---
+
+Ignore-aware filesystem walker yielding every `.py` / `.pyi` / `.pyw` source and `.ipynb` notebook under given paths.

--- a/site/src/content/docs/reference/cache.md
+++ b/site/src/content/docs/reference/cache.md
@@ -1,0 +1,5 @@
+---
+title: Cache
+---
+
+*Prose* caches per-file pipeline output keyed on the source bytes, the configuration governing the file, the rules the run selects, and the *Prose* version. A repeat `prose check` or `prose format` against an unchanged file collapses to a stat, a hash, and a deserialize, since the cache hit re-emits diagnostics from the cached entry without entering the pipeline.

--- a/site/src/content/docs/reference/cli.md
+++ b/site/src/content/docs/reference/cli.md
@@ -1,0 +1,5 @@
+---
+title: CLI
+---
+
+The `prose` binary's subcommands each resolve a distinct workflow shape. `format` rewrites Python files in place, `check` reports violations without modifying anything, `server` speaks the language-server protocol to an editor, and `completions` emits a shell-completion script. `format` and `check` share the same path-handling, stdin, rule-filtering, and output-format surface, so a CI step that runs `prose check` and a developer that runs `prose format` see the same flag set with the same precedence.

--- a/site/src/content/docs/reference/configuration.md
+++ b/site/src/content/docs/reference/configuration.md
@@ -1,0 +1,5 @@
+---
+title: Configuration
+---
+
+*Prose* loads its configuration from a `prose.toml` file, a `.config/prose.toml`, or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically.

--- a/site/src/content/docs/reference/exit-codes.md
+++ b/site/src/content/docs/reference/exit-codes.md
@@ -1,0 +1,5 @@
+---
+title: Exit Codes
+---
+
+Every `prose check` and `prose format` invocation resolves into a discrete exit code that CI gates compile against. The codes are mutually exclusive at run time, in that when two outcomes apply, the higher number wins. A `format` run that auto-fixes a rule's diagnostics returns `0` once the rewrite lands *(the diagnostic was applied, not left pending)*, whereas a `check` run on the same source returns `1`.

--- a/site/src/content/docs/reference/glossary.md
+++ b/site/src/content/docs/reference/glossary.md
@@ -1,0 +1,5 @@
+---
+title: Glossary
+---
+
+

--- a/site/src/content/docs/reference/index.md
+++ b/site/src/content/docs/reference/index.md
@@ -1,0 +1,5 @@
+---
+title: Reference
+---
+
+Reference is the lookup surface for everything *Prose* exposes once a project is past the **Usage** chapters. Where Usage walks workflows and Integrations wraps them at boundaries, Reference answers shaped questions about flags, facets, codes, diagnostic shapes, suppression directives, and the deterministic order rules fire in.

--- a/site/src/content/docs/reference/output-formats.md
+++ b/site/src/content/docs/reference/output-formats.md
@@ -1,0 +1,5 @@
+---
+title: Output Formats
+---
+
+`--output-format` selects the diagnostic shape *Prose* emits, with named formats covering the common consumers. `text` is the human-readable default, rendering rustc-style snippets with carets and fix suggestions. `json` emits Ruff-shaped NDJSON for editor plugins and tooling, wherein the record shape mirrors what LSP-style diagnostic surfaces already consume. `github` emits workflow commands that  renders as inline annotations. `sarif` emits a **SARIF 2.1.0** run document for upload into **GitHub Code Scanning**, persisting findings across runs in the repository's Security tab.

--- a/site/src/content/docs/reference/pipeline-order.md
+++ b/site/src/content/docs/reference/pipeline-order.md
@@ -1,0 +1,5 @@
+---
+title: Pipeline Order
+---
+
+*Prose* runs each enabled rule in a deterministic order, reparsing the source between rules so every downstream rule reads a settled AST. The reparse is the discipline that makes the rule set composable, wherein no rule observes the half-applied state of another, leaving every pass free of cross-rule edit conflict by construction. The order itself is canonical, source-of-truth in `crate/src/rule.rs` *(the `register_rules!` macro block)*, and pedagogically valuable. A rule that depends on a settled token surface sits downstream of every rule that touches that surface, in that *(for example)* align-colons runs before docstring-wrap because the docstring wrap budget depends on the post-colon column the alignment rule sets.

--- a/site/src/content/docs/reference/suppression-directives.md
+++ b/site/src/content/docs/reference/suppression-directives.md
@@ -1,0 +1,5 @@
+---
+title: Suppression Directives
+---
+
+Directive shapes opt code out of *Prose*'s rewrites or lints at the file, block, line, and dict-literal scopes. The conceptual narrative for when to reach for suppression lives in the **Suppression** guide chapter. This page is the canonical index.

--- a/site/src/content/docs/rules/alignment/align-colons.md
+++ b/site/src/content/docs/rules/alignment/align-colons.md
@@ -1,0 +1,13 @@
+---
+title: align-colons
+caption: Aligns the `:` separator across dict literals, dataclass and Pydantic fields, function-signature annotations, and docstring `Args:` blocks.
+related:
+  - align-equals
+  - align-imports
+  - alphabetize
+  - collection-layout
+  - align-match-case
+  - strip-align-padding
+---
+
+Aligns the `:` separator across dict literals, dataclass and Pydantic fields, function-signature annotations, and docstring `Args:` blocks.

--- a/site/src/content/docs/rules/alignment/align-comparisons.md
+++ b/site/src/content/docs/rules/alignment/align-comparisons.md
@@ -1,0 +1,12 @@
+---
+title: align-comparisons
+caption: Aligns comparison operators vertically across the operands of a multi-line `and`-chain or `or`-chain.
+related:
+  - align-colons
+  - align-equals
+  - align-imports
+  - alphabetize
+  - align-match-case
+---
+
+Aligns comparison operators vertically across the operands of a multi-line `and`-chain or `or`-chain.

--- a/site/src/content/docs/rules/alignment/align-equals.md
+++ b/site/src/content/docs/rules/alignment/align-equals.md
@@ -1,0 +1,11 @@
+---
+title: align-equals
+caption: Aligns the `=` separator across consecutive single-target assignments, annotated function-parameter defaults, and an exploded call's keyword arguments.
+related:
+  - align-colons
+  - align-imports
+  - align-match-case
+  - strip-align-padding
+---
+
+Aligns the `=` separator across consecutive single-target assignments, annotated function-parameter defaults, and an exploded call's keyword arguments.

--- a/site/src/content/docs/rules/alignment/align-imports.md
+++ b/site/src/content/docs/rules/alignment/align-imports.md
@@ -1,0 +1,13 @@
+---
+title: align-imports
+caption: Aligns the `import` and `as` keywords across consecutive import statements.
+related:
+  - align-colons
+  - align-equals
+  - alphabetize
+  - bare-imports
+  - blank-lines
+  - align-match-case
+---
+
+Aligns the `import` and `as` keywords across consecutive import statements.

--- a/site/src/content/docs/rules/alignment/align-match-case.md
+++ b/site/src/content/docs/rules/alignment/align-match-case.md
@@ -1,0 +1,11 @@
+---
+title: align-match-case
+caption: Aligns the post-pattern `:` across single-expression case bodies inside a `match` statement.
+related:
+  - align-colons
+  - align-equals
+  - align-imports
+  - strip-align-padding
+---
+
+Aligns the post-pattern `:` across single-expression case bodies inside a `match` statement.

--- a/site/src/content/docs/rules/alignment/index.md
+++ b/site/src/content/docs/rules/alignment/index.md
@@ -1,0 +1,5 @@
+---
+title: Alignment Rules
+---
+
+The alignment rules align a shared token across consecutive rows so columns of assignments, annotations, and patterns read as vertical groups. The shared math lives in the aligner primitive, and each rule supplies the walker that decides what counts as a group. The per-rule `max-shift` facet bounds how far rows shift to align, wherein each rule walks a run in source order and breaks a fresh group at the first row whose width spread would exceed the cap. `false` lifts the cap so a contiguous run folds into one column, and `0` forbids any shift. A `# prose: skip` on one row holds it out of its group while the rest align around it.

--- a/site/src/content/docs/rules/alignment/strip-align-padding.md
+++ b/site/src/content/docs/rules/alignment/strip-align-padding.md
@@ -1,0 +1,11 @@
+---
+title: strip-align-padding
+caption: Strips padding from alignment groups that resolve to a single member.
+related:
+  - align-colons
+  - align-equals
+  - align-imports
+  - align-match-case
+---
+
+Strips padding from alignment groups that resolve to a single member.

--- a/site/src/content/docs/rules/auto-fix/index.md
+++ b/site/src/content/docs/rules/auto-fix/index.md
@@ -1,0 +1,5 @@
+---
+title: Auto-Fix Rules
+---
+
+Auto-fix rules rewrite source as part of `prose format` and surface as `Severity::Format` diagnostics under `prose check`. Each rule resolves a layout question *Prose* can answer mechanically *(alignment columns, alphabetization order, blank-line counts, collection layout, trailing-comma presence)* and emits an edit list the pipeline applies between rules. Auto-fix rules never report a violation the binary won't itself resolve.

--- a/site/src/content/docs/rules/composition/index.md
+++ b/site/src/content/docs/rules/composition/index.md
@@ -1,0 +1,5 @@
+---
+title: Rule Composition
+---
+
+The per-rule pages walk each rule's canonical case in isolation, but the real question for most projects is what happens when several rules apply to the same block. The composition fixtures answer that question. Each case here pairs a small Python source with the rule set it activates, and the before/after pair shows the combined effect of those rules running together in **Pipeline Order**.

--- a/site/src/content/docs/rules/docs/docstring-expand.md
+++ b/site/src/content/docs/rules/docs/docstring-expand.md
@@ -1,0 +1,9 @@
+---
+title: docstring-expand
+caption: Expands a one-line docstring into the multi-line block shape.
+related:
+  - docstring-wrap
+  - docstring-frame
+---
+
+Expands a one-line docstring into the multi-line block shape.

--- a/site/src/content/docs/rules/docs/docstring-frame.md
+++ b/site/src/content/docs/rules/docs/docstring-frame.md
@@ -1,0 +1,9 @@
+---
+title: docstring-frame
+caption: Drops a multi-line docstring's opener and closer onto their own lines.
+related:
+  - docstring-wrap
+  - docstring-expand
+---
+
+Drops a multi-line docstring's opener and closer onto their own lines.

--- a/site/src/content/docs/rules/docs/docstring-wrap.md
+++ b/site/src/content/docs/rules/docs/docstring-wrap.md
@@ -1,0 +1,9 @@
+---
+title: docstring-wrap
+caption: Wraps multi-line docstring bodies at the configured measure.
+related:
+  - docstring-frame
+  - docstring-expand
+---
+
+Wraps multi-line docstring bodies at the configured measure.

--- a/site/src/content/docs/rules/docs/index.md
+++ b/site/src/content/docs/rules/docs/index.md
@@ -1,0 +1,5 @@
+---
+title: Docs Rules
+---
+
+The docs rules read against the PEP 257 docstring set discovered by the docstring walker and reshape the body, the quote placement, or both. Description prose between the opening `"""` and the first section heading reads against `docstring-line-length` *(default 76)*, while every Title-case-headed section that follows reads against `code-line-length` *(default 88)* or both collapse to one budget when `docstring-structured-policy = "docstring-line-length"`.

--- a/site/src/content/docs/rules/formatting/blank-lines.md
+++ b/site/src/content/docs/rules/formatting/blank-lines.md
@@ -1,0 +1,10 @@
+---
+title: blank-lines
+caption: Normalizes blank-line counts to canonical values between thematically adjacent statements.
+related:
+  - alphabetize
+  - align-imports
+  - bare-imports
+---
+
+Normalizes blank-line counts to canonical values between thematically adjacent statements.

--- a/site/src/content/docs/rules/formatting/index.md
+++ b/site/src/content/docs/rules/formatting/index.md
@@ -1,0 +1,5 @@
+---
+title: Formatting Rules
+---
+
+The formatting rules clear the small scaffolding that clutters a statement once its shape is settled, normalizing blank-line counts between definitions, shedding grouping parentheses that bind nothing, dropping a redundant `-> None`, stripping trailing commas, and removing a `from __future__ import annotations` that no longer earns its place on the target version. Each rewrite is narrower than a layout rule and more pervasive than an ordering rule, tidying what the eye reads without touching the structure it reads.

--- a/site/src/content/docs/rules/formatting/shed-parentheses.md
+++ b/site/src/content/docs/rules/formatting/shed-parentheses.md
@@ -1,0 +1,9 @@
+---
+title: shed-parentheses
+caption: Sheds a grouping parenthesis pair that binds nothing, reflowing the expression onto the line it now fits.
+related:
+  - collection-layout
+  - signature-layout
+---
+
+Sheds a grouping parenthesis pair that binds nothing, reflowing the expression onto the line it now fits.

--- a/site/src/content/docs/rules/formatting/strip-none-return.md
+++ b/site/src/content/docs/rules/formatting/strip-none-return.md
@@ -1,0 +1,10 @@
+---
+title: strip-none-return
+caption: Drops a redundant `-> None` return annotation, since an omitted one already reads as returning nothing.
+related:
+  - signature-annotations
+  - signature-layout
+  - unused-future-annotations
+---
+
+Drops a redundant `-> None` return annotation, since an omitted one already reads as returning nothing.

--- a/site/src/content/docs/rules/formatting/strip-trailing-commas.md
+++ b/site/src/content/docs/rules/formatting/strip-trailing-commas.md
@@ -1,0 +1,9 @@
+---
+title: strip-trailing-commas
+caption: Removes trailing commas from collections, signatures, calls, and every other bracketed container.
+related:
+  - collection-layout
+  - align-colons
+---
+
+Removes trailing commas from collections, signatures, calls, and every other bracketed container.

--- a/site/src/content/docs/rules/formatting/unused-future-annotations.md
+++ b/site/src/content/docs/rules/formatting/unused-future-annotations.md
@@ -1,0 +1,8 @@
+---
+title: unused-future-annotations
+caption: Removes `from __future__ import annotations` lines that no longer carry their weight on the target Python version.
+related:
+  - legacy-union-syntax
+---
+
+Removes `from __future__ import annotations` lines that no longer carry their weight on the target Python version.

--- a/site/src/content/docs/rules/index.md
+++ b/site/src/content/docs/rules/index.md
@@ -1,0 +1,5 @@
+---
+title: Rules
+---
+
+*Prose* ships its rules across two categories. Auto-fix rules rewrite source as part of `prose format` and surface as `Severity::Format` diagnostics under `prose check`. Lint rules surface as `Severity::Lint` diagnostics in both subcommands and never rewrite.

--- a/site/src/content/docs/rules/layout/call-layout.md
+++ b/site/src/content/docs/rules/layout/call-layout.md
@@ -1,0 +1,11 @@
+---
+title: call-layout
+caption: Explodes a keyword-expressible call carrying more than the inline-argument cap to one keyword argument per line.
+related:
+  - alphabetize
+  - collection-layout
+  - signature-layout
+  - strip-trailing-commas
+---
+
+Explodes a keyword-expressible call carrying more than the inline-argument cap to one keyword argument per line.

--- a/site/src/content/docs/rules/layout/collection-layout.md
+++ b/site/src/content/docs/rules/layout/collection-layout.md
@@ -1,0 +1,11 @@
+---
+title: collection-layout
+caption: Splits list, tuple, dict, and set literals into one-entry-per-line layout once they overflow their width, or a dict crosses an entry-count cap.
+related:
+  - align-colons
+  - alphabetize
+  - signature-layout
+  - strip-trailing-commas
+---
+
+Splits list, tuple, dict, and set literals into one-entry-per-line layout once they overflow their width, or a dict crosses an entry-count cap.

--- a/site/src/content/docs/rules/layout/import-layout.md
+++ b/site/src/content/docs/rules/layout/import-layout.md
@@ -1,0 +1,12 @@
+---
+title: import-layout
+caption: Splits an over-budget `from ... import ...` into a run of repeated-prefix statements packed to the import budget.
+related:
+  - align-imports
+  - alphabetize
+  - bare-imports
+  - collection-layout
+  - signature-layout
+---
+
+Splits an over-budget `from ... import ...` into a run of repeated-prefix statements packed to the import budget.

--- a/site/src/content/docs/rules/layout/index.md
+++ b/site/src/content/docs/rules/layout/index.md
@@ -1,0 +1,5 @@
+---
+title: Layout Rules
+---
+
+The layout rules decide the shape a bracketed construct takes once it outgrows a single line, exploding a call, signature, collection, or `from … import …` to one entry per line so each binding reads on its own and a later edit touches a single row. The trigger is a width budget like `code-line-length`, a count cap like `max-args`, or both, so the inline shape gives way to the stacked one the moment it stops being legible.

--- a/site/src/content/docs/rules/layout/signature-layout.md
+++ b/site/src/content/docs/rules/layout/signature-layout.md
@@ -1,0 +1,11 @@
+---
+title: signature-layout
+caption: Normalizes function signatures to one line or one parameter per line, gated by line length and inline-parameter count.
+related:
+  - align-colons
+  - align-equals
+  - collection-layout
+  - strip-trailing-commas
+---
+
+Normalizes function signatures to one line or one parameter per line, gated by line length and inline-parameter count.

--- a/site/src/content/docs/rules/lint/bare-imports.md
+++ b/site/src/content/docs/rules/lint/bare-imports.md
@@ -1,0 +1,10 @@
+---
+title: bare-imports
+caption: Surfaces a narrowly-used bare import that `from x import …` would replace.
+related:
+  - alphabetize
+  - align-imports
+  - blank-lines
+---
+
+Surfaces a narrowly-used bare import that `from x import …` would replace.

--- a/site/src/content/docs/rules/lint/index.md
+++ b/site/src/content/docs/rules/lint/index.md
@@ -1,0 +1,5 @@
+---
+title: Lint Rules
+---
+
+Lint rules surface diagnostics without rewriting source. They run under both `prose check` and `prose format`, returning exit code 2 when any lint diagnostic fires, and they never produce an edit. Lint coincides with its domain, in that every lint rule sits in the `lint` domain and every rule in the `lint` domain is a lint. The category-versus-domain distinction collapses cleanly to one landing.

--- a/site/src/content/docs/rules/lint/legacy-union-syntax.md
+++ b/site/src/content/docs/rules/lint/legacy-union-syntax.md
@@ -1,0 +1,8 @@
+---
+title: legacy-union-syntax
+caption: Surfaces `Union[A, B]` and `Optional[T]` patterns that should read as modern `A | B` and `T | None`.
+related:
+  - unused-future-annotations
+---
+
+Surfaces `Union[A, B]` and `Optional[T]` patterns that should read as modern `A | B` and `T | None`.

--- a/site/src/content/docs/rules/lint/reassigned-constants.md
+++ b/site/src/content/docs/rules/lint/reassigned-constants.md
@@ -1,0 +1,9 @@
+---
+title: reassigned-constants
+caption: Surfaces a module-level constant reassigned despite its `UPPER_SNAKE_CASE` casing.
+related:
+  - step-narration
+  - single-use-variables
+---
+
+Surfaces a module-level constant reassigned despite its `UPPER_SNAKE_CASE` casing.

--- a/site/src/content/docs/rules/lint/signature-annotations.md
+++ b/site/src/content/docs/rules/lint/signature-annotations.md
@@ -1,0 +1,10 @@
+---
+title: signature-annotations
+caption: Flags a signature parameter or a value-returning function that carries no type annotation.
+related:
+  - strip-none-return
+  - signature-layout
+  - legacy-union-syntax
+---
+
+Flags a signature parameter or a value-returning function that carries no type annotation.

--- a/site/src/content/docs/rules/lint/single-use-variables.md
+++ b/site/src/content/docs/rules/lint/single-use-variables.md
@@ -1,0 +1,9 @@
+---
+title: single-use-variables
+caption: Surfaces single-use local bindings that could inline cleanly.
+related:
+  - reassigned-constants
+  - step-narration
+---
+
+Surfaces single-use local bindings that could inline cleanly.

--- a/site/src/content/docs/rules/lint/step-narration.md
+++ b/site/src/content/docs/rules/lint/step-narration.md
@@ -1,0 +1,9 @@
+---
+title: step-narration
+caption: Surfaces comments that narrate the next line.
+related:
+  - reassigned-constants
+  - single-use-variables
+---
+
+Surfaces comments that narrate the next line.

--- a/site/src/content/docs/rules/lint/unsorted-parameters.md
+++ b/site/src/content/docs/rules/lint/unsorted-parameters.md
@@ -1,0 +1,8 @@
+---
+title: unsorted-parameters
+caption: Surfaces a free function whose parameters sit out of alphabetical order.
+related:
+  - alphabetize
+---
+
+Surfaces a free function whose parameters sit out of alphabetical order.

--- a/site/src/content/docs/rules/ordering/alphabetize.md
+++ b/site/src/content/docs/rules/ordering/alphabetize.md
@@ -1,0 +1,14 @@
+---
+title: alphabetize
+caption: Alphabetizes import siblings, dict-key blocks, and dataclass field runs.
+related:
+  - align-colons
+  - align-imports
+  - band-constants
+  - bare-imports
+  - blank-lines
+  - group-imports
+  - unsorted-parameters
+---
+
+Alphabetizes import siblings, dict-key blocks, and dataclass field runs.

--- a/site/src/content/docs/rules/ordering/band-constants.md
+++ b/site/src/content/docs/rules/ordering/band-constants.md
@@ -1,0 +1,12 @@
+---
+title: band-constants
+caption: Hoists module-level constants into a leading band below the imports and a trailing band beneath the definitions.
+related:
+  - alphabetize
+  - group-imports
+  - blank-lines
+  - align-equals
+  - reassigned-constants
+---
+
+Hoists module-level constants into a leading band below the imports and a trailing band beneath the definitions.

--- a/site/src/content/docs/rules/ordering/group-imports.md
+++ b/site/src/content/docs/rules/ordering/group-imports.md
@@ -1,0 +1,12 @@
+---
+title: group-imports
+caption: Partitions a module's imports into bare, external `from`, and local-package sections.
+related:
+  - alphabetize
+  - align-imports
+  - import-layout
+  - blank-lines
+  - bare-imports
+---
+
+Partitions a module's imports into bare, external `from`, and local-package sections.

--- a/site/src/content/docs/rules/ordering/index.md
+++ b/site/src/content/docs/rules/ordering/index.md
@@ -1,0 +1,5 @@
+---
+title: Ordering Rules
+---
+
+The ordering rules reorder sibling AST nodes by a deterministic key while preserving attached comments and inter-section gaps. The shared machinery lives in the orderer primitive, with each rule supplying the classifier closure that names the sort key. A pinning shape lets specific items *(class docstrings, module-level imports above a divider comment)* stay in their authored slot while the rest of the siblings redistribute.

--- a/site/src/content/docs/usage/index.md
+++ b/site/src/content/docs/usage/index.md
@@ -1,0 +1,5 @@
+---
+title: Usage
+---
+
+The Usage chapters walk the day-one path from a fresh install to a CI-gated `prose check`, with each page below stepping through one piece of that path. The section is operations rather than lookup, so the writing leans toward narrative against a working project rather than enumeration of every flag.

--- a/site/src/content/docs/usage/installation.md
+++ b/site/src/content/docs/usage/installation.md
@@ -1,0 +1,5 @@
+---
+title: Installation
+---
+
+*Prose* ships as a single native binary written in Rust, distributed as a Python wheel so the install path lands on PyPI with no separate toolchain. The binary runs on Linux, macOS, and Windows, with no Python interpreter on the hot path. The recommended install is through , in that `uv tool install` fetches the platform wheel and exposes the `prose` executable on the user's `PATH` without an explicit venv.

--- a/site/src/content/docs/usage/quick-start.md
+++ b/site/src/content/docs/usage/quick-start.md
@@ -1,0 +1,5 @@
+---
+title: Quick Start
+---
+
+Three subcommands cover every shape of run *Prose* supports. `format` rewrites files in place, `check` reports violations without modifying anything, and `completions` emits a shell-completion script. The same exit-code matrix gates both `format` and `check`, meaning a CI step and a local pre-commit hook compile against the same outcomes.

--- a/site/src/content/docs/usage/suppression.md
+++ b/site/src/content/docs/usage/suppression.md
@@ -1,0 +1,5 @@
+---
+title: Suppression
+---
+
+*Prose* is opinionated by design, and most projects benefit from running every rule at its default. Every codebase has its corners, though, and those corners want a way to opt out without dropping a whole rule from the pipeline. The decision is which scope the exception lives at, because *Prose* exposes suppression at four scopes *(file, block, line, dict literal)* and each one fits a different shape of exception.

--- a/site/src/data/directives.yaml
+++ b/site/src/data/directives.yaml
@@ -1,0 +1,167 @@
+fmt-off:
+  effect: Opens a region every auto-fix rule leaves untouched, so a hand-tuned block survives the formatter pass intact.
+  example: |-
+    # fmt: off
+    keep_this_block_exactly_as_written = (1,2,3)
+    # fmt: on
+  form: '# fmt: off'
+  pairId: fmt-on
+  pairRole: opens
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'fmt:'
+    - role: action
+      text: 'off'
+  scope: block
+fmt-on:
+  effect: Closes the suppressed region. Formatting resumes on the following line.
+  example: |-
+    # fmt: off
+    keep_this_block_exactly_as_written = (1,2,3)
+    # fmt: on
+  form: '# fmt: on'
+  pairId: fmt-off
+  pairRole: closes
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'fmt:'
+    - role: action
+      text: 'on'
+  scope: block
+fmt-skip:
+  effect: Every auto-fix rule skips the line carrying the directive. Pairs with `[<rule>, ...]` to narrow the scope.
+  example: 'data = {"a": 1, "b": 2, "c": 3}  # fmt: skip'
+  form: '# fmt: skip'
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'fmt:'
+    - role: action
+      text: skip
+  scope: line
+prose-ignore:
+  effect: Every lint rule skips the line. Pairs with `[<rule>, ...]` to narrow the scope.
+  example: 'helper = build_helper()  # prose: ignore'
+  form: '# prose: ignore'
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'prose:'
+    - role: action
+      text: ignore
+  scope: line
+prose-ignore-rules:
+  effect: Only the listed lint rules skip the line. Two bracketed directives on one line union their rule slugs.
+  example: 'TIMEOUT = 30  # prose: ignore[reassigned-constants, single-use-variables]'
+  form: '# prose: ignore[<rule>, ...]'
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'prose:'
+    - role: action
+      text: ignore
+    - role: payload
+      text: '[<rule>, ...]'
+  scope: line
+prose-keep:
+  effect: Every ordering rule leaves the dict entries in their authored order. Scopes to that one dict literal.
+  example: |-
+    config = {  # prose: keep
+        "stage_one"   : True,
+        "stage_two"   : False,
+    }
+  form: '# prose: keep'
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'prose:'
+    - role: action
+      text: keep
+  scope: block
+  scopeNote: dict literal only
+prose-off:
+  effect: Suppresses every *Prose* rewrite for the entire file. Declared on a comment line near the top.
+  example: |-
+    # prose: off
+
+    def messy(): pass
+  form: '# prose: off'
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'prose:'
+    - role: action
+      text: 'off'
+  scope: file
+prose-skip:
+  aliasOf: fmt-skip
+  effect: 'Alias for `# fmt: skip`. Every auto-fix rule skips the line carrying the directive.'
+  example: 'data = {"a": 1, "b": 2, "c": 3}  # prose: skip'
+  form: '# prose: skip'
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'prose:'
+    - role: action
+      text: skip
+  scope: line
+prose-skip-rules:
+  effect: Only the listed auto-fix rules skip the line. Two bracketed directives on one line union their rule slugs.
+  example: 'foo = 1  # prose: skip[align-equals, strip-trailing-commas]'
+  form: '# prose: skip[<rule>, ...]'
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'prose:'
+    - role: action
+      text: skip
+    - role: payload
+      text: '[<rule>, ...]'
+  scope: line
+yapf-disable:
+  aliasOf: fmt-off
+  effect: 'Alias for `# fmt: off`. Recognized to ease migration from yapf.'
+  example: |-
+    # yapf: disable
+    keep_this_block_exactly_as_written = (1,2,3)
+    # yapf: enable
+  form: '# yapf: disable'
+  pairId: yapf-enable
+  pairRole: opens
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'yapf:'
+    - role: action
+      text: disable
+  scope: block
+yapf-enable:
+  aliasOf: fmt-on
+  effect: 'Alias for `# fmt: on`. Closes a yapf-style suppressed region.'
+  example: |-
+    # yapf: disable
+    keep_this_block_exactly_as_written = (1,2,3)
+    # yapf: enable
+  form: '# yapf: enable'
+  pairId: yapf-disable
+  pairRole: closes
+  parts:
+    - role: comment
+      text: '#'
+    - role: namespace
+      text: 'yapf:'
+    - role: action
+      text: enable
+  scope: block

--- a/site/src/data/editor-configs.yaml
+++ b/site/src/data/editor-configs.yaml
@@ -1,0 +1,74 @@
+emacs:
+  caption: after-save-hook
+  code: |-
+    (defun prose-format-on-save ()
+      (when (derived-mode-p 'python-mode)
+        (call-process "prose" nil nil nil
+                      "format" buffer-file-name)
+        (revert-buffer :ignore-auto
+                       :noconfirm
+                       :preserve-modes)))
+
+    (add-hook 'after-save-hook
+              #'prose-format-on-save)
+  language: elisp
+  name: Emacs
+  target: init.el
+helix:
+  caption: editor.formatter
+  code: |-
+    [[editor.formatter]]
+    languages = ["python"]
+    command   = "prose"
+    args      = ["format", "-"]
+  language: toml
+  name: Helix
+  target: languages.toml
+jetbrains:
+  caption: File Watchers
+  code: |-
+    File type         : Python
+    Scope             : Project Files
+    Program           : prose
+    Arguments         : format $FilePath$
+    Working directory : $ProjectFileDir$
+  language: text
+  name: JetBrains
+  target: Watcher dialog
+neovim:
+  caption: autocmd BufWritePost
+  code: autocmd BufWritePost *.py silent! !prose format %
+  language: vim
+  name: Neovim
+  target: init.vim
+sublime:
+  caption: SublimeOnSaveBuild
+  code: |-
+    # Install: SublimeOnSaveBuild
+    {
+      "build_systems": [{
+        "name"        : "prose",
+        "shell_cmd"   : "prose format \"$file\"",
+        "selector"    : "source.python",
+        "working_dir" : "$file_path"
+      }]
+    }
+  language: python
+  name: Sublime Text
+  target: <Project>.sublime-project
+vscode:
+  caption: emeraldwalk.runonsave
+  code: |-
+    {
+      "emeraldwalk.runonsave": {
+        "commands": [
+          {
+            "match" : "\\.py$",
+            "cmd"   : "prose format ${file}"
+          }
+        ]
+      }
+    }
+  language: json
+  name: VS Code
+  target: settings.json

--- a/site/src/data/exit-codes.yaml
+++ b/site/src/data/exit-codes.yaml
@@ -1,0 +1,36 @@
+'0':
+  code: 0
+  detail:
+    - Returned by both `prose check` and `prose format` when the input is already conforming.
+    - CI gates pass without further work.
+  label: Clean
+  summary: No diagnostics, no rewrites pending.
+'1':
+  code: 1
+  detail:
+    - '`prose check` returns this when one or more auto-fix rules would emit edits.'
+    - '`prose format` returns 0 once the rewrite lands.'
+    - Every auto-fix rule contributes here.
+  label: Format would change
+  summary: At least one auto-fix diagnostic is pending.
+'2':
+  code: 2
+  detail:
+    - Surfaces under both `prose check` and `prose format`.
+    - 'The shipped lints contribute: `legacy-union-syntax`, `reassigned-constants`, `step-narration`, `single-use-variables`.'
+  label: Lint violation
+  summary: At least one lint-only diagnostic surfaced.
+'3':
+  code: 3
+  detail:
+    - Surfaces under both subcommands when `ruff_python_parser` fails on the source.
+    - The pipeline does not run, leaving no other diagnostics to fire.
+  label: Parse error
+  summary: Input could not be parsed as Python.
+'4':
+  code: 4
+  detail:
+    - Surfaces from config-file parse errors, malformed `--select` / `--ignore` flags, or unknown CLI options.
+    - A malformed flag pre-empts the whole run, whereas a broken ancestor config fails only the files it governs while the rest proceed.
+  label: Config error
+  summary: Config file or argument validation failed.

--- a/site/src/data/glossary.yaml
+++ b/site/src/data/glossary.yaml
@@ -1,0 +1,500 @@
+'# fmt: off':
+  aliases:
+    - '# fmt: on'
+  definition: '`# fmt: off` and `# fmt: on` are block markers that preserve the exact source layout of code between them by disabling every rewriting rule. Inline comments on the same line are recognized as the marker.'
+  families:
+    - formatting
+    - engine
+  href: /usage/suppression#block-markers
+'# fmt: skip':
+  definition: '`# fmt: skip` is a line-level marker that exempts the statement it sits on from every rewriting rule, without needing surrounding block markers.'
+  families:
+    - formatting
+    - engine
+  href: /usage/suppression#line-markers
+'# prose: ignore':
+  aliases:
+    - '# prose: ignore[...]'
+  definition: '`# prose: ignore` is a per-line directive that suppresses specific lint diagnostics. The bracketed form names the rule slugs to silence, whereas the bare form silences every lint on that line.'
+  families:
+    - lint
+    - engine
+  href: /usage/suppression#lint-directives
+'--ignore':
+  definition: '`--ignore` is a CLI flag that disables the named rules for a single invocation. The flag is repeatable, and pairs with `--select` to scope a run.'
+  families:
+    - cli
+  href: /usage/quick-start#subset-the-active-rules
+'--no-cache':
+  definition: '`--no-cache` is a CLI flag that bypasses the user-level cache for a single invocation of `prose check` or `prose format`. The flag overrides the configured `[cache] enabled` value.'
+  families:
+    - cli
+  href: /reference/cache#no-cache
+'--select':
+  definition: '`--select` is a CLI flag that restricts a run to the named rules. The flag is repeatable, and pairs with `--ignore` to subtract from the active set.'
+  families:
+    - cli
+  href: /usage/quick-start#subset-the-active-rules
+'--verbose':
+  definition: '`--verbose` is a global CLI flag that prints a one-line cache hit/miss summary to stderr at the end of each `prose check` or `prose format` run. The flag writes `cache: bypassed` when the cache is disabled via `--no-cache` or `[cache] enabled = false`.'
+  families:
+    - cli
+  href: /reference/cache#hit-miss-telemetry
+AST:
+  aliases:
+    - abstract syntax tree
+  definition: An AST is the parsed-program tree produced by `ruff_python_parser`. *Prose* bundles it inside `Source` and reparses it between rules so each rule reads against the post-rewrite tree.
+  families:
+    - engine
+  href: /primitives/source
+BLAKE3:
+  definition: BLAKE3 is the cryptographic hash function *Prose* uses to derive [[Cache]] keys. The key digests the source bytes, the canonical TOML serialization of the active configuration, and the *Prose* version, so any meaningful change to any input produces a different key.
+  families:
+    - engine
+    - cli
+  href: /reference/cache#key-shape
+BindingAnalysis:
+  aliases:
+    - binding analysis
+    - binding map
+    - name bindings
+    - binding
+    - bindings
+  definition: '`BindingAnalysis` is a per-`Source` table indexing every write and read of every name in every lexical scope. The `single-use-variables` rule consumes it.'
+  families:
+    - engine
+    - lint
+  href: /primitives/binding-analysis
+Diagnostic:
+  aliases:
+    - diagnostic
+    - diagnostics
+    - lint diagnostic
+  definition: A `Diagnostic` is the structured report a rule emits when it detects a pattern. It carries a severity, wherein `AutoFix` rewrites source under `prose format` and `Lint` only surfaces.
+  families:
+    - engine
+    - lint
+NDJSON:
+  aliases:
+    - ndjson
+    - newline-delimited JSON
+  definition: NDJSON is newline-delimited JSON. `prose check --output-format json` emits one record per line in this shape, so editors and tooling can stream diagnostics without buffering the whole document.
+  families:
+    - cli
+  href: /reference/output-formats#json
+PEP 257:
+  aliases:
+    - pep 257
+    - PEP-257
+  definition: PEP 257 is the docstring conventions PEP. It defines a docstring as the first body statement of a module, class, or function when that statement is a single string literal expression, and the `docstring` walker matches this shape exactly.
+  families:
+    - docs
+    - engine
+  href: /primitives/docstring#the-pep-257-definition
+PEP 604:
+  aliases:
+    - pep 604
+    - PEP-604
+    - pipe-union
+    - pipe-union syntax
+  definition: PEP 604 is the pipe-union syntax PEP (Python 3.10+). It lets `X | Y` and `T | None` replace `Union[X, Y]` and `Optional[T]` at the type level, and `legacy-union-syntax` surfaces the legacy `typing` forms on projects whose `target-version` allows the pipe form.
+  families:
+    - lint
+  rule: legacy-union-syntax
+PEP 749:
+  aliases:
+    - pep 749
+    - PEP-749
+    - deferred annotation
+    - deferred annotations
+  definition: PEP 749 is the deferred-annotation-evaluation PEP, landing in Python 3.14. The runtime no longer evaluates annotations eagerly for typing-only code, so `from __future__ import annotations` becomes redundant and `unused-future-annotations` removes it on 3.14+.
+  families:
+    - lint
+  rule: unused-future-annotations
+Pipeline:
+  aliases:
+    - pipeline
+  definition: The `Pipeline` orchestrates the rule loop against a `Source`, reparses between rules, and returns the final source plus diagnostics.
+  families:
+    - engine
+  href: /primitives/pipeline
+Pydantic:
+  aliases:
+    - pydantic
+    - Pydantic field
+    - Pydantic fields
+  definition: Pydantic is a widely used data-validation library whose models declare typed fields in the class body. `alphabetize` sorts those fields with required before optional, and `align-colons` aligns the annotation colons across the field block.
+  families:
+    - ordering
+    - alignment
+  href: https://docs.pydantic.dev/
+Ruff:
+  aliases:
+    - ruff
+  definition: Ruff is Astral's Python linter and formatter. *Prose* composes cleanly with it when both are in the toolchain, leaving token-level normalization to `ruff` and layout-level legibility to *Prose*.
+  families:
+    - engine
+  href: /integrations/ruff
+RuleId:
+  aliases:
+    - rule id
+    - rule IDs
+  definition: A `RuleId` is the canonical kebab-case slug identifying each registered rule across CLI flags, config tables, suppression directives, and diagnostic output.
+  families:
+    - engine
+    - cli
+  href: /primitives/rule-id
+Severity:
+  aliases:
+    - severity
+  definition: Severity is a diagnostic's emission kind. `AutoFix` rewrites source under `prose format` and surfaces as a pending change under `prose check`, whereas `Lint` only reports and never rewrites.
+  families:
+    - engine
+Source:
+  definition: '`Source` is the parsed-text wrapper bundling original text, AST, token stream, line index, and suppression map. Every rule reads through this value.'
+  families:
+    - engine
+  href: /primitives/source
+SuppressionMap:
+  aliases:
+    - suppression map
+    - suppression directive
+    - suppression directives
+    - suppression
+  definition: '`SuppressionMap` is the per-`Source` index of `# fmt: off` / `# fmt: skip` / `# yapf` / `# prose: ignore[...]` directives, consulted at the edit-emission boundary.'
+  families:
+    - engine
+    - formatting
+    - lint
+  href: /primitives/suppression-map
+TYPE_CHECKING:
+  aliases:
+    - typing.TYPE_CHECKING
+    - if TYPE_CHECKING
+  definition: '`TYPE_CHECKING` is a `typing` flag that is `False` at runtime and `True` to type checkers, used inside `if TYPE_CHECKING:` blocks to guard import-only-for-typing code. `reassigned-constants` exempts bindings declared inside the block.'
+  families:
+    - lint
+  href: https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING
+TypedDict:
+  aliases:
+    - typeddict
+  definition: A `TypedDict` is a `typing.TypedDict` subclass declaring a dict's key-to-value-type contract. `alphabetize` sorts its fields the same way it sorts `dataclass` and Pydantic fields.
+  families:
+    - ordering
+    - alignment
+  href: https://docs.python.org/3/library/typing.html#typing.TypedDict
+alignment group:
+  aliases:
+    - alignment groups
+    - group
+    - singleton group
+    - singleton groups
+  definition: An alignment group is a run of consecutive members at the same indentation that share an alignment target. Blank lines, comment lines, and non-member statements reset the run, so each contiguous group resolves independently.
+  families:
+    - alignment
+  href: /primitives/aligner
+annotation:
+  aliases:
+    - annotations
+    - type annotation
+    - type annotations
+  definition: 'An annotation is a `name: Type` declaration on a function parameter, return value, or variable. Type checkers and version-gated rules like `legacy-union-syntax` and `unused-future-annotations` read it, and `alphabetize` treats a non-deferred annotation as a reference that pins definition order.'
+  families:
+    - lint
+    - alignment
+    - ordering
+  href: https://docs.python.org/3/glossary.html#term-annotation
+applicability:
+  definition: Applicability is the Ruff-shared confidence level on an auto-fix's `fix` payload. `safe` means the rewrite preserves runtime semantics and an editor can apply it without prompting, whereas `unsafe` and `display` exist in the schema for forward compatibility.
+  families:
+    - cli
+    - engine
+  href: /reference/output-formats#json
+atomic:
+  aliases:
+    - atomic literal
+    - atomic literals
+  definition: An atomic is a simple, indivisible code element (integer, float, string, single name) that `collection-layout` can safely keep on one line without readability loss.
+  families:
+    - layout
+  rule: collection-layout
+auto-fix:
+  aliases:
+    - auto-fixes
+    - auto-fixing
+    - Auto-Fix
+  definition: Auto-fix is the rule category whose diagnostics rewrite source under `prose format` and surface as `Severity::AutoFix` under `prose check`.
+  families:
+    - formatting
+blank line:
+  aliases:
+    - blank-line
+    - blank lines
+    - blank-lines
+  definition: A blank line is an empty line separating logical units. *Prose* enforces blank-line counts between module-level definitions, class members, and import groups per the `blank-lines` rule, and binds description-shaped own-line comment blocks tight against the following statement while leaving banner-shaped blocks separated by 1 blank line below.
+  families:
+    - formatting
+  rule: blank-lines
+cache:
+  aliases:
+    - Cache
+    - cached
+    - caching
+  definition: The user-level on-disk cache *Prose* keeps for repeat `prose check` and `prose format` runs. Keyed by [[BLAKE3]] over `(source ++ config ++ rules ++ prose_version)`, capped by the LRU eviction the `[cache] max-size-mib` facet configures, bypassable per invocation with `--no-cache`, and clearable with `prose cache clean`.
+  families:
+    - engine
+    - cli
+  href: /reference/cache
+code-line-length:
+  definition: '`code-line-length` is the top-level config key for the line budget consumed by code-shaped rules. It defaults to **88**.'
+  families:
+    - cli
+    - formatting
+  href: /reference/configuration#top-level-keys
+comprehension:
+  aliases:
+    - comprehensions
+    - list comprehension
+    - dict comprehension
+    - set comprehension
+  definition: 'A comprehension is one of Python''s `[x for x in xs]`, `{k: v for ...}`, or `{x for ...}` literal forms that build a list, dict, or set inline. `collection-layout` joins them back onto one line when they fit, and their bound targets sit outside `single-use-variables`.'
+  families:
+    - layout
+    - lint
+  href: https://docs.python.org/3/tutorial/datastructures.html#list-comprehensions
+count trigger:
+  aliases:
+    - count-based trigger
+    - count gate
+  definition: A count trigger expands a layout once an element count crosses a configured cap, whatever the width. `signature-layout` counts parameters with `max-params` and `collection-layout` counts dict entries with `max-dict-entries`, and `false` disables either. It replaces the magic trailing comma that Black and Ruff read with an explicit, configurable count.
+  families:
+    - layout
+  rule: collection-layout
+dataclass:
+  aliases:
+    - dataclasses
+    - dataclass field
+    - dataclass fields
+  definition: A dataclass is a class decorated with `@dataclass` whose body lists typed field declarations. `alphabetize` reorders the fields (required before optional), `align-colons` aligns their annotation colons, and `align-equals` aligns their default-value `=` signs.
+  families:
+    - ordering
+    - alignment
+  href: https://docs.python.org/3/library/dataclasses.html
+decorator:
+  aliases:
+    - decorators
+    - decorated function
+    - decorated functions
+  definition: A decorator is an `@name` prefix attached to a function or class definition that wraps it at definition time. `alphabetize` sorts decorated functions together inside framework-decorator groups, and `blank-lines` keeps each decorator attached to its `def`.
+  families:
+    - ordering
+    - formatting
+  href: https://docs.python.org/3/glossary.html#term-decorator
+docstring:
+  aliases:
+    - docstrings
+    - triple-quoted docstring
+  definition: A docstring is a triple-quoted string literal placed as the first statement in a module, class, or function. *Prose* rewraps multi-line bodies under `docstring-wrap` and gates single-line shapes under `docstring-expand`.
+  families:
+    - docs
+    - engine
+  href: /primitives/docstring
+docstring-line-length:
+  definition: '`docstring-line-length` is the top-level config key for the description-prose budget inside docstrings. It defaults to **76**.'
+  families:
+    - cli
+    - docs
+  href: /reference/configuration#top-level-keys
+dunder:
+  aliases:
+    - dunder name
+    - dunder names
+    - __all__
+    - __slots__
+  definition: A dunder is the Python convention for names wrapped in double underscores (`__name__`, `__all__`, `__init__`). `reassigned-constants` treats them as runtime sentinels, and `alphabetize` treats them as ordering anchors that surface before properties and privates inside a class body.
+  families:
+    - ordering
+    - lint
+enum:
+  aliases:
+    - Enum
+    - enums
+    - enum member
+    - enum members
+  definition: An enum is a subclass of `enum.Enum` whose body lists named constants. `alphabetize` sorts the members, except when they carry explicit integer or string values that encode ordering.
+  families:
+    - ordering
+  href: https://docs.python.org/3/library/enum.html
+f-string:
+  aliases:
+    - f-strings
+  definition: An f-string is a Python string literal prefixed `f"..."` that interpolates expressions inside `{}` placeholders. The `docstring` walker skips f-string and other concatenated forms, so only plain triple-quoted string literals count as docstrings.
+  families:
+    - formatting
+    - docs
+  href: https://docs.python.org/3/reference/lexical_analysis.html#f-strings
+fixture:
+  aliases:
+    - fixtures
+    - fixture pair
+  definition: A fixture is an input-and-output pair that pins a rule's behavior. Each rule page renders fixtures inline as side-by-side before-and-after Python snippets, and the same files drive snapshot testing inside the crate.
+  families:
+    - engine
+forward reference:
+  aliases:
+    - forward references
+  definition: A forward reference is an annotation that names a class or alias defined later in the file. The `from __future__ import annotations` directive made these safe on older Python runtimes, and `unused-future-annotations` removes the directive when no annotation needs the forward reference. `alphabetize` never introduces one, holding a class or function behind any sibling it names at evaluation time so the reorder cannot lift a definition above a name it depends on.
+  families:
+    - lint
+    - ordering
+  rule: unused-future-annotations
+gitignore:
+  aliases:
+    - .gitignore
+  definition: '`.gitignore` is the standard Git exclusion file. *Prose*''s walker honors `.gitignore` and `.ignore` files at every level of the walked tree plus the user''s global gitignore, so vendored dependencies and build artifacts stay out of the run automatically.'
+  families:
+    - engine
+  href: /primitives/walker#ignore-semantics
+idempotent:
+  aliases:
+    - idempotence
+    - idempotency
+  definition: A second `prose format` run against `prose`-formatted source produces no further edits. Every rule preserves this property, so re-running the formatter never thrashes the source.
+  families:
+    - engine
+import-line-length:
+  definition: '`import-line-length` is the top-level config key for the wrap budget `import-layout` holds long from-imports to. It defaults to **120** and falls back to `code-line-length` when set to `false`.'
+  families:
+    - cli
+    - layout
+  href: /reference/configuration#top-level-keys
+kebab-case:
+  definition: Kebab-case is the lowercase-with-hyphens naming convention *Prose* uses for every rule slug (`align-equals`, `single-use-variables`). The form is canonical across CLI flags, config tables, suppression directives, and diagnostic output.
+  families:
+    - engine
+    - cli
+  href: /primitives/rule-id
+leading comment block:
+  aliases:
+    - own-line comment
+    - own-line comments
+    - leading comment
+    - leading comments
+    - own-line comment block
+  definition: A leading comment block is a run of own-line `#` comments sitting directly above a statement. `blank-lines` binds description-shaped blocks tight against the following statement and keeps 1 blank line below banner-shaped blocks *(any line of which is a decorative rule of `=`, `-`, `*`, `_`, `#`, or `~`)*, with the canonical above-gap measured from the topmost comment either way. The orderer primitive's `block_range` carries the block with its item when reordering siblings.
+  families:
+    - formatting
+    - ordering
+  rule: blank-lines
+lexical scope:
+  aliases:
+    - lexical scopes
+    - scope
+  definition: A lexical scope is the textual region of source code in which a name resolves to a given binding. Python scopes nest by module, class, and function, and `binding-analysis` walks them once per `Source` to index every write and read.
+  families:
+    - engine
+  href: /primitives/binding-analysis
+lint:
+  aliases:
+    - Lint
+    - lint violation
+    - lint-only
+    - linting
+  definition: Lint is the rule category whose diagnostics surface as `Severity::Lint` without rewriting source. *Prose* always inspects them, but never modifies the source.
+  families:
+    - lint
+match:
+  aliases:
+    - match statement
+    - match-arm
+    - match arms
+    - match-case
+  definition: 'A match is Python''s structural-pattern-matching statement (PEP 634). Each `case Pattern: body` arm pairs a pattern with a body, and `align-match-case` shares a column for the post-pattern `:` separator across consecutive single-expression arms.'
+  families:
+    - alignment
+  rule: align-match-case
+max-shift:
+  definition: '`max-shift` is the per-alignment-rule config key bounding how far a row may shift to align. It defaults to **16**. A positive `N` caps the width spread of a run, `0` forbids any shift, and `false` lifts the cap so a contiguous run folds into one column.'
+  families:
+    - alignment
+    - cli
+  href: /reference/configuration#per-rule-facets
+module-level:
+  aliases:
+    - module level
+    - module-scope
+    - module scope
+  definition: Module-level names the outermost lexical scope of a Python file, sitting outside any class or function body. `reassigned-constants` fires only on module-level assignments, and `blank-lines` reserves two blanks above every module-level `def` and `class`.
+  families:
+    - engine
+    - formatting
+    - lint
+reparse:
+  aliases:
+    - reparses
+    - reparsing
+  definition: Reparse names the `Source::reparse` step the `Pipeline` runs between rules. Each rule reads a settled AST built from the post-rewrite text, so no rule observes another rule's half-applied state.
+  families:
+    - engine
+  href: /primitives/pipeline
+ruff format:
+  aliases:
+    - ruff-format
+  definition: '`ruff format` is Ruff''s formatter subcommand. When a project pairs it with *Prose*, Ruff runs first to settle line wraps, quote normalization, indentation, and blank-line discipline, after which `prose format` runs against the settled tokens.'
+  families:
+    - engine
+  href: /integrations/ruff
+ruff_python_parser:
+  definition: '`ruff_python_parser` is the Astral parser crate *Prose* consumes to produce the AST inside each `Source`. Reparsing between rules guarantees every rule reads against the post-rewrite tree.'
+  families:
+    - engine
+stdin mode:
+  aliases:
+    - '--stdin'
+    - stdin
+  definition: Stdin mode is the CLI shape that reads a single source from standard input and writes to standard output. It bypasses the filesystem walker entirely, so editors and pipelines drive *Prose* without touching disk.
+  families:
+    - cli
+strip-align-padding:
+  aliases:
+    - singleton rule
+    - singleton rules
+  definition: '`strip-align-padding` drops the pre-`:` padding when a colon group has no column to align to, either a single-member group or a multi-member group whose colons all share one source line, so a one-key dict reads as plain code.'
+  families:
+    - alignment
+  rule: strip-align-padding
+structured section:
+  aliases:
+    - structured sections
+    - Args block
+    - Args section
+    - Returns section
+    - Raises section
+  definition: A structured section is a docstring section like `Args:`, `Returns:`, or `Raises:` that reads as a code-shaped table rather than prose. `docstring-wrap` budgets these against `code-line-length` by default, so argument lines align with surrounding code.
+  families:
+    - docs
+    - alignment
+  rule: docstring-wrap
+target-version:
+  aliases:
+    - target version
+  definition: '`target-version` is the top-level config key naming the Python runtime the project ships to. Version-gated rules consume it, and leaving it unset means no version-dependent rewrites fire.'
+  families:
+    - cli
+    - lint
+  href: /reference/configuration#top-level-keys
+walrus operator:
+  aliases:
+    - walrus
+    - walrus assignment
+  definition: The walrus operator is Python's assignment expression `:=` (PEP 572). `align-equals` treats it as a non-member, so a walrus inside a condition or comprehension never enters an alignment group.
+  families:
+    - alignment
+workflow command:
+  aliases:
+    - workflow commands
+    - workflow-command annotation
+  definition: A workflow command is GitHub Actions' inline-annotation syntax (`::warning file=...,line=...::message`). The `--output-format github` shape emits one workflow command per diagnostic, which GitHub renders as a check-run annotation on the PR diff.
+  families:
+    - cli
+  href: /reference/output-formats#github

--- a/site/src/data/landing-surfaces.yaml
+++ b/site/src/data/landing-surfaces.yaml
@@ -1,0 +1,12 @@
+alignment:
+  body: Equals signs, colons, the `import` keyword, and match arrows line up across consecutive lines. The eye drops down the column.
+docs:
+  body: Docstrings join the same legibility discipline as code. Wrap to the project line length, keep single-line shapes single-line, multi-line shapes multi-line, and quote style consistent throughout.
+formatting:
+  body: Trailing commas come off, blank lines snap to canonical counts, empty grouping parentheses and redundant `-> None` annotations fall away, and a stale `__future__` import is removed once nothing needs it. The scaffolding clears after the shape is set.
+layout:
+  body: Calls, signatures, collections, and from-imports that outgrow the line budget explode to one entry per line. Each argument, key, or name lands on its own row, so the eye reads down the column and a later edit touches a single line.
+lint:
+  body: Legacy union syntax, reassigned constants, step-narration comments, bare-import patterns, and single-use bindings surface as diagnostics. The formatter never rewrites these, because the fix belongs to the reader.
+ordering:
+  body: Sibling entries sort into a predictable order. Imports, dictionary keys, and set members read top-to-bottom by name, so a reader looking for an entry already knows where it sits.

--- a/site/src/data/landing-workflow.yaml
+++ b/site/src/data/landing-workflow.yaml
@@ -1,0 +1,22 @@
+'01':
+  body: Fetch the wheel and expose the `prose` binary.
+  code: uv tool install prose-formatter
+  language: bash
+  title: Install
+'02':
+  body: Drop a `prose.toml` at the project root, a `.config/prose.toml`, or a `[tool.prose]` table in `pyproject.toml`. The defaults already work.
+  code: target-version = "3.13"
+  language: toml
+  title: Configure
+'03':
+  body: Rewrite in place, or check without writing.
+  code: |-
+    prose format path/
+    prose check path/
+  language: bash
+  title: Run
+'04':
+  body: Optionally pair with Ruff for the token-level surface *Prose* doesn't touch.
+  code: ruff format && prose format
+  language: bash
+  title: Compose

--- a/site/src/data/rule-config-presets.yaml
+++ b/site/src/data/rule-config-presets.yaml
@@ -1,0 +1,16 @@
+alignment:
+  rows:
+    - default: 'true'
+      key: enabled
+      meaning: Toggle the rule on or off
+      type: bool
+    - default: '16'
+      key: max-shift
+      meaning: Width-spread budget for an alignment run. A positive `N` caps the spread, `0` forbids any shift, and `false` folds a contiguous run into one column
+      type: positive int | `0` | `false`
+toggle:
+  rows:
+    - default: 'true'
+      key: enabled
+      meaning: Toggle the rule on or off
+      type: bool

--- a/site/src/data/shell-completions.yaml
+++ b/site/src/data/shell-completions.yaml
@@ -1,0 +1,47 @@
+bash:
+  caption: bash_completion.d
+  code: prose completions bash > /etc/bash_completion.d/prose
+  command: prose completions bash
+  language: bash
+  mono: bash
+  name: Bash
+  note: The `/etc/bash_completion.d/` directory is the system-wide completion hook on most distributions. For a per-user install, write to `~/.local/share/bash-completion/completions/prose` instead.
+  target: /etc/bash_completion.d/prose
+elvish:
+  caption: use module
+  code: |-
+    prose completions elvish > ~/.config/elvish/lib/prose-completions.elv
+    use prose-completions
+  command: prose completions elvish
+  language: shellscript
+  mono: elvish
+  name: Elvish
+  note: The `use` line goes in `~/.config/elvish/rc.elv` to register the completions on shell start.
+  target: ~/.config/elvish/lib/prose-completions.elv
+fish:
+  caption: completions directory
+  code: prose completions fish > ~/.config/fish/completions/prose.fish
+  command: prose completions fish
+  language: fish
+  mono: fish
+  name: Fish
+  note: Fish picks up completions in `~/.config/fish/completions/` on the next shell start, no `source` required.
+  target: ~/.config/fish/completions/prose.fish
+powershell:
+  caption: $PROFILE script
+  code: prose completions powershell > $PROFILE.CurrentUserAllHosts
+  command: prose completions powershell
+  language: powershell
+  mono: powershell
+  name: PowerShell
+  note: PowerShell loads `$PROFILE.CurrentUserAllHosts` on every session, so the completions register on the next shell start.
+  target: $PROFILE.CurrentUserAllHosts
+zsh:
+  caption: fpath function
+  code: prose completions zsh > "${fpath[1]}/_prose"
+  command: prose completions zsh
+  language: zsh
+  mono: zsh
+  name: Zsh
+  note: The `${fpath[1]}` expansion lands at the first entry of zsh's function path, which is where `compinit` picks up new completions. Restart the shell or run `autoload -Uz compinit && compinit` to pick the completions up without re-launching.
+  target: ${fpath[1]}/_prose

--- a/site/src/data/token-index.yaml
+++ b/site/src/data/token-index.yaml
@@ -1,0 +1,141 @@
+cli-flag:
+  - blurb: Color-output mode for human-readable output.
+    href: /reference/cli#global-flag
+    key: '--color'
+  - blurb: Print a unified diff without rewriting the source.
+    href: /reference/cli#prose-format
+    key: '--diff'
+  - blurb: Subtract the listed rule from the active set.
+    href: /reference/cli#precedence
+    key: '--ignore <slug>'
+  - blurb: Bypass the user-level cache for the single invocation.
+    href: /reference/cache
+    key: '--no-cache'
+  - blurb: Pick the diagnostic shape (`text` / `json` / `github` / `sarif`).
+    href: /reference/cli#prose-format
+    key: '--output-format'
+  - blurb: Reduce the closing summary to a bare count line.
+    href: /reference/cli#run-summary
+    key: '--quiet'
+  - blurb: Restrict the run to the listed rule.
+    href: /reference/cli#precedence
+    key: '--select <slug>'
+  - blurb: Read source from stdin, write the rewrite to stdout.
+    href: /reference/cli#prose-format
+    key: '--stdin'
+  - blurb: Treat stdin as this filename, its extension selecting Python or a notebook.
+    href: /reference/cli#prose-format
+    key: '--stdin-filename'
+  - blurb: Confirm the would-be rewrite re-parses, surfacing an unparseable rule output.
+    href: /reference/cli#prose-check
+    key: '--validate'
+  - blurb: Print a one-line cache summary to stderr at the end of the run.
+    href: /reference/cache#hit-miss-telemetry
+    key: '--verbose'
+config-key:
+  - blurb: Toggle the user-level cache globally.
+    href: /reference/cache#configuration
+    key: cache.enabled
+  - blurb: LRU eviction cap on the cache directory.
+    href: /reference/cache#configuration
+    key: cache.max-size-mib
+  - blurb: Maximum column budget for code lines.
+    href: /reference/configuration#top-level-keys
+    key: code-line-length
+  - blurb: Maximum column budget for docstring prose.
+    href: /reference/configuration#docstring-budgets
+    key: docstring-line-length
+  - blurb: Budget policy for docstring structured sections.
+    href: /reference/configuration#docstring-budgets
+    key: docstring-structured-policy
+  - blurb: Per-rule toggle, the bare bool in `[rules]`.
+    href: /reference/configuration#per-rule-facets
+    key: enabled
+  - blurb: Import-wrap column budget, falls back to `code-line-length`.
+    href: /reference/configuration#top-level-keys
+    key: import-line-length
+  - blurb: Package names lifted into the local-package import group.
+    href: /reference/configuration#imports
+    key: imports.first-party
+  - blurb: Per-rule width-spread budget for an alignment run.
+    href: /reference/configuration#per-rule-facets
+    key: max-shift
+  - blurb: Glob list selecting the files an override entry applies its partial config to.
+    href: /reference/configuration#per-pattern-overrides
+    key: overrides.paths
+  - blurb: Python version the parser reads against.
+    href: /reference/configuration#top-level-keys
+    key: target-version
+exit-code:
+  - blurb: Clean run, every rewrite applied.
+    href: /reference/exit-codes
+    key: '0'
+  - blurb: Pending rewrites under check.
+    href: /reference/exit-codes
+    key: '1'
+  - blurb: Lint diagnostics emitted.
+    href: /reference/exit-codes
+    key: '2'
+  - blurb: Parse failure on at least one file.
+    href: /reference/exit-codes
+    key: '3'
+  - blurb: Invalid CLI invocation or configuration.
+    href: /reference/exit-codes
+    key: '4'
+output-format:
+  - blurb: Workflow-command annotations for inline PR review.
+    href: /reference/output-formats#github
+    key: github
+  - blurb: LSP-style structured diagnostics.
+    href: /reference/output-formats#json
+    key: json
+  - blurb: GitHub Code Scanning upload format.
+    href: /reference/output-formats#sarif
+    key: sarif
+  - blurb: Default human-readable output.
+    href: /reference/output-formats#text
+    key: text
+subcommand:
+  - blurb: Clear every cached entry and report the freed bytes.
+    href: /reference/cache#prose-cache-clean
+    key: prose cache clean
+  - blurb: Evict oldest entries until the configured size cap is met.
+    href: /reference/cache#prose-cache-compact
+    key: prose cache compact
+  - blurb: Print cache path, entry count, byte total, and mtimes.
+    href: /reference/cache#prose-cache-info
+    key: prose cache info
+  - blurb: Verify without rewriting, resolving to a non-zero exit code when any rewrite pends.
+    href: /reference/cli#prose-check
+    key: prose check
+  - blurb: Emit shell-completion scripts for the active shell.
+    href: /reference/cli#prose-completions
+    key: prose completions
+  - blurb: Apply every pending rewrite in place.
+    href: /reference/cli#prose-format
+    key: prose format
+  - blurb: Serve format-on-save and live diagnostics over the language-server protocol.
+    href: /reference/cli#prose-server
+    key: prose server
+suppression:
+  - blurb: 'Yapf alias for `# fmt: off`.'
+    href: /reference/suppression-directives#block-markers
+    key: '# yapf: disable'
+  - blurb: 'Yapf alias for `# fmt: on`.'
+    href: /reference/suppression-directives#block-markers
+    key: '# yapf: enable'
+  - blurb: Per-line lint suppression for the listed rule.
+    href: /reference/suppression-directives#line-markers
+    key: '# prose: ignore[<slug>]'
+  - blurb: Preserve the authored shape against rewrites.
+    href: /reference/suppression-directives#dict-literal-order-preservation
+    key: '# prose: keep'
+  - blurb: Block-format suppression open.
+    href: /reference/suppression-directives#block-markers
+    key: '# fmt: off'
+  - blurb: Block-format suppression close.
+    href: /reference/suppression-directives#block-markers
+    key: '# fmt: on'
+  - blurb: Single-line format suppression.
+    href: /reference/suppression-directives#line-markers
+    key: '# fmt: skip'

--- a/site/src/data/tools.yaml
+++ b/site/src/data/tools.yaml
@@ -1,0 +1,110 @@
+bash:
+  href: https://www.gnu.org/software/bash/
+  icon: logos:bash-icon
+  name: Bash
+  role: Shell completion target
+clap:
+  href: https://docs.rs/clap/
+  icon: logos:rust
+  name: clap
+  role: CLI parsing
+elvish:
+  href: https://elv.sh/
+  icon: logos:terminal
+  name: Elvish
+  role: Shell completion target
+emacs:
+  href: https://www.gnu.org/software/emacs/
+  icon: logos:emacs
+  name: Emacs
+  role: Editor integration target
+fish:
+  href: https://fishshell.com/
+  icon: simple-icons:fishshell
+  name: Fish
+  role: Shell completion target
+github:
+  href: https://github.com/features/actions
+  icon: simple-icons:githubactions
+  name: GitHub Actions
+  role: CI integration target
+helix:
+  href: https://helix-editor.com/
+  icon: simple-icons:helix
+  name: Helix
+  role: Editor integration target
+jetbrains:
+  href: https://www.jetbrains.com/
+  icon: logos:intellij-idea
+  name: JetBrains
+  role: Editor integration target
+maturin:
+  href: https://www.maturin.rs/
+  icon: logos:rust
+  name: maturin
+  role: Rust to Python wheel build
+mise:
+  href: https://mise.jdx.dev/
+  icon: custom:mise
+  name: mise
+  role: Tool versions and tasks
+neovim:
+  href: https://neovim.io/
+  icon: logos:neovim
+  name: Neovim
+  role: Editor integration target
+powershell:
+  href: https://learn.microsoft.com/powershell/
+  icon: simple-icons:powershell
+  name: PowerShell
+  role: Shell completion target
+precommit:
+  href: https://pre-commit.com/
+  icon: simple-icons:precommit
+  name: pre-commit
+  role: Git commit-boundary hook
+python:
+  href: https://www.python.org/
+  icon: logos:python
+  name: Python
+  role: The target language
+rayon:
+  href: https://docs.rs/rayon/
+  icon: logos:rust
+  name: rayon
+  role: Per-file parallelism
+ruff:
+  href: https://docs.astral.sh/ruff/
+  icon: simple-icons:ruff
+  name: Ruff
+  role: Parser & AST
+rust:
+  href: https://www.rust-lang.org/
+  icon: simple-icons:rust
+  name: Rust
+  role: Implementation language
+sublime:
+  href: https://www.sublimetext.com/
+  icon: logos:sublimetext-icon
+  name: Sublime Text
+  role: Editor integration target
+uv:
+  href: https://docs.astral.sh/uv/
+  icon: simple-icons:uv
+  name: uv
+  role: Canonical install path
+vitepress:
+  href: https://vitepress.dev/
+  icon: simple-icons:vitepress
+  name: VitePress
+  role: Docs site framework
+vscode:
+  href: https://code.visualstudio.com/
+  icon: logos:visual-studio-code
+  name: VS Code
+  role: Editor integration target
+zsh:
+  href: https://www.zsh.org/
+  icon: logos:zsh
+  name: Zsh
+  role: Shell completion target

--- a/site/src/lib/content/docs-loader.ts
+++ b/site/src/lib/content/docs-loader.ts
@@ -1,0 +1,30 @@
+import { docsLoader }           from '@astrojs/starlight/loaders'
+import type { DataStore, Loader } from 'astro/loaders'
+
+import { assertCorpusIntegrity } from './integrity'
+import type { CorpusEntry }      from './integrity'
+
+const DOCS_ROOT = 'src/content/docs/'
+
+// Wraps Starlight's `docsLoader` so the cross-record integrity pass runs once
+// the store is populated, since a loader sees its own collection in full where
+// a per-record schema sees one entry at a time.
+export function docsLoaderWithIntegrity(): Loader {
+  const inner = docsLoader()
+  return {
+    ...inner,
+    name: 'docs-with-integrity',
+    load: async context => {
+      await inner.load(context)
+      assertCorpusIntegrity(corpusEntries(context.store))
+    }
+  }
+}
+
+function* corpusEntries(store: DataStore): Generator<CorpusEntry> {
+  for (const { data, filePath } of store.values()) {
+    if (filePath === undefined) continue
+    const root = filePath.indexOf(DOCS_ROOT)
+    if (root !== -1) yield { data, path: filePath.slice(root + DOCS_ROOT.length) }
+  }
+}

--- a/site/src/lib/content/fixtures.ts
+++ b/site/src/lib/content/fixtures.ts
@@ -40,7 +40,7 @@ export function fixturesLoader(): Loader {
             data: {
               findings : await readFindings(dir),
               input    : source,
-              output   : snapshotBody(snapshot).replace(/\s+$/, '\n'),
+              output   : snapshotBody(snapshot).trimEnd() + '\n',
               ...(await readDocs(dir))
             }
           })

--- a/site/src/lib/content/fixtures.ts
+++ b/site/src/lib/content/fixtures.ts
@@ -11,13 +11,6 @@ const INPUT_FILE    = 'input.py'
 const META_FILE     = 'meta.toml'
 const SNAPSHOT_FILE = 'input.py.snap'
 
-interface FixtureDocs {
-  canonical?   : boolean
-  description?  : string
-  previewable? : boolean
-  title?        : string
-}
-
 // Folds a fixture case directory into one entry the built-in loaders cannot
 // produce, pairing the input with the snapshot output, the lint findings the
 // harness emits, and the `[docs]` table that surfaces the case on its rule
@@ -68,15 +61,19 @@ function snapshotBody(raw: string): string {
   return close === -1 ? raw : raw.slice(close + 5)
 }
 
+async function readOptional(dir: string, name: string): Promise<string | null> {
+  const file = path.join(dir, name)
+  return existsSync(file) ? fs.readFile(file, 'utf8') : null
+}
+
 async function readFindings(dir: string): Promise<unknown[]> {
-  const file = path.join(dir, FINDINGS_FILE)
-  if (!existsSync(file)) return []
-  const body = snapshotBody(await fs.readFile(file, 'utf8')).trim()
+  const raw = await readOptional(dir, FINDINGS_FILE)
+  if (raw === null) return []
+  const body = snapshotBody(raw).trim()
   return body ? (JSON.parse(body) as unknown[]) : []
 }
 
-async function readDocs(dir: string): Promise<FixtureDocs> {
-  const file = path.join(dir, META_FILE)
-  if (!existsSync(file)) return {}
-  return (parse(await fs.readFile(file, 'utf8')) as { docs?: FixtureDocs }).docs ?? {}
+async function readDocs(dir: string): Promise<Record<string, unknown>> {
+  const raw = await readOptional(dir, META_FILE)
+  return raw === null ? {} : (parse(raw) as { docs?: Record<string, unknown> }).docs ?? {}
 }

--- a/site/src/lib/content/fixtures.ts
+++ b/site/src/lib/content/fixtures.ts
@@ -1,0 +1,82 @@
+import { existsSync, readdirSync } from 'node:fs'
+import fs                          from 'node:fs/promises'
+import path                        from 'node:path'
+import { fileURLToPath }           from 'node:url'
+
+import { parse }       from 'smol-toml'
+import type { Loader } from 'astro/loaders'
+
+const FINDINGS_FILE = 'lint_findings.snap'
+const INPUT_FILE    = 'input.py'
+const META_FILE     = 'meta.toml'
+const SNAPSHOT_FILE = 'input.py.snap'
+
+interface FixtureDocs {
+  canonical?   : boolean
+  description?  : string
+  previewable? : boolean
+  title?        : string
+}
+
+// Folds a fixture case directory into one entry the built-in loaders cannot
+// produce, pairing the input with the snapshot output, the lint findings the
+// harness emits, and the `[docs]` table that surfaces the case on its rule
+// page. The case id is `<rule>/<case>` with the rule slug in kebab form so it
+// joins the docs collection's rule slugs.
+export function fixturesLoader(): Loader {
+  return {
+    name: 'prose-fixtures',
+    load: async ({ config, parseData, store }) => {
+      const root = fileURLToPath(new URL('../crate/tests/fixtures/', config.root))
+      store.clear()
+      for (const rule of subdirectories(root)) {
+        const ruleDir = path.join(root, rule)
+        for (const name of subdirectories(ruleDir)) {
+          const dir   = path.join(ruleDir, name)
+          const input = path.join(dir, INPUT_FILE)
+          const snap  = path.join(dir, SNAPSHOT_FILE)
+          if (!existsSync(input) || !existsSync(snap)) continue
+
+          const [source, snapshot] = await Promise.all([
+            fs.readFile(input, 'utf8'),
+            fs.readFile(snap, 'utf8')
+          ])
+          const id   = `${rule.replaceAll('_', '-')}/${name}`
+          const data = await parseData({
+            id,
+            data: {
+              findings : await readFindings(dir),
+              input    : source,
+              output   : snapshotBody(snapshot).replace(/\s+$/, '\n'),
+              ...(await readDocs(dir))
+            }
+          })
+          store.set({ data, id })
+        }
+      }
+    }
+  }
+}
+
+const subdirectories = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).filter(e => e.isDirectory()).map(e => e.name).sort()
+
+// Drops the leading insta YAML frontmatter the snapshot tooling writes,
+// leaving the recorded body the source-of-truth output.
+function snapshotBody(raw: string): string {
+  const close = raw.startsWith('---\n') ? raw.indexOf('\n---\n', 4) : -1
+  return close === -1 ? raw : raw.slice(close + 5)
+}
+
+async function readFindings(dir: string): Promise<unknown[]> {
+  const file = path.join(dir, FINDINGS_FILE)
+  if (!existsSync(file)) return []
+  const body = snapshotBody(await fs.readFile(file, 'utf8')).trim()
+  return body ? (JSON.parse(body) as unknown[]) : []
+}
+
+async function readDocs(dir: string): Promise<FixtureDocs> {
+  const file = path.join(dir, META_FILE)
+  if (!existsSync(file)) return {}
+  return (parse(await fs.readFile(file, 'utf8')) as { docs?: FixtureDocs }).docs ?? {}
+}

--- a/site/src/lib/content/integrity.ts
+++ b/site/src/lib/content/integrity.ts
@@ -1,22 +1,16 @@
-import { FAMILY_ORDER }   from '../shared/registries'
-import type { RuleFamily } from '../shared/registries'
+import { FAMILY_ORDER }         from '../shared/registries'
+import type { RuleFamily }      from '../shared/registries'
+import type { DocsFrontmatter } from './schemas'
 
 // `consumedBy` names a primitive's consumers, which span rules, sibling
 // primitives, and the CLI, so the CLI is a legitimate consumer that owns no
 // primitive page of its own.
 const CLI_CONSUMER = 'cli'
 
-interface CorpusFrontmatter {
-  caption?    : string
-  consumedBy? : readonly string[]
-  consumes?   : readonly string[]
-  related?    : readonly string[]
-}
-
 // One docs entry plus its path relative to `src/content/docs`, which carries
 // the section and family the cross-record checks read off the directory tree.
 export interface CorpusEntry {
-  data : CorpusFrontmatter
+  data : DocsFrontmatter
   path : string
 }
 

--- a/site/src/lib/content/integrity.ts
+++ b/site/src/lib/content/integrity.ts
@@ -21,7 +21,6 @@ export interface CorpusEntry {
 }
 
 interface Rule {
-  caption : string
   family  : RuleFamily
   related : readonly string[]
   slug    : string
@@ -37,11 +36,10 @@ const isFamily = (name: string): name is RuleFamily => (FAMILY_ORDER as readonly
 
 const slugOf = (file: string): string => file.replace(/\.mdx?$/, '')
 
-function requireCaption(value: string | undefined, slug: string): string {
+function assertCaption(value: string | undefined, slug: string): void {
   if (typeof value !== 'string' || value.trim() === '') {
     throw new Error(`rule "${slug}" is missing its caption`)
   }
-  return value
 }
 
 // Enforces the relationship invariants a per-record schema cannot reach over
@@ -57,7 +55,7 @@ export function assertCorpusIntegrity(entries: Iterable<CorpusEntry>): void {
   for (const { data, path } of entries) {
     const parts = path.split('/')
     const file  = parts.at(-1) ?? ''
-    if (file === 'index.md' || file === 'index.mdx') continue
+    if (slugOf(file) === 'index') continue
 
     if (parts[0] === 'rules') {
       const family = parts[1]
@@ -66,10 +64,10 @@ export function assertCorpusIntegrity(entries: Iterable<CorpusEntry>): void {
         continue
       }
       const slug = slugOf(file)
+      assertCaption(data.caption, slug)
       rules.push({
-        caption : requireCaption(data.caption, slug),
         family,
-        related : data.related ?? [],
+        related: data.related ?? [],
         slug
       })
     } else if (parts[0] === 'primitives' && parts.length === 2) {

--- a/site/src/lib/content/integrity.ts
+++ b/site/src/lib/content/integrity.ts
@@ -1,0 +1,131 @@
+import { FAMILY_ORDER }   from '../shared/registries'
+import type { RuleFamily } from '../shared/registries'
+
+// `consumedBy` names a primitive's consumers, which span rules, sibling
+// primitives, and the CLI, so the CLI is a legitimate consumer that owns no
+// primitive page of its own.
+const CLI_CONSUMER = 'cli'
+
+interface CorpusFrontmatter {
+  caption?    : string
+  consumedBy? : readonly string[]
+  consumes?   : readonly string[]
+  related?    : readonly string[]
+}
+
+// One docs entry plus its path relative to `src/content/docs`, which carries
+// the section and family the cross-record checks read off the directory tree.
+export interface CorpusEntry {
+  data : CorpusFrontmatter
+  path : string
+}
+
+interface Rule {
+  caption : string
+  family  : RuleFamily
+  related : readonly string[]
+  slug    : string
+}
+
+interface Primitive {
+  consumedBy : readonly string[]
+  consumes   : readonly string[]
+  slug       : string
+}
+
+const isFamily = (name: string): name is RuleFamily => (FAMILY_ORDER as readonly string[]).includes(name)
+
+const slugOf = (file: string): string => file.replace(/\.mdx?$/, '')
+
+function requireCaption(value: string | undefined, slug: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`rule "${slug}" is missing its caption`)
+  }
+  return value
+}
+
+// Enforces the relationship invariants a per-record schema cannot reach over
+// the loaded docs collection, throwing on the first violation to fail the
+// build. Covers stray-page rejection and family-directory legitimacy, one
+// family per rule slug, `related` resolution, and the primitive
+// consumes-and-consumed-by graph.
+export function assertCorpusIntegrity(entries: Iterable<CorpusEntry>): void {
+  const primitives : Primitive[] = []
+  const rules      : Rule[]      = []
+  const strays     : string[]    = []
+
+  for (const { data, path } of entries) {
+    const parts = path.split('/')
+    const file  = parts.at(-1) ?? ''
+    if (file === 'index.md' || file === 'index.mdx') continue
+
+    if (parts[0] === 'rules') {
+      const family = parts[1]
+      if (parts.length !== 3 || !isFamily(family)) {
+        strays.push(path)
+        continue
+      }
+      const slug = slugOf(file)
+      rules.push({
+        caption : requireCaption(data.caption, slug),
+        family,
+        related : data.related ?? [],
+        slug
+      })
+    } else if (parts[0] === 'primitives' && parts.length === 2) {
+      primitives.push({
+        consumedBy : data.consumedBy ?? [],
+        consumes   : data.consumes ?? [],
+        slug       : slugOf(file)
+      })
+    }
+  }
+
+  if (strays.length > 0) {
+    throw new Error(`rule pages must live in a family directory, found stray: ${strays.join(', ')}`)
+  }
+  assertOneFamilyPerSlug(rules)
+  assertRelatedResolves(rules)
+  assertPrimitiveGraph(rules, primitives)
+}
+
+function assertOneFamilyPerSlug(rules: readonly Rule[]): void {
+  const placed = new Map<string, RuleFamily>()
+  for (const { family, slug } of rules) {
+    const prior = placed.get(slug)
+    if (prior !== undefined && prior !== family) {
+      throw new Error(`rule "${slug}" appears in both the ${prior} and ${family} families`)
+    }
+    placed.set(slug, family)
+  }
+}
+
+function assertRelatedResolves(rules: readonly Rule[]): void {
+  const slugs = new Set(rules.map(r => r.slug))
+  for (const { related, slug } of rules) {
+    for (const ref of related) {
+      if (!slugs.has(ref)) throw new Error(`rule "${slug}" lists unknown related rule "${ref}"`)
+    }
+  }
+}
+
+// Validates that every edge of the consumes-and-consumed-by graph resolves to a
+// real node. A `consumes` edge names another primitive, whereas a `consumedBy`
+// edge names a consumer the primitive serves, which spans rules, sibling
+// primitives, and the CLI. The graph is not a strict inverse, because a
+// primitive curates the consumers it lists rather than mirroring every edge.
+function assertPrimitiveGraph(rules: readonly Rule[], primitives: readonly Primitive[]): void {
+  const primitiveSlugs = new Set(primitives.map(p => p.slug))
+  const ruleSlugs      = new Set(rules.map(r => r.slug))
+  const consumerOk     = (name: string): boolean =>
+    name === CLI_CONSUMER || primitiveSlugs.has(name) || ruleSlugs.has(name)
+
+  for (const { consumedBy, consumes, slug } of primitives) {
+    for (const dep of consumes) {
+      if (!primitiveSlugs.has(dep)) throw new Error(`primitive "${slug}" consumes unknown primitive "${dep}"`)
+    }
+    for (const consumer of consumedBy) {
+      if (!consumerOk(consumer)) throw new Error(`primitive "${slug}" lists unknown consumer "${consumer}"`)
+    }
+  }
+}

--- a/site/src/lib/content/schemas.ts
+++ b/site/src/lib/content/schemas.ts
@@ -20,6 +20,8 @@ export const docsExtension = z.object({
   tagline    : z.string().optional()
 })
 
+export type DocsFrontmatter = z.infer<typeof docsExtension>
+
 export const glossary = z.object({
   aliases    : z.array(z.string()).optional(),
   definition : z.string(),

--- a/site/src/lib/content/schemas.ts
+++ b/site/src/lib/content/schemas.ts
@@ -1,0 +1,123 @@
+import { z } from 'astro/zod'
+
+import { GLOSSARY_FAMILIES, PRIMITIVE_LAYERS, PRIMITIVE_STABILITIES } from '../shared/registries'
+
+const DIRECTIVE_SCOPES = ['block', 'file', 'line'] as const
+const PART_ROLES       = ['action', 'comment', 'namespace', 'payload'] as const
+
+// The rule and primitive frontmatter the `docs` collection carries beyond
+// Starlight's own fields, every field optional because one schema spans the
+// rules, primitives, and prose pages alike, with the per-section requirements
+// enforced by the cross-record integrity pass.
+export const docsExtension = z.object({
+  caption    : z.string().optional(),
+  consumedBy : z.array(z.string()).optional(),
+  consumes   : z.array(z.string()).optional(),
+  layer      : z.enum(PRIMITIVE_LAYERS).optional(),
+  related    : z.array(z.string()).optional(),
+  stability  : z.enum(PRIMITIVE_STABILITIES).optional(),
+  summary    : z.string().optional(),
+  tagline    : z.string().optional()
+})
+
+export const glossary = z.object({
+  aliases    : z.array(z.string()).optional(),
+  definition : z.string(),
+  families   : z.array(z.enum(GLOSSARY_FAMILIES)).nonempty(),
+  href       : z.string().optional(),
+  rule       : z.string().optional()
+})
+
+export const tool = z.object({
+  href : z.string(),
+  icon : z.string(),
+  name : z.string(),
+  role : z.string()
+})
+
+export const tokenIndex = z.array(z.object({
+  blurb : z.string(),
+  href  : z.string(),
+  key   : z.string()
+}))
+
+export const exitCode = z.object({
+  code    : z.number(),
+  detail  : z.array(z.string()).nonempty(),
+  label   : z.string(),
+  summary : z.string()
+})
+
+export const directive = z.object({
+  aliasOf   : z.string().optional(),
+  effect    : z.string(),
+  example   : z.string(),
+  form      : z.string(),
+  pairId    : z.string().optional(),
+  pairRole  : z.enum(['closes', 'opens']).optional(),
+  parts     : z.array(z.object({ role: z.enum(PART_ROLES), text: z.string() })).nonempty(),
+  scope     : z.enum(DIRECTIVE_SCOPES),
+  scopeNote : z.string().optional()
+})
+
+export const editorConfig = z.object({
+  caption  : z.string(),
+  code     : z.string(),
+  language : z.string(),
+  name     : z.string(),
+  target   : z.string()
+})
+
+export const shellCompletion = z.object({
+  caption  : z.string(),
+  code     : z.string(),
+  command  : z.string(),
+  language : z.string(),
+  mono     : z.string(),
+  name     : z.string(),
+  note     : z.string(),
+  target   : z.string()
+})
+
+export const ruleConfigPreset = z.object({
+  rows: z.array(z.object({
+    default : z.string(),
+    key     : z.string(),
+    meaning : z.string(),
+    type    : z.string()
+  })).nonempty()
+})
+
+export const landingSurface = z.object({ body: z.string() })
+
+export const landingStep = z.object({
+  body     : z.string(),
+  code     : z.string(),
+  language : z.string(),
+  title    : z.string()
+})
+
+export const composition = z
+  .object({ harness: z.object({ rules: z.array(z.string()).nonempty() }) })
+  .transform(({ harness }) => ({ rules: harness.rules }))
+
+const findingLocation = z.object({ column: z.number(), row: z.number() })
+
+export const fixture = z.object({
+  canonical   : z.boolean().optional(),
+  description : z.string().optional(),
+  findings    : z.array(z.object({
+    code         : z.string(),
+    end_location : findingLocation,
+    fix          : z.object({
+      applicability : z.string(),
+      edits         : z.array(z.object({ before: z.string(), content: z.string() }))
+    }).nullable(),
+    location     : findingLocation,
+    message      : z.string()
+  })),
+  input       : z.string(),
+  output      : z.string(),
+  previewable : z.boolean().optional(),
+  title       : z.string().optional()
+})

--- a/site/src/lib/shared/registries.ts
+++ b/site/src/lib/shared/registries.ts
@@ -1,0 +1,13 @@
+// The hand-curated taxonomy unions that the content schemas and the integrity
+// check read. Runtime classification flows from frontmatter and the directory
+// tree, so this module carries only the closed vocabularies a Zod enum and the
+// cross-record pass validate against.
+
+export const FAMILY_ORDER = ['alignment', 'docs', 'formatting', 'layout', 'lint', 'ordering'] as const
+export type RuleFamily = (typeof FAMILY_ORDER)[number]
+
+export const GLOSSARY_FAMILIES = [...FAMILY_ORDER, 'cli', 'engine'] as const
+
+export const PRIMITIVE_LAYERS = ['analysis', 'base', 'orchestration'] as const
+
+export const PRIMITIVE_STABILITIES = ['internal', 'public'] as const


### PR DESCRIPTION
### 🪻 Quick Summary

Defines the docs corpus as Astro content collections, each page and structured dataset becoming a declarative collection with a Zod schema, so the build generates the types and slug unions the rest of the migration reads. The cross-document invariants a per-record schema cannot reach (*a slug claimed by two families, a `related` reference resolving to nothing, a `consumes` naming an unknown primitive*) move into a build-time integrity pass that runs over the loaded collections.

---

### 🗞️ Key Changes

- Organizes the page corpus under Starlight's `docs` collection rooted at `site/src/content/docs`, the rule pages nested by family beside the primitives, usage, reference, and integration pages, wired through a `docsLoader` wrapper and a `docsSchema` extended with the rule and primitive frontmatter so the build generates the page types and slug unions.

- Models the structured corpora on Astro's built-in `file()` loader (*glossary, tools, editor-configs, exit-codes, shell-completions, directives, the token index, the landing surfaces and workflow, and rule-config presets*) and the composition cases on a `glob()`, each validated by a Zod schema in `site/src/lib/content/schemas.ts`.

- Adds the custom fixtures loader in `site/src/lib/content/fixtures.ts`, folding each case directory's input, snapshot output, lint findings, and `meta.toml` docs table into the single entry no built-in loader produces.

- Adds the cross-record integrity pass in `site/src/lib/content/integrity.ts`, run by the `docsLoader` wrapper once the store is populated, enforcing stray-page rejection, family-directory legitimacy, one family per rule slug, `related` resolution, and the primitive consumes-and-consumed-by graph over the loaded collection.

- Carries the closed taxonomy vocabularies (*rule families, primitive layers and stabilities*) in `site/src/lib/shared/registries.ts` as the source the Zod enums and the integrity pass validate against, the runtime classification flowing from per-entry frontmatter and the directory tree instead of a hand-curated lookup.

- Hoists `smol-toml` to a direct `site` dependency for the fixtures loader's `meta.toml` parsing.

---

### 🧵 Related Issues

- Closes #362