### PR TITLE
[365] Build the SEO surface and Open Graph cards on the Astro modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,13 @@ jobs:
       - *build-prose
       - *provision-bun
 
+      - name : Restore the OG card cache
+        uses : actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          key          : og-cards-${{ runner.os }}-${{ github.sha }}
+          path         : .cache/og
+          restore-keys : og-cards-${{ runner.os }}-
+
       - name : Build the site
         run  : mise run press
 

--- a/.mise/tasks/links
+++ b/.mise/tasks/links
@@ -4,4 +4,7 @@
 #MISE depends=["press"]
 #MISE tools={"aqua:lycheeverse/lychee" = "latest"}
 
-lychee --no-progress --base-url https://prose.fyi --exclude '^https?://(www\.)?prose\.fyi' dist
+lychee --no-progress --base-url https://prose.fyi \
+  --exclude '^https?://(www\.)?prose\.fyi' \
+  --exclude '^https://github\.com/Jybbs/prose/edit/' \
+  dist

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -6,19 +6,28 @@ import starlightLinksValidator from 'starlight-links-validator'
 import { buildContentTimestamps, lastmodForUrl }       from './src/lib/config/page-timestamps'
 import { watchCrateSources }                           from './src/lib/integrations/watch-crate'
 import { lintFlagPlugin, proseProcessor, shikiConfig } from './src/lib/markdown/config'
+import { REPO_URL }                                    from './src/lib/shared/constants'
+import { resolveColor }                                from './src/lib/tokens/resolve'
 
-const siteRoot   = new URL('./', import.meta.url)
-const timestamps = buildContentTimestamps(siteRoot)
+const timestamps = buildContentTimestamps(new URL('./', import.meta.url))
 
 export default defineConfig({
   site         : 'https://prose.fyi',
   markdown     : { processor: proseProcessor, shikiConfig },
   integrations : [
     starlight({
-      title          : 'Prose',
-      lastUpdated    : true,
-      expressiveCode : { plugins: [lintFlagPlugin] },
-      plugins        : [starlightLinksValidator()]
+      title           : 'Prose',
+      components      : { SocialIcons: './src/components/SocialIcons.astro' },
+      editLink        : { baseUrl: `${REPO_URL}/edit/main/site/` },
+      expressiveCode  : { plugins: [lintFlagPlugin] },
+      lastUpdated     : true,
+      plugins         : [starlightLinksValidator()],
+      routeMiddleware : './src/lib/head/middleware.ts',
+      titleDelimiter  : '·',
+      head            : [{
+        attrs : { content: resolveColor('palette-ube'), name: 'theme-color' },
+        tag   : 'meta'
+      }]
     }),
     sitemap({
       serialize(item) {

--- a/site/astro.config.ts
+++ b/site/astro.config.ts
@@ -16,13 +16,13 @@ export default defineConfig({
   markdown     : { processor: proseProcessor, shikiConfig },
   integrations : [
     starlight({
-      title           : 'Prose',
       components      : { SocialIcons: './src/components/SocialIcons.astro' },
       editLink        : { baseUrl: `${REPO_URL}/edit/main/site/` },
       expressiveCode  : { plugins: [lintFlagPlugin] },
       lastUpdated     : true,
       plugins         : [starlightLinksValidator()],
       routeMiddleware : './src/lib/head/middleware.ts',
+      title           : 'Prose',
       titleDelimiter  : '·',
       head            : [{
         attrs : { content: resolveColor('palette-ube'), name: 'theme-color' },

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -6,12 +6,21 @@
       "name": "prose-site",
       "dependencies": {
         "@astrojs/starlight": "0.41.1",
+        "@fontsource/fraunces": "5.2.9",
+        "@fontsource/jetbrains-mono": "5.2.8",
+        "@fontsource/lora": "5.2.8",
         "@shikijs/magic-move": "4.3.0",
         "astro": "7.0.3",
+        "cacache": "21.0.1",
+        "culori": "4.0.2",
         "ofetch": "1.5.1",
+        "satori": "0.26.0",
       },
       "devDependencies": {
         "@astrojs/check": "0.9.9",
+        "@types/cacache": "20.0.1",
+        "@types/culori": "4.0.1",
+        "schema-dts": "2.0.0",
         "starlight-links-validator": "0.25.1",
         "typescript": "5.9.3",
       },
@@ -178,6 +187,12 @@
 
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.44.0", "", { "dependencies": { "@expressive-code/core": "^0.44.0" } }, "sha512-0/m3A5b+lz2upyNq+wzZ1S69HRoJmyFs5LsR42lVZ9pmGRlBiSBYQpvqlji4DBj1+Riamxc0AvcCr5kuzOQeWA=="],
 
+    "@fontsource/fraunces": ["@fontsource/fraunces@5.2.9", "", {}, "sha512-XDzuddBtoC7BZgZdBn6b7hsFZY2+V1hgN7yca5fBTKuHjb/lOd45a0Ji8dTUgFhPoL7RdGupo+bC2BFSt6UH8Q=="],
+
+    "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
+
+    "@fontsource/lora": ["@fontsource/lora@5.2.8", "", {}, "sha512-AQlfsHw4TP1x/eb2IZ6VjQ70ctKa39m9JN9A4zlvDOeKYLrCs+GaYIEQ86Y6YfSPGHn01bErXkRcyktOW0LOPQ=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -233,6 +248,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@npmcli/fs": ["@npmcli/fs@6.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-AheOs4swKka/XLtht6xxJDPezlQ7K2IYQ9Y8lST4JLDjnralnWuMM9AE2CdVcgQJ5omrXhsRzM7F7aYmeZBvKQ=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -306,7 +323,13 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@types/cacache": ["@types/cacache@20.0.1", "", { "dependencies": { "@types/node": "*", "minipass": "*" } }, "sha512-QlKW3AFoFr/hvPHwFHMIVUH/ZCYeetBNou3PCmxu5LaNDvrtBlPJtIA6uhmU9JRt9oxj7IYoqoLcpxtzpPiTcw=="],
+
+    "@types/culori": ["@types/culori@4.0.1", "", {}, "sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -388,11 +411,21 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
     "bcp-47": ["bcp-47@2.1.0", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w=="],
 
     "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+
+    "cacache": ["cacache@21.0.1", "", { "dependencies": { "@npmcli/fs": "^6.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^14.0.0" } }, "sha512-pTwz/uj3Jyp6WXdJ6fWhR+7LVxVs6RyroQSn7KJwHsSxXuyGSp0pcMVcwSwTpCFq1X2YG8QBe0W+vN+cr0SwzA=="],
+
+    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -430,9 +463,19 @@
 
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
+    "css-background-parser": ["css-background-parser@0.1.0", "", {}, "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA=="],
+
+    "css-box-shadow": ["css-box-shadow@1.0.0-3", "", {}, "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg=="],
+
+    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
+
+    "css-gradient-parser": ["css-gradient-parser@0.0.17", "", {}, "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg=="],
+
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
     "css-selector-parser": ["css-selector-parser@3.3.0", "", {}, "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g=="],
+
+    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -441,6 +484,8 @@
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
+
+    "culori": ["culori@4.0.2", "", {}, "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -478,6 +523,8 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@2.0.1", "", {}, "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g=="],
+
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
@@ -491,6 +538,8 @@
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -526,11 +575,15 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.7.4", "", {}, "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="],
+
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
 
     "fontkitten": ["fontkitten@1.0.3", "", { "dependencies": { "tiny-inflate": "^1.0.3" } }, "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw=="],
+
+    "fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -539,6 +592,8 @@
     "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
 
@@ -583,6 +638,8 @@
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "hex-rgb": ["hex-rgb@4.3.0", "", {}, "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
@@ -651,6 +708,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -774,6 +833,16 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
+
+    "minipass-flush": ["minipass-flush@1.0.7", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA=="],
+
+    "minipass-pipeline": ["minipass-pipeline@1.2.4", "", { "dependencies": { "minipass": "^3.0.0" } }, "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A=="],
+
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -806,6 +875,8 @@
 
     "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
 
+    "p-map": ["p-map@7.0.5", "", {}, "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA=="],
+
     "p-queue": ["p-queue@9.3.0", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang=="],
 
     "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
@@ -814,6 +885,10 @@
 
     "pagefind": ["pagefind@1.5.2", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.5.2", "@pagefind/darwin-x64": "1.5.2", "@pagefind/freebsd-x64": "1.5.2", "@pagefind/linux-arm64": "1.5.2", "@pagefind/linux-x64": "1.5.2", "@pagefind/windows-arm64": "1.5.2", "@pagefind/windows-x64": "1.5.2" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q=="],
 
+    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
+    "parse-css-color": ["parse-css-color@0.2.1", "", { "dependencies": { "color-name": "^1.1.4", "hex-rgb": "^4.1.0" } }, "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
@@ -821,6 +896,8 @@
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
@@ -833,6 +910,8 @@
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "prettier": ["prettier@3.9.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-HWmu+K+zvHNpaMfSnYeqdqrDbR16cuIXaPx8WoHaviQkDJh1/0BNtOZmHVQI5jc3wXv0H1yXc9wjvFdXh+n3hQ=="],
 
@@ -906,9 +985,15 @@
 
     "rolldown": ["rolldown@1.1.3", "", { "dependencies": { "@oxc-project/types": "=0.137.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.3", "@rolldown/binding-darwin-arm64": "1.1.3", "@rolldown/binding-darwin-x64": "1.1.3", "@rolldown/binding-freebsd-x64": "1.1.3", "@rolldown/binding-linux-arm-gnueabihf": "1.1.3", "@rolldown/binding-linux-arm64-gnu": "1.1.3", "@rolldown/binding-linux-arm64-musl": "1.1.3", "@rolldown/binding-linux-ppc64-gnu": "1.1.3", "@rolldown/binding-linux-s390x-gnu": "1.1.3", "@rolldown/binding-linux-x64-gnu": "1.1.3", "@rolldown/binding-linux-x64-musl": "1.1.3", "@rolldown/binding-openharmony-arm64": "1.1.3", "@rolldown/binding-wasm32-wasi": "1.1.3", "@rolldown/binding-win32-arm64-msvc": "1.1.3", "@rolldown/binding-win32-x64-msvc": "1.1.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g=="],
 
+    "satori": ["satori@0.26.0", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA=="],
+
     "satteri": ["satteri@0.9.3", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.9.3", "@bruits/satteri-darwin-x64": "0.9.3", "@bruits/satteri-linux-arm64-gnu": "0.9.3", "@bruits/satteri-linux-arm64-musl": "0.9.3", "@bruits/satteri-linux-x64-gnu": "0.9.3", "@bruits/satteri-linux-x64-musl": "0.9.3", "@bruits/satteri-wasm32-wasi": "0.9.3", "@bruits/satteri-win32-arm64-msvc": "0.9.3", "@bruits/satteri-win32-x64-msvc": "0.9.3" } }, "sha512-2XfBh89LCnBMFkNOeVKkBLelAZcIA17VLHsgJum1tJ2fXiPZDN/TDXv4ku46rFOQXYd41LJ0kiZh5gPqExcCsg=="],
 
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "schema-dts": ["schema-dts@2.0.0", "", { "dependencies": { "schema-dts-lib": "^1.0.0" } }, "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw=="],
+
+    "schema-dts-lib": ["schema-dts-lib@1.0.0", "", { "peerDependencies": { "typescript": ">=4.9.5" } }, "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A=="],
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
@@ -928,11 +1013,15 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "ssri": ["ssri@14.0.0", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-jQxKI0yx0ZnTKrqjKkLDV2DXkBQn3k49JVmVqDGcDwKDtGDbImD/GXsq04KD0VVzCQQ9wZJYal3RwR1GzWTSow=="],
+
     "starlight-links-validator": ["starlight-links-validator@0.25.1", "", { "dependencies": { "@astrojs/markdown-satteri": "^0.3.2", "@types/picomatch": "^4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "is-absolute-url": "^5.0.0", "mdast-util-mdx-jsx": "^3.2.0", "mdast-util-to-hast": "^13.2.1", "picomatch": "^4.0.3", "satteri": "^0.9.3", "terminal-link": "^5.0.0", "unist-util-visit": "^5.1.0", "yaml": "^2.8.3" }, "peerDependencies": { "@astrojs/starlight": ">=0.41.0", "astro": ">=7.0.2" } }, "sha512-49F1JRvaJmvKSnM/jPFTjDVVwDJBUJ78jZE+fOResTRwYSa8MzPQzsJlSS1FeolsdqAat1evAu//WgIm65uyzw=="],
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string.prototype.codepointat": ["string.prototype.codepointat@0.2.1", "", {}, "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -977,6 +1066,8 @@
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -1062,6 +1153,8 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yaml-language-server": ["yaml-language-server@1.20.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "prettier": "^3.5.0", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.7.1" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA=="],
@@ -1071,6 +1164,8 @@
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
@@ -1089,6 +1184,10 @@
     "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
+
+    "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/site/package.json
+++ b/site/package.json
@@ -4,14 +4,23 @@
   "private" : true,
 
   "dependencies": {
-    "@astrojs/starlight"  : "0.41.1",
-    "@shikijs/magic-move" : "4.3.0",
-    "astro"               : "7.0.3",
-    "ofetch"              : "1.5.1"
+    "@astrojs/starlight"         : "0.41.1",
+    "@fontsource/fraunces"       : "5.2.9",
+    "@fontsource/jetbrains-mono" : "5.2.8",
+    "@fontsource/lora"           : "5.2.8",
+    "@shikijs/magic-move"        : "4.3.0",
+    "astro"                      : "7.0.3",
+    "cacache"                    : "21.0.1",
+    "culori"                     : "4.0.2",
+    "ofetch"                     : "1.5.1",
+    "satori"                     : "0.26.0"
   },
 
   "devDependencies": {
     "@astrojs/check"            : "0.9.9",
+    "@types/cacache"            : "20.0.1",
+    "@types/culori"             : "4.0.1",
+    "schema-dts"                : "2.0.0",
     "starlight-links-validator" : "0.25.1",
     "typescript"                : "5.9.3"
   }

--- a/site/src/components/SocialIcons.astro
+++ b/site/src/components/SocialIcons.astro
@@ -1,0 +1,26 @@
+---
+import Default           from '@astrojs/starlight/components/SocialIcons.astro'
+import { getCollection } from 'astro:content'
+
+import { REPO_URL } from '../lib/shared/constants'
+
+const [release] = await getCollection('release')
+---
+
+<a class="version" href={`${REPO_URL}/releases`}>v{release.data.version}</a>
+<Default />
+
+<style>
+  .version {
+    color           : var(--sl-color-text-accent);
+    font-family     : var(--sl-font-mono, monospace);
+    font-size       : var(--sl-text-sm);
+    margin          : -0.5em;
+    padding         : 0.5em;
+    text-decoration : none;
+  }
+
+  .version:hover {
+    color: var(--sl-color-white);
+  }
+</style>

--- a/site/src/content/docs/rules/alignment/index.md
+++ b/site/src/content/docs/rules/alignment/index.md
@@ -1,5 +1,6 @@
 ---
 title: Alignment Rules
+warmth: warm
 ---
 
 The alignment rules align a shared token across consecutive rows so columns of assignments, annotations, and patterns read as vertical groups. The shared math lives in the aligner primitive, and each rule supplies the walker that decides what counts as a group. The per-rule `max-shift` facet bounds how far rows shift to align, wherein each rule walks a run in source order and breaks a fresh group at the first row whose width spread would exceed the cap. `false` lifts the cap so a contiguous run folds into one column, and `0` forbids any shift. A `# prose: skip` on one row holds it out of its group while the rest align around it.

--- a/site/src/content/docs/rules/docs/index.md
+++ b/site/src/content/docs/rules/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Docs Rules
+warmth: cool
 ---
 
 The docs rules read against the PEP 257 docstring set discovered by the docstring walker and reshape the body, the quote placement, or both. Description prose between the opening `"""` and the first section heading reads against `docstring-line-length` *(default 76)*, while every Title-case-headed section that follows reads against `code-line-length` *(default 88)* or both collapse to one budget when `docstring-structured-policy = "docstring-line-length"`.

--- a/site/src/content/docs/rules/formatting/index.md
+++ b/site/src/content/docs/rules/formatting/index.md
@@ -1,5 +1,6 @@
 ---
 title: Formatting Rules
+warmth: warm
 ---
 
 The formatting rules clear the small scaffolding that clutters a statement once its shape is settled, normalizing blank-line counts between definitions, shedding grouping parentheses that bind nothing, dropping a redundant `-> None`, stripping trailing commas, and removing a `from __future__ import annotations` that no longer earns its place on the target version. Each rewrite is narrower than a layout rule and more pervasive than an ordering rule, tidying what the eye reads without touching the structure it reads.

--- a/site/src/content/docs/rules/layout/index.md
+++ b/site/src/content/docs/rules/layout/index.md
@@ -1,5 +1,6 @@
 ---
 title: Layout Rules
+warmth: cool
 ---
 
 The layout rules decide the shape a bracketed construct takes once it outgrows a single line, exploding a call, signature, collection, or `from … import …` to one entry per line so each binding reads on its own and a later edit touches a single row. The trigger is a width budget like `code-line-length`, a count cap like `max-args`, or both, so the inline shape gives way to the stacked one the moment it stops being legible.

--- a/site/src/content/docs/rules/lint/index.md
+++ b/site/src/content/docs/rules/lint/index.md
@@ -1,5 +1,6 @@
 ---
 title: Lint Rules
+warmth: warm
 ---
 
 Lint rules surface diagnostics without rewriting source. They run under both `prose check` and `prose format`, returning exit code 2 when any lint diagnostic fires, and they never produce an edit. Lint coincides with its domain, in that every lint rule sits in the `lint` domain and every rule in the `lint` domain is a lint. The category-versus-domain distinction collapses cleanly to one landing.

--- a/site/src/content/docs/rules/ordering/index.md
+++ b/site/src/content/docs/rules/ordering/index.md
@@ -1,5 +1,6 @@
 ---
 title: Ordering Rules
+warmth: cool
 ---
 
 The ordering rules reorder sibling AST nodes by a deterministic key while preserving attached comments and inter-section gaps. The shared machinery lives in the orderer primitive, with each rule supplying the classifier closure that names the sort key. A pinning shape lets specific items *(class docstrings, module-level imports above a divider comment)* stay in their authored slot while the rest of the siblings redistribute.

--- a/site/src/lib/content/integrity.ts
+++ b/site/src/lib/content/integrity.ts
@@ -33,11 +33,15 @@ function assertCaption(value: string | undefined, slug: string): void {
   }
 }
 
+function assertWarmth(value: DocsFrontmatter['warmth'], family: RuleFamily): void {
+  if (value === undefined) throw new Error(`family "${family}" index is missing its warmth`)
+}
+
 // Enforces the relationship invariants a per-record schema cannot reach over
 // the loaded docs collection, throwing on the first violation to fail the
-// build. Covers stray-page rejection and family-directory legitimacy, one
-// family per rule slug, `related` resolution, and the primitive
-// consumes-and-consumed-by graph.
+// build. Covers stray-page rejection and family-directory legitimacy,
+// family-index warmth, one family per rule slug, `related` resolution, and
+// the primitive consumes-and-consumed-by graph.
 export function assertCorpusIntegrity(entries: Iterable<CorpusEntry>): void {
   const primitives : Primitive[] = []
   const rules      : Rule[]      = []
@@ -46,6 +50,10 @@ export function assertCorpusIntegrity(entries: Iterable<CorpusEntry>): void {
   for (const { data, path } of entries) {
     const parts = path.split('/')
     const file  = parts.at(-1) ?? ''
+    if (parts[0] === 'rules' && parts.length === 3 && isFamily(parts[1]) && isIndex(file)) {
+      assertWarmth(data.warmth, parts[1])
+      continue
+    }
     if (isIndex(file)) continue
 
     if (parts[0] === 'rules') {
@@ -111,10 +119,14 @@ function assertPrimitiveGraph(rules: readonly Rule[], primitives: readonly Primi
 
   for (const { consumedBy, consumes, slug } of primitives) {
     for (const dep of consumes) {
-      if (!primitiveSlugs.has(dep)) throw new Error(`primitive "${slug}" consumes unknown primitive "${dep}"`)
+      if (!primitiveSlugs.has(dep)) {
+        throw new Error(`primitive "${slug}" consumes unknown primitive "${dep}"`)
+      }
     }
     for (const consumer of consumedBy) {
-      if (!consumerOk(consumer)) throw new Error(`primitive "${slug}" lists unknown consumer "${consumer}"`)
+      if (!consumerOk(consumer)) {
+        throw new Error(`primitive "${slug}" lists unknown consumer "${consumer}"`)
+      }
     }
   }
 }

--- a/site/src/lib/content/schemas.ts
+++ b/site/src/lib/content/schemas.ts
@@ -1,14 +1,16 @@
 import { z } from 'astro/zod'
 
-import { GLOSSARY_FAMILIES, PRIMITIVE_LAYERS, PRIMITIVE_STABILITIES } from '../shared/registries'
+import {
+  FAMILY_WARMTHS, GLOSSARY_FAMILIES, PRIMITIVE_LAYERS, PRIMITIVE_STABILITIES
+} from '../shared/registries'
 
 const DIRECTIVE_SCOPES = ['block', 'file', 'line'] as const
 const PART_ROLES       = ['action', 'comment', 'namespace', 'payload'] as const
 
-// The rule and primitive frontmatter the `docs` collection carries beyond
-// Starlight's own fields, every field optional because one schema spans the
-// rules, primitives, and prose pages alike, with the per-section requirements
-// enforced by the cross-record integrity pass.
+// The rule, family-index, and primitive frontmatter the `docs` collection
+// carries beyond Starlight's own fields, every field optional because one
+// schema spans the rules, primitives, and prose pages alike, with the
+// per-section requirements enforced by the cross-record integrity pass.
 export const docsExtension = z.object({
   caption    : z.string().optional(),
   consumedBy : z.array(z.string()).optional(),
@@ -17,7 +19,8 @@ export const docsExtension = z.object({
   related    : z.array(z.string()).optional(),
   stability  : z.enum(PRIMITIVE_STABILITIES).optional(),
   summary    : z.string().optional(),
-  tagline    : z.string().optional()
+  tagline    : z.string().optional(),
+  warmth     : z.enum(FAMILY_WARMTHS).optional()
 })
 
 export type DocsFrontmatter = z.infer<typeof docsExtension>

--- a/site/src/lib/head/json-ld.ts
+++ b/site/src/lib/head/json-ld.ts
@@ -1,0 +1,38 @@
+import type { Graph, TechArticle, WithContext } from 'schema-dts'
+
+const CONTEXT = 'https://schema.org'
+
+interface ArticleFacts {
+  description ?: string
+  headline     : string
+  image        : string
+  url          : string
+}
+
+// One `TechArticle` node per docs page, carrying the headline, description,
+// canonical URL, and the page's card as its image.
+export function articleLd(facts: ArticleFacts): string {
+  const article: WithContext<TechArticle> = { '@context': CONTEXT, '@type': 'TechArticle', ...facts }
+  return JSON.stringify(article)
+}
+
+// The landing graph: the `WebSite` node plus the `SoftwareApplication` node
+// describing the formatter itself.
+export function landingLd(site: string, version: string, description?: string): string {
+  const graph: Graph = {
+    '@context' : CONTEXT,
+    '@graph'   : [
+      { '@type': 'WebSite', description, name: 'Prose', url: site },
+      {
+        '@type'             : 'SoftwareApplication',
+        applicationCategory : 'DeveloperApplication',
+        license             : 'https://opensource.org/license/mit',
+        name                : 'Prose',
+        operatingSystem     : 'Linux, macOS, Windows',
+        softwareVersion     : version,
+        url                 : site
+      }
+    ]
+  }
+  return JSON.stringify(graph)
+}

--- a/site/src/lib/head/json-ld.ts
+++ b/site/src/lib/head/json-ld.ts
@@ -12,7 +12,11 @@ interface ArticleFacts {
 // One `TechArticle` node per docs page, carrying the headline, description,
 // canonical URL, and the page's card as its image.
 export function articleLd(facts: ArticleFacts): string {
-  const article: WithContext<TechArticle> = { '@context': CONTEXT, '@type': 'TechArticle', ...facts }
+  const article: WithContext<TechArticle> = {
+    '@context' : CONTEXT,
+    '@type'    : 'TechArticle',
+    ...facts
+  }
   return JSON.stringify(article)
 }
 

--- a/site/src/lib/head/meta.ts
+++ b/site/src/lib/head/meta.ts
@@ -30,7 +30,12 @@ export function jsonLd(head: Head, content: string): void {
 
 // Rewrites the entry Starlight already emitted for the tag, falling back to a
 // push when none exists.
-export function upsertMeta(head: Head, key: 'name' | 'property', id: string, content: string): void {
+export function upsertMeta(
+  head    : Head,
+  key     : 'name' | 'property',
+  id      : string,
+  content : string
+): void {
   const existing = head.find(entry => entry.tag === 'meta' && entry.attrs?.[key] === id)
   if (existing?.attrs !== undefined) existing.attrs.content = content
   else head.push(meta(key, id, content))

--- a/site/src/lib/head/meta.ts
+++ b/site/src/lib/head/meta.ts
@@ -1,0 +1,41 @@
+import type { StarlightRouteData } from '@astrojs/starlight/route-data'
+
+import { CARD_HEIGHT, CARD_WIDTH } from '../og/parts'
+
+type Head      = StarlightRouteData['head']
+type HeadEntry = Head[number]
+
+// The canonical URL Starlight already computed for the page, read back off the
+// head so the structured data cannot drift from the emitted link.
+export function canonicalOf(head: Head): string | undefined {
+  const link = head.find(entry => entry.tag === 'link' && entry.attrs?.rel === 'canonical')
+  return typeof link?.attrs?.href === 'string' ? link.attrs.href : undefined
+}
+
+export function imageMeta(head: Head, image: string, alt: string): void {
+  head.push(
+    meta('property', 'og:image',         image),
+    meta('property', 'og:image:width',   String(CARD_WIDTH)),
+    meta('property', 'og:image:height',  String(CARD_HEIGHT)),
+    meta('property', 'og:image:type',    'image/png'),
+    meta('property', 'og:image:alt',     alt),
+    meta('name',     'twitter:image',     image),
+    meta('name',     'twitter:image:alt', alt)
+  )
+}
+
+export function jsonLd(head: Head, content: string): void {
+  head.push({ attrs: { type: 'application/ld+json' }, content, tag: 'script' })
+}
+
+// Rewrites the entry Starlight already emitted for the tag, falling back to a
+// push when none exists.
+export function upsertMeta(head: Head, key: 'name' | 'property', id: string, content: string): void {
+  const existing = head.find(entry => entry.tag === 'meta' && entry.attrs?.[key] === id)
+  if (existing?.attrs !== undefined) existing.attrs.content = content
+  else head.push(meta(key, id, content))
+}
+
+function meta(key: 'name' | 'property', id: string, content: string): HeadEntry {
+  return { attrs: { content, [key]: id }, tag: 'meta' }
+}

--- a/site/src/lib/head/middleware.ts
+++ b/site/src/lib/head/middleware.ts
@@ -1,0 +1,47 @@
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data'
+import { getCollection }         from 'astro:content'
+
+import { isLandingId, ogImagePath }                   from '../og/url'
+import { articleLd, landingLd }                       from './json-ld'
+import { canonicalOf, imageMeta, jsonLd, upsertMeta } from './meta'
+
+const LANDING_ALT = 'Prose, a Python typesetter for the reader.'
+
+const [docs, [release]] = await Promise.all([getCollection('docs'), getCollection('release')])
+const docsIds           = new Set(docs.map(entry => entry.id))
+
+// Adds the per-route card image, Twitter image, description, and structured
+// data onto the head Starlight built. A rule page's description falls back to
+// its caption, and a route with no docs entry behind it, the 404 page, takes
+// the landing card.
+export const onRequest = defineRouteMiddleware(context => {
+  const { site } = context
+  if (site === undefined) return
+
+  const { entry, head } = context.locals.starlightRoute
+  const virtual     = !docsIds.has(entry.id)
+  const landing     = isLandingId(entry.id)
+  const description = entry.data.description ?? entry.data.caption
+  const image       = new URL(ogImagePath(virtual ? 'index' : entry.id), site).href
+  const alt         = landing || virtual ? LANDING_ALT : `${entry.data.title} card`
+  imageMeta(head, image, alt)
+  if (description !== undefined) {
+    upsertMeta(head, 'name',     'description',    description)
+    upsertMeta(head, 'property', 'og:description', description)
+  }
+
+  if (landing) {
+    upsertMeta(head, 'property', 'og:type', 'website')
+    jsonLd(head, landingLd(site.href, release.data.version, entry.data.description))
+    return
+  }
+  const canonical = virtual ? undefined : canonicalOf(head)
+  if (canonical !== undefined) {
+    jsonLd(head, articleLd({
+      description,
+      headline : entry.data.title,
+      image,
+      url      : canonical
+    }))
+  }
+})

--- a/site/src/lib/og/assets.ts
+++ b/site/src/lib/og/assets.ts
@@ -1,0 +1,46 @@
+import fs                from 'node:fs'
+import { createRequire } from 'node:module'
+
+import { root }      from 'astro:config/server'
+import type { Font } from 'satori'
+
+const require = createRequire(import.meta.url)
+
+export const BRAND_TITLE_ASPECT = 1031 / 380
+
+export interface BrandAssets {
+  fonts            : Font[]
+  glyph            : string
+  titleWithTagline : string
+  wordmark         : string
+}
+
+// The faces the card templates name. satori embeds each glyph as a vector
+// path, so only these weights reach the renderer.
+const FONT_FACES: readonly Omit<Font, 'data'>[] = [
+  { name: 'Fraunces',       style: 'normal', weight: 600 },
+  { name: 'JetBrains Mono', style: 'normal', weight: 400 },
+  { name: 'JetBrains Mono', style: 'normal', weight: 500 },
+  { name: 'JetBrains Mono', style: 'normal', weight: 700 },
+  { name: 'Lora',           style: 'normal', weight: 400 }
+]
+
+export function loadBrandAssets(): BrandAssets {
+  const publicDir = new URL('public/', root)
+  const read      = (file: string): Buffer => fs.readFileSync(new URL(file, publicDir))
+  return {
+    fonts            : FONT_FACES.map(face => ({ ...face, data: fs.readFileSync(fontFile(face)) })),
+    glyph            : dataUri(read('logo.svg')),
+    titleWithTagline : dataUri(read('title-with-tagline.svg')),
+    wordmark         : dataUri(read('title.svg'))
+  }
+}
+
+function dataUri(svg: Buffer): string {
+  return `data:image/svg+xml;base64,${svg.toString('base64')}`
+}
+
+function fontFile(face: Omit<Font, 'data'>): string {
+  const id = face.name.toLowerCase().replaceAll(' ', '-')
+  return require.resolve(`@fontsource/${id}/files/${id}-latin-${face.weight}-${face.style}.woff`)
+}

--- a/site/src/lib/og/assets.ts
+++ b/site/src/lib/og/assets.ts
@@ -6,11 +6,10 @@ import type { Font } from 'satori'
 
 const require = createRequire(import.meta.url)
 
-export const BRAND_TITLE_ASPECT = 1031 / 380
-
 export interface BrandAssets {
   fonts            : Font[]
   glyph            : string
+  titleAspect      : number
   titleWithTagline : string
   wordmark         : string
 }
@@ -19,7 +18,6 @@ export interface BrandAssets {
 // path, so only these weights reach the renderer.
 const FONT_FACES: readonly Omit<Font, 'data'>[] = [
   { name: 'Fraunces',       style: 'normal', weight: 600 },
-  { name: 'JetBrains Mono', style: 'normal', weight: 400 },
   { name: 'JetBrains Mono', style: 'normal', weight: 500 },
   { name: 'JetBrains Mono', style: 'normal', weight: 700 },
   { name: 'Lora',           style: 'normal', weight: 400 }
@@ -28,11 +26,13 @@ const FONT_FACES: readonly Omit<Font, 'data'>[] = [
 export function loadBrandAssets(): BrandAssets {
   const publicDir = new URL('public/', root)
   const read      = (file: string): Buffer => fs.readFileSync(new URL(file, publicDir))
+  const title     = read('title.svg')
   return {
     fonts            : FONT_FACES.map(face => ({ ...face, data: fs.readFileSync(fontFile(face)) })),
     glyph            : dataUri(read('logo.svg')),
+    titleAspect      : viewBoxAspect(title),
     titleWithTagline : dataUri(read('title-with-tagline.svg')),
-    wordmark         : dataUri(read('title.svg'))
+    wordmark         : dataUri(title)
   }
 }
 
@@ -43,4 +43,10 @@ function dataUri(svg: Buffer): string {
 function fontFile(face: Omit<Font, 'data'>): string {
   const id = face.name.toLowerCase().replaceAll(' ', '-')
   return require.resolve(`@fontsource/${id}/files/${id}-latin-${face.weight}-${face.style}.woff`)
+}
+
+function viewBoxAspect(svg: Buffer): number {
+  const box = svg.toString().match(/viewBox="0 0 ([\d.]+) ([\d.]+)"/)
+  if (box === null) throw new Error('no viewBox on title.svg')
+  return Number(box[1]) / Number(box[2])
 }

--- a/site/src/lib/og/cache.ts
+++ b/site/src/lib/og/cache.ts
@@ -1,0 +1,56 @@
+import * as cacache from 'cacache'
+import { hash }     from 'ohash'
+
+import resolveSource  from '../tokens/resolve.ts?raw'
+import assetsSource   from './assets.ts?raw'
+import colorsSource   from './colors.ts?raw'
+import landingSource  from './landing.ts?raw'
+import partsSource    from './parts.ts?raw'
+import templateSource from './template.ts?raw'
+
+import type { BrandAssets } from './assets'
+import type { OgPage }      from './pages'
+
+// The render sources folded into every cache key, so an edit to any of them
+// re-renders every card.
+const TEMPLATE_DIGEST = hash([
+  assetsSource, colorsSource, landingSource, partsSource, resolveSource, templateSource
+])
+
+export function cardKeyer(version: string, brand: BrandAssets): (card: OgPage | 'landing') => string {
+  const base = { brand: hash(brand), template: TEMPLATE_DIGEST, version }
+  return card => hash({ base, card })
+}
+
+export async function readCard(cacheDir: string, key: string): Promise<Buffer | null> {
+  try {
+    return (await cacache.get(cacheDir, key)).data
+  }
+  catch {
+    // a miss and a failed integrity check both fall through to a fresh render
+    return null
+  }
+}
+
+export async function writeCard(cacheDir: string, key: string, png: Buffer): Promise<void> {
+  try {
+    await cacache.put(cacheDir, key, png)
+  }
+  catch {
+    // a failed write still leaves the rendered card in the response
+  }
+}
+
+export async function pruneCards(cacheDir: string, live: Iterable<string>): Promise<void> {
+  try {
+    const keep  = new Set(live)
+    const index = await cacache.ls(cacheDir)
+    const stale = Object.keys(index).filter(key => !keep.has(key))
+    if (stale.length === 0) return
+    await Promise.all(stale.map(key => cacache.rm.entry(cacheDir, key)))
+    await cacache.verify(cacheDir)
+  }
+  catch {
+    // prune is best-effort housekeeping
+  }
+}

--- a/site/src/lib/og/cache.ts
+++ b/site/src/lib/og/cache.ts
@@ -6,6 +6,7 @@ import assetsSource   from './assets.ts?raw'
 import colorsSource   from './colors.ts?raw'
 import landingSource  from './landing.ts?raw'
 import partsSource    from './parts.ts?raw'
+import renderSource   from './render.ts?raw'
 import templateSource from './template.ts?raw'
 
 import type { BrandAssets } from './assets'
@@ -14,10 +15,14 @@ import type { OgPage }      from './pages'
 // The render sources folded into every cache key, so an edit to any of them
 // re-renders every card.
 const TEMPLATE_DIGEST = hash([
-  assetsSource, colorsSource, landingSource, partsSource, resolveSource, templateSource
+  assetsSource, colorsSource, landingSource, partsSource, renderSource, resolveSource,
+  templateSource
 ])
 
-export function cardKeyer(version: string, brand: BrandAssets): (card: OgPage | 'landing') => string {
+export function cardKeyer(
+  version : string,
+  brand   : BrandAssets
+): (card: OgPage | 'landing') => string {
   const base = { brand: hash(brand), template: TEMPLATE_DIGEST, version }
   return card => hash({ base, card })
 }

--- a/site/src/lib/og/colors.ts
+++ b/site/src/lib/og/colors.ts
@@ -1,0 +1,7 @@
+import { resolveColor } from '../tokens/resolve'
+
+export const BG         = resolveColor('palette-woodsmoke')
+export const BODY       = resolveColor('palette-champagne')
+export const KICKER     = resolveColor('palette-ube-pale')
+export const META_LABEL = resolveColor('palette-ube-mid')
+export const UBE        = resolveColor('palette-ube')

--- a/site/src/lib/og/landing.ts
+++ b/site/src/lib/og/landing.ts
@@ -1,7 +1,8 @@
+import { site }         from 'astro:config/server'
 import type { JSXNode } from 'satori/jsx'
 
-import { type BrandAssets, BRAND_TITLE_ASPECT } from './assets'
-import { BODY, META_LABEL, UBE }                from './colors'
+import type { BrandAssets }      from './assets'
+import { BODY, META_LABEL, UBE } from './colors'
 import {
   CARD_WIDTH,
   cardShell, dataPanel, el, leftRail, monoLabel, toSvg
@@ -13,15 +14,15 @@ const TITLE_WIDTH   = 889
 const TRACK         = '0.28em'
 
 export function landingSvg(brand: BrandAssets, version: string): Promise<string> {
-  return toSvg(buildLandingCard(version, brand.titleWithTagline), brand.fonts)
+  return toSvg(buildLandingCard(version, brand), brand.fonts)
 }
 
-function buildLandingCard(version: string, titleWithTagline: string): JSXNode {
+function buildLandingCard(version: string, brand: BrandAssets): JSXNode {
   return cardShell(
     leftRail(UBE),
     glyphBlock(),
-    dataPanel(UBE, '66', [['URL', 'prose.fyi']], version),
-    titleArtwork(titleWithTagline)
+    dataPanel(UBE, '66', [['URL', new URL(site!).hostname]], version),
+    titleArtwork(brand)
   )
 }
 
@@ -59,7 +60,6 @@ function pilcrowMark(): JSXNode {
     style    : {
       alignItems     : 'center',
       color          : UBE,
-      display        : 'flex',
       fontFamily     : 'Fraunces',
       fontSize       : 80,
       fontWeight     : 600,
@@ -71,10 +71,10 @@ function pilcrowMark(): JSXNode {
   })
 }
 
-function titleArtwork(src: string): JSXNode {
-  const height = Math.round(TITLE_WIDTH / BRAND_TITLE_ASPECT)
+function titleArtwork(brand: BrandAssets): JSXNode {
+  const height = Math.round(TITLE_WIDTH / brand.titleAspect)
   return el('div', {
-    children : el('img', { height, src, width: TITLE_WIDTH }),
+    children : el('img', { height, src: brand.titleWithTagline, width: TITLE_WIDTH }),
     style    : {
       display  : 'flex',
       left     : Math.round((CARD_WIDTH - TITLE_WIDTH) / 2),

--- a/site/src/lib/og/landing.ts
+++ b/site/src/lib/og/landing.ts
@@ -1,0 +1,85 @@
+import type { JSXNode } from 'satori/jsx'
+
+import { type BrandAssets, BRAND_TITLE_ASPECT } from './assets'
+import { BODY, META_LABEL, UBE }                from './colors'
+import {
+  CARD_WIDTH,
+  cardShell, dataPanel, el, leftRail, monoLabel, toSvg
+} from './parts'
+
+const ARTIFACT_LEFT = 120
+const TITLE_TOP     = 246
+const TITLE_WIDTH   = 889
+const TRACK         = '0.28em'
+
+export function landingSvg(brand: BrandAssets, version: string): Promise<string> {
+  return toSvg(buildLandingCard(version, brand.titleWithTagline), brand.fonts)
+}
+
+function buildLandingCard(version: string, titleWithTagline: string): JSXNode {
+  return cardShell(
+    leftRail(UBE),
+    glyphBlock(),
+    dataPanel(UBE, '66', [['URL', 'prose.fyi']], version),
+    titleArtwork(titleWithTagline)
+  )
+}
+
+function glyphBlock(): JSXNode {
+  return el('div',
+    {
+      style: {
+        alignItems : 'center',
+        display    : 'flex',
+        gap        : 18,
+        left       : ARTIFACT_LEFT,
+        position   : 'absolute',
+        top        : 88
+      }
+    },
+    pilcrowMark(),
+    el('div',
+      {
+        style: {
+          display       : 'flex',
+          flexDirection : 'column',
+          gap           : 6
+        }
+      },
+      el('div', { children: 'WRITTEN IN RUST',   style: monoLabel(BODY,       15, TRACK) }),
+      el('div', { children: 'EST. 2025',         style: monoLabel(META_LABEL, 13, TRACK) }),
+      el('div', { children: 'OPEN SOURCE · MIT', style: monoLabel(META_LABEL, 13, TRACK) })
+    )
+  )
+}
+
+function pilcrowMark(): JSXNode {
+  return el('div', {
+    children : '¶',
+    style    : {
+      alignItems     : 'center',
+      color          : UBE,
+      display        : 'flex',
+      fontFamily     : 'Fraunces',
+      fontSize       : 80,
+      fontWeight     : 600,
+      height         : 72,
+      justifyContent : 'center',
+      lineHeight     : 1,
+      width          : 72
+    }
+  })
+}
+
+function titleArtwork(src: string): JSXNode {
+  const height = Math.round(TITLE_WIDTH / BRAND_TITLE_ASPECT)
+  return el('div', {
+    children : el('img', { height, src, width: TITLE_WIDTH }),
+    style    : {
+      display  : 'flex',
+      left     : Math.round((CARD_WIDTH - TITLE_WIDTH) / 2),
+      position : 'absolute',
+      top      : TITLE_TOP
+    }
+  })
+}

--- a/site/src/lib/og/pages.ts
+++ b/site/src/lib/og/pages.ts
@@ -1,0 +1,91 @@
+import { getCollection }        from 'astro:content'
+import type { CollectionEntry } from 'astro:content'
+
+import { isFamily }        from '../shared/registries'
+import type { RuleFamily } from '../shared/registries'
+import { resolveColor }    from '../tokens/resolve'
+import { isLandingId }     from './url'
+
+type DocsEntry = CollectionEntry<'docs'>
+type Warmth    = NonNullable<DocsEntry['data']['warmth']>
+
+export interface OgPage {
+  accent    ?: string
+  breadcrumb : readonly string[]
+  caption   ?: string
+  family    ?: RuleFamily
+  kind       : string
+  pipeline  ?: { position: number, total: number }
+  stability ?: string
+  title      : string
+  warmth    ?: Warmth
+}
+
+export interface OgCard {
+  id   : string
+  page : OgPage | 'landing'
+}
+
+// Enumerates every card the build renders, the landing card plus one card per
+// docs page, enriched from the docs and pipeline collections.
+export async function enumerateCards(): Promise<OgCard[]> {
+  const [docs, pipeline] = await Promise.all([getCollection('docs'), getCollection('pipeline')])
+  const positions = new Map(pipeline.map(entry => [entry.data.slug, entry.data.position]))
+  const warmths   = familyWarmths(docs)
+  return [
+    { id: 'index', page: 'landing' },
+    ...docs
+      .filter(entry => !isLandingId(entry.id))
+      .map(entry => ({ id: entry.id, page: pageFor(entry, positions, pipeline.length, warmths) }))
+  ]
+}
+
+function accentFor(kind: string, family?: RuleFamily): string | undefined {
+  return resolveColor(family !== undefined ? `family-${family}` : `section-${kind}`) || undefined
+}
+
+function familyWarmths(docs: readonly DocsEntry[]): Map<RuleFamily, Warmth> {
+  const out = new Map<RuleFamily, Warmth>()
+  for (const entry of docs) {
+    const [head, family, ...rest] = entry.id.split('/')
+    if (head !== 'rules' || rest.length > 0 || family === undefined || !isFamily(family)) continue
+    if (entry.data.warmth !== undefined) out.set(family, entry.data.warmth)
+  }
+  return out
+}
+
+function pageFor(
+  entry     : DocsEntry,
+  positions : ReadonlyMap<string, number>,
+  total     : number,
+  warmths   : ReadonlyMap<RuleFamily, Warmth>
+): OgPage {
+  const parts = entry.id.split('/')
+  const kind  = parts[0]
+  const base  = { accent: accentFor(kind), breadcrumb: [kind], kind, title: entry.data.title }
+  if (kind === 'rules' && parts.length === 3 && isFamily(parts[1])) {
+    const family   = parts[1]
+    const position = positions.get(parts[2])
+    return {
+      ...base,
+      accent     : accentFor(kind, family),
+      breadcrumb : [kind, family],
+      caption    : entry.data.caption,
+      family,
+      pipeline   : position !== undefined ? { position, total } : undefined,
+      title      : titleCase(parts[2]),
+      warmth     : warmths.get(family)
+    }
+  }
+  if (kind === 'rules' && parts.length === 2 && isFamily(parts[1])) {
+    return { ...base, accent: accentFor(kind, parts[1]) }
+  }
+  if (kind === 'primitives' && parts.length === 2) {
+    return { ...base, stability: entry.data.stability ?? 'internal' }
+  }
+  return base
+}
+
+function titleCase(slug: string): string {
+  return slug.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
+}

--- a/site/src/lib/og/parts.ts
+++ b/site/src/lib/og/parts.ts
@@ -118,7 +118,13 @@ function metaRow(
 ): JSXNode {
   return el('div',
     {
-      style: { alignItems: 'baseline', display: 'flex', gap, justifyContent: 'space-between', marginBottom }
+      style: {
+        alignItems     : 'baseline',
+        display        : 'flex',
+        gap            : gap,
+        justifyContent : 'space-between',
+        marginBottom   : marginBottom
+      }
     },
     el('div', { children: label, style: monoLabel(META_LABEL, 16) }),
     el('div', {
@@ -134,6 +140,11 @@ function panelRow(label: string, value: string): JSXNode {
 }
 
 function versionCallout(version: string): JSXNode {
-  return metaRow('VERSION', version,
-    { fontFamily: 'Fraunces', fontSize: 72, fontWeight: 600, letterSpacing: '-0.01em', lineHeight: 1 }, 18)
+  return metaRow('VERSION', version, {
+    fontFamily    : 'Fraunces',
+    fontSize      : 72,
+    fontWeight    : 600,
+    letterSpacing : '-0.01em',
+    lineHeight    : 1
+  }, 18)
 }

--- a/site/src/lib/og/parts.ts
+++ b/site/src/lib/og/parts.ts
@@ -1,0 +1,139 @@
+import { createElement as h }       from 'satori/jsx'
+import type { JSXElement, JSXNode } from 'satori/jsx'
+import satori, { type Font }        from 'satori'
+
+import { BG, BODY, META_LABEL } from './colors'
+
+export const CARD_HEIGHT = 630
+export const CARD_WIDTH  = 1200
+
+const BORDER     = 'rgba(255, 255, 255, 0.10)'
+const PANEL_FILL = 'rgba(255, 255, 255, 0.04)'
+
+// satori's createElement<P> returns JSXElement<P>, which its own JSXNode union
+// rejects for non-unknown P, so el returns satori's JSX.Element (JSXElement<any, any>).
+export function el(
+  type       : string,
+  props      : Record<string, unknown> | null,
+  ...children: JSXNode[]
+): JSXElement<any, any> {
+  return h(type, props, ...children)
+}
+
+export function toSvg(node: JSXNode, fonts: Font[]): Promise<string> {
+  return satori(node, { fonts, height: CARD_HEIGHT, width: CARD_WIDTH })
+}
+
+export function cardShell(...children: JSXNode[]): JSXNode {
+  return el('div',
+    {
+      style: {
+        backgroundColor : BG,
+        display         : 'flex',
+        flexDirection   : 'column',
+        height          : '100%',
+        position        : 'relative',
+        width           : '100%'
+      }
+    },
+    ...children
+  )
+}
+
+export function leftRail(color: string): JSXNode {
+  return el('div', {
+    style: {
+      backgroundImage : `linear-gradient(to bottom, ${color}, ${color}cc)`,
+      bottom          : 0,
+      left            : 50,
+      position        : 'absolute',
+      top             : 0,
+      width           : 14
+    }
+  })
+}
+
+export function monoLabel(color: string, size: number, track = '0.14em') {
+  return {
+    color         : color,
+    fontFamily    : 'JetBrains Mono',
+    fontSize      : size,
+    fontWeight    : 500,
+    letterSpacing : track
+  }
+}
+
+// The data panel every card carries: the label-value rows, a divider when any
+// row exists, and the version callout beneath.
+export function dataPanel(
+  accent  : string,
+  alpha   : string,
+  rows    : ReadonlyArray<readonly [string, string]>,
+  version : string
+): JSXNode {
+  return panelShell(accent, alpha,
+    ...rows.map(row => panelRow(...row)),
+    ...(rows.length > 0 ? [panelDivider()] : []),
+    versionCallout(version)
+  )
+}
+
+function panelShell(accent: string, alpha: string, ...children: JSXNode[]): JSXNode {
+  return el('div',
+    {
+      style: {
+        backgroundColor : PANEL_FILL,
+        border          : `1px solid ${accent}${alpha}`,
+        borderRadius    : 8,
+        display         : 'flex',
+        flexDirection   : 'column',
+        minWidth        : 360,
+        padding         : '24px 28px',
+        position        : 'absolute',
+        right           : 80,
+        top             : 80
+      }
+    },
+    ...children
+  )
+}
+
+function panelDivider(): JSXNode {
+  return el('div', {
+    style: {
+      borderTop    : `1px solid ${BORDER}`,
+      height       : 1,
+      marginBottom : 18,
+      marginTop    : 14
+    }
+  })
+}
+
+function metaRow(
+  label        : string,
+  value        : string,
+  valueStyle   : Record<string, unknown>,
+  gap          : number,
+  marginBottom : number = 0
+): JSXNode {
+  return el('div',
+    {
+      style: { alignItems: 'baseline', display: 'flex', gap, justifyContent: 'space-between', marginBottom }
+    },
+    el('div', { children: label, style: monoLabel(META_LABEL, 16) }),
+    el('div', {
+      children : value,
+      style    : { color: BODY, fontVariantNumeric: 'tabular-nums', ...valueStyle }
+    })
+  )
+}
+
+function panelRow(label: string, value: string): JSXNode {
+  return metaRow(label.toUpperCase(), value,
+    { fontFamily: 'JetBrains Mono', fontSize: 19, fontWeight: 500 }, 24, 8)
+}
+
+function versionCallout(version: string): JSXNode {
+  return metaRow('VERSION', version,
+    { fontFamily: 'Fraunces', fontSize: 72, fontWeight: 600, letterSpacing: '-0.01em', lineHeight: 1 }, 18)
+}

--- a/site/src/lib/og/render.ts
+++ b/site/src/lib/og/render.ts
@@ -1,0 +1,62 @@
+import { fileURLToPath } from 'node:url'
+
+import { root }          from 'astro:config/server'
+import { getCollection } from 'astro:content'
+import sharp             from 'sharp'
+
+import { type BrandAssets, loadBrandAssets }          from './assets'
+import { cardKeyer, pruneCards, readCard, writeCard } from './cache'
+import { landingSvg }                                 from './landing'
+import { type OgCard, enumerateCards }                from './pages'
+import { pageSvg }                                    from './template'
+
+const CACHE_DIR = fileURLToPath(new URL('../.cache/og/', root))
+
+interface Renderer {
+  brand   : BrandAssets
+  cards   : ReadonlyMap<string, OgCard & { key: string }>
+  version : string
+}
+
+let renderer: Promise<Renderer> | undefined
+
+// The PNG response both card endpoints delegate to.
+export async function cardResponse(id: string): Promise<Response> {
+  return new Response(new Uint8Array(await renderCard(id)), {
+    headers: { 'Content-Type': 'image/png' }
+  })
+}
+
+// The docs-page card ids the card endpoint enumerates its routes from.
+export async function pageCardIds(): Promise<string[]> {
+  const { cards } = await (renderer ??= init())
+  return [...cards.values()].filter(card => card.page !== 'landing').map(card => card.id)
+}
+
+// Renders one card by its docs-collection id, served from the
+// content-addressed store when the key is unchanged.
+async function renderCard(id: string): Promise<Buffer> {
+  const { brand, cards, version } = await (renderer ??= init())
+  const card = cards.get(id)
+  if (card === undefined) throw new Error(`no OG card enumerated for "${id}"`)
+  const cached = await readCard(CACHE_DIR, card.key)
+  if (cached !== null) return cached
+  const svg = card.page === 'landing'
+    ? await landingSvg(brand, version)
+    : await pageSvg(card.page, brand, version)
+  const png = await sharp(Buffer.from(svg)).png().toBuffer()
+  await writeCard(CACHE_DIR, card.key, png)
+  return png
+}
+
+// Enumerates every card once per build and prunes cache entries no live card
+// claims, leaving the store holding exactly the current card set.
+async function init(): Promise<Renderer> {
+  const [[release], enumerated] = await Promise.all([getCollection('release'), enumerateCards()])
+  const brand   = loadBrandAssets()
+  const version = release.data.version
+  const keyOf   = cardKeyer(version, brand)
+  const cards   = new Map(enumerated.map(card => [card.id, { ...card, key: keyOf(card.page) }]))
+  await pruneCards(CACHE_DIR, [...cards.values()].map(card => card.key))
+  return { brand, cards, version }
+}

--- a/site/src/lib/og/template.ts
+++ b/site/src/lib/og/template.ts
@@ -1,21 +1,17 @@
 import type { JSXNode } from 'satori/jsx'
 
-import { type BrandAssets, BRAND_TITLE_ASPECT } from './assets'
-import { BODY, KICKER, UBE }                    from './colors'
-import type { OgPage }                          from './pages'
+import type { BrandAssets }  from './assets'
+import { BODY, KICKER, UBE } from './colors'
+import type { OgPage }       from './pages'
 import {
   CARD_HEIGHT, CARD_WIDTH,
   cardShell, dataPanel, el, leftRail, monoLabel, toSvg
 } from './parts'
 
-const DOCS_TRACK = '0.14em'
-
 const CODE_CHIP = {
+  ...monoLabel(KICKER, 19),
   backgroundColor : 'rgba(255, 255, 255, 0.08)',
   borderRadius    : 4,
-  color           : KICKER,
-  fontFamily      : 'JetBrains Mono',
-  fontSize        : 19,
   padding         : '2px 8px',
   transform       : 'translateY(-2px)'
 }
@@ -30,15 +26,15 @@ export function pageSvg(
   brand   : BrandAssets,
   version : string
 ): Promise<string> {
-  return toSvg(buildCard(page, version, brand.wordmark, brand.glyph), brand.fonts)
+  return toSvg(buildCard(page, version, brand), brand.fonts)
 }
 
-function buildCard(page: OgPage, version: string, wordmark: string, glyph: string): JSXNode {
+function buildCard(page: OgPage, version: string, brand: BrandAssets): JSXNode {
   const accent = page.accent ?? UBE
   return cardShell(
-    watermarkLayer(glyph),
+    watermarkLayer(brand.glyph),
     leftRail(accent),
-    wordmarkBlock(wordmark),
+    wordmarkBlock(brand),
     dataPanel(accent, page.warmth === 'warm' ? '99' : '66', panelRows(page), version),
     titleBlock(page, accent)
   )
@@ -48,9 +44,9 @@ function buildKicker(page: OgPage): string {
   return `— ${page.breadcrumb.map(part => part.toUpperCase()).join(' · ')} —`
 }
 
-function captionSegments(raw: string): ReadonlyArray<{ code: boolean; text: string }> {
+function captionSegments(raw: string): ReadonlyArray<{ code: boolean, text: string }> {
   const strip = (s: string): string => s.replace(/(\*\*?|_)(.+?)\1/g, '$2')
-  return raw.split(/`([^`]+)`/).flatMap((part, index): Array<{ code: boolean; text: string }> =>
+  return raw.split(/`([^`]+)`/).flatMap((part, index): Array<{ code: boolean, text: string }> =>
     index % 2 === 1
       ? [{ code: true, text: part }]
       : strip(part).split(/\s+/).filter(Boolean).map(text => ({ code: false, text }))
@@ -68,7 +64,7 @@ function formatFolio(n: number): string {
 function panelRows(page: OgPage): ReadonlyArray<readonly [string, string]> {
   if (page.kind === 'rules' && page.family !== undefined) {
     const rows: Array<readonly [string, string]> = [['Family', page.family]]
-    if (page.pipeline) {
+    if (page.pipeline !== undefined) {
       const { position, total } = page.pipeline
       rows.push(['Pipeline', `${formatFolio(position)} / ${formatFolio(total)}`])
     }
@@ -101,7 +97,6 @@ function titleBlock(page: OgPage, accent: string): JSXNode {
       children : page.title,
       style    : {
         color         : accent,
-        display       : 'flex',
         fontFamily    : 'Fraunces',
         fontSize      : fitTitleSize(page.title, caption !== undefined),
         fontStyle     : 'normal',
@@ -150,7 +145,7 @@ function watermarkLayer(glyph: string): JSXNode {
   )
 }
 
-function wordmarkBlock(wordmark: string): JSXNode {
+function wordmarkBlock(brand: BrandAssets): JSXNode {
   const height = 76
   return el('div',
     {
@@ -165,22 +160,17 @@ function wordmarkBlock(wordmark: string): JSXNode {
     },
     el('img', {
       height : height,
-      src    : wordmark,
-      style  : { display: 'flex' },
-      width  : Math.round(height * BRAND_TITLE_ASPECT)
+      src    : brand.wordmark,
+      width  : Math.round(height * brand.titleAspect)
     }),
     el('div', {
       children : 'DOCS',
       style    : {
+        ...monoLabel(BODY, 15),
         backgroundColor : `${UBE}2e`,
         border          : `1px solid ${BODY}52`,
         borderRadius    : 6,
-        color           : BODY,
-        display         : 'flex',
-        fontFamily      : 'JetBrains Mono',
-        fontSize        : 15,
-        fontWeight      : 600,
-        letterSpacing   : DOCS_TRACK,
+        fontWeight      : 700,
         marginBottom    : 22,
         padding         : '6px 12px'
       }

--- a/site/src/lib/og/template.ts
+++ b/site/src/lib/og/template.ts
@@ -1,0 +1,189 @@
+import type { JSXNode } from 'satori/jsx'
+
+import { type BrandAssets, BRAND_TITLE_ASPECT } from './assets'
+import { BODY, KICKER, UBE }                    from './colors'
+import type { OgPage }                          from './pages'
+import {
+  CARD_HEIGHT, CARD_WIDTH,
+  cardShell, dataPanel, el, leftRail, monoLabel, toSvg
+} from './parts'
+
+const DOCS_TRACK = '0.14em'
+
+const CODE_CHIP = {
+  backgroundColor : 'rgba(255, 255, 255, 0.08)',
+  borderRadius    : 4,
+  color           : KICKER,
+  fontFamily      : 'JetBrains Mono',
+  fontSize        : 19,
+  padding         : '2px 8px',
+  transform       : 'translateY(-2px)'
+}
+
+const TITLE_SIZES = {
+  bare : [[4, 144], [8, 132], [14, 120], [Infinity, 100]],
+  cap  : [[12, 108], [17, 100], [22, 84], [Infinity, 76]]
+} as const
+
+export function pageSvg(
+  page    : OgPage,
+  brand   : BrandAssets,
+  version : string
+): Promise<string> {
+  return toSvg(buildCard(page, version, brand.wordmark, brand.glyph), brand.fonts)
+}
+
+function buildCard(page: OgPage, version: string, wordmark: string, glyph: string): JSXNode {
+  const accent = page.accent ?? UBE
+  return cardShell(
+    watermarkLayer(glyph),
+    leftRail(accent),
+    wordmarkBlock(wordmark),
+    dataPanel(accent, page.warmth === 'warm' ? '99' : '66', panelRows(page), version),
+    titleBlock(page, accent)
+  )
+}
+
+function buildKicker(page: OgPage): string {
+  return `— ${page.breadcrumb.map(part => part.toUpperCase()).join(' · ')} —`
+}
+
+function captionSegments(raw: string): ReadonlyArray<{ code: boolean; text: string }> {
+  const strip = (s: string): string => s.replace(/(\*\*?|_)(.+?)\1/g, '$2')
+  return raw.split(/`([^`]+)`/).flatMap((part, index): Array<{ code: boolean; text: string }> =>
+    index % 2 === 1
+      ? [{ code: true, text: part }]
+      : strip(part).split(/\s+/).filter(Boolean).map(text => ({ code: false, text }))
+  )
+}
+
+function fitTitleSize(text: string, hasCaption: boolean): number {
+  return TITLE_SIZES[hasCaption ? 'cap' : 'bare'].find(([max]) => text.length <= max)![1]
+}
+
+function formatFolio(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+function panelRows(page: OgPage): ReadonlyArray<readonly [string, string]> {
+  if (page.kind === 'rules' && page.family !== undefined) {
+    const rows: Array<readonly [string, string]> = [['Family', page.family]]
+    if (page.pipeline) {
+      const { position, total } = page.pipeline
+      rows.push(['Pipeline', `${formatFolio(position)} / ${formatFolio(total)}`])
+    }
+    return rows
+  }
+  if (page.kind === 'primitives' && page.stability !== undefined) {
+    return [['Section', 'primitives'], ['Surface', page.stability]]
+  }
+  return []
+}
+
+function titleBlock(page: OgPage, accent: string): JSXNode {
+  const caption = page.caption
+  return el('div',
+    {
+      style: {
+        display       : 'flex',
+        flexDirection : 'column',
+        left          : 80,
+        position      : 'absolute',
+        right         : 80,
+        top           : 360
+      }
+    },
+    el('div', {
+      children : buildKicker(page),
+      style    : { ...monoLabel(KICKER, 22), marginBottom: 12 }
+    }),
+    el('div', {
+      children : page.title,
+      style    : {
+        color         : accent,
+        display       : 'flex',
+        fontFamily    : 'Fraunces',
+        fontSize      : fitTitleSize(page.title, caption !== undefined),
+        fontStyle     : 'normal',
+        fontWeight    : 600,
+        letterSpacing : '-0.015em',
+        lineHeight    : 1.02,
+        marginBottom  : 14,
+        maxWidth      : 1040
+      }
+    }),
+    ...(caption !== undefined ? [el('div', {
+      children: captionSegments(caption).map(seg => el('span', {
+        children : seg.text,
+        style    : seg.code ? CODE_CHIP : {}
+      })),
+
+      style: {
+        alignItems : 'baseline',
+        color      : BODY,
+        columnGap  : 7,
+        display    : 'flex',
+        flexWrap   : 'wrap',
+        fontFamily : 'Lora',
+        fontSize   : 24,
+        fontWeight : 400,
+        maxWidth   : 1040,
+        rowGap     : 10
+      }
+    })] : [])
+  )
+}
+
+function watermarkLayer(glyph: string): JSXNode {
+  const size = 720
+  return el('div',
+    {
+      style: {
+        display  : 'flex',
+        left     : (CARD_WIDTH - size) / 2,
+        opacity  : 0.012,
+        position : 'absolute',
+        top      : (CARD_HEIGHT - size) / 2
+      }
+    },
+    el('img', { height: size, src: glyph, width: size })
+  )
+}
+
+function wordmarkBlock(wordmark: string): JSXNode {
+  const height = 76
+  return el('div',
+    {
+      style: {
+        alignItems : 'flex-end',
+        display    : 'flex',
+        gap        : 10,
+        left       : 80,
+        position   : 'absolute',
+        top        : 80
+      }
+    },
+    el('img', {
+      height : height,
+      src    : wordmark,
+      style  : { display: 'flex' },
+      width  : Math.round(height * BRAND_TITLE_ASPECT)
+    }),
+    el('div', {
+      children : 'DOCS',
+      style    : {
+        backgroundColor : `${UBE}2e`,
+        border          : `1px solid ${BODY}52`,
+        borderRadius    : 6,
+        color           : BODY,
+        display         : 'flex',
+        fontFamily      : 'JetBrains Mono',
+        fontSize        : 15,
+        fontWeight      : 600,
+        letterSpacing   : DOCS_TRACK,
+        marginBottom    : 22,
+        padding         : '6px 12px'
+      }
+    })
+  )
+}

--- a/site/src/lib/og/url.ts
+++ b/site/src/lib/og/url.ts
@@ -1,0 +1,8 @@
+// The card URL space: the landing card at `og.png`, every other page's card
+// under `og/` off its docs-collection id.
+
+export const isLandingId = (id: string): boolean => id === 'index'
+
+export function ogImagePath(id: string): string {
+  return isLandingId(id) ? 'og.png' : `og/${id}.png`
+}

--- a/site/src/lib/shared/constants.ts
+++ b/site/src/lib/shared/constants.ts
@@ -1,3 +1,5 @@
+export const REPO_URL = 'https://github.com/Jybbs/prose'
+
 export const SHIKI_THEMES = { dark: 'github-dark', light: 'github-light' } as const
 
 // The Python target versions the rule pages tab across, oldest first.

--- a/site/src/lib/shared/registries.ts
+++ b/site/src/lib/shared/registries.ts
@@ -9,6 +9,8 @@ export type RuleFamily = (typeof FAMILY_ORDER)[number]
 export const isFamily = (name: string): name is RuleFamily =>
   (FAMILY_ORDER as readonly string[]).includes(name)
 
+export const FAMILY_WARMTHS = ['cool', 'warm'] as const
+
 export const GLOSSARY_FAMILIES = [...FAMILY_ORDER, 'cli', 'engine'] as const
 
 export const PRIMITIVE_LAYERS = ['analysis', 'base', 'orchestration'] as const

--- a/site/src/lib/tokens/resolve.ts
+++ b/site/src/lib/tokens/resolve.ts
@@ -1,6 +1,8 @@
-// The design-system tokens as a typed map. `resolveToken` reads a value
-// following one `var()` alias, and `tokensToCss` regenerates the `:root`
-// custom properties for the browser.
+// The design-system tokens as a typed map. `resolveColor` evaluates a token
+// to a concrete color, and `tokensToCss` regenerates the `:root` custom
+// properties for the browser.
+
+import { formatHex, interpolate } from 'culori'
 
 const TOKENS: Record<string, string> = {
   'family-alignment'     : 'var(--prose-palette-eureka)',
@@ -43,13 +45,19 @@ const TOKENS: Record<string, string> = {
   'section-usage'        : 'var(--prose-palette-oat)'
 }
 
-// Reads a token's value, following one `var()` alias so an aliased token and a
-// `color-mix()` blend both resolve to their first referenced token's value,
-// leaving the concrete blend to the color consumer.
-export function resolveToken(name: string): string {
-  const value      = TOKENS[name] ?? ''
-  const referenced = value.match(/var\(--prose-([\w-]+)\)/)?.[1]
-  return referenced ? (TOKENS[referenced] ?? '') : value
+const MIX = /^color-mix\(in oklch, var\(--prose-([\w-]+)\), (black|white) (\d+)%\)$/
+
+// Evaluates a token to a concrete color, following `var()` aliases and
+// computing `color-mix()` blends, the same operation CSS performs for the
+// browser.
+export function resolveColor(name: string): string {
+  const value = TOKENS[name] ?? ''
+  const alias = value.match(/^var\(--prose-([\w-]+)\)$/)
+  if (alias !== null) return resolveColor(alias[1])
+  const mix = value.match(MIX)
+  if (mix === null) return value
+  const [, base, toward, share] = mix
+  return formatHex(interpolate([resolveColor(base), toward], 'oklch')(Number(share) / 100))
 }
 
 export function tokensToCss(): string {

--- a/site/src/pages/og.png.ts
+++ b/site/src/pages/og.png.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from 'astro'
+
+import { cardResponse } from '../lib/og/render'
+
+export const GET: APIRoute = () => cardResponse('index')

--- a/site/src/pages/og/[...slug].png.ts
+++ b/site/src/pages/og/[...slug].png.ts
@@ -1,0 +1,8 @@
+import type { APIRoute, GetStaticPaths } from 'astro'
+
+import { cardResponse, pageCardIds } from '../../lib/og/render'
+
+export const getStaticPaths: GetStaticPaths = async () =>
+  (await pageCardIds()).map(id => ({ params: { slug: id } }))
+
+export const GET: APIRoute = ({ params }) => cardResponse(params.slug!)

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -3,6 +3,9 @@ import type { APIRoute } from 'astro'
 // Allow-all crawling, pointing crawlers at the index the sitemap integration
 // emits.
 export const GET: APIRoute = ({ site }) => {
-  const lines = ['User-agent: *', 'Allow: /', '', `Sitemap: ${new URL('sitemap-index.xml', site)}`, '']
+  const lines = [
+    'User-agent: *', 'Allow: /', '',
+    `Sitemap: ${new URL('sitemap-index.xml', site)}`, ''
+  ]
   return new Response(lines.join('\n'), { headers: { 'Content-Type': 'text/plain' } })
 }

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from 'astro'
+
+// Allow-all crawling, pointing crawlers at the index the sitemap integration
+// emits.
+export const GET: APIRoute = ({ site }) => {
+  const lines = ['User-agent: *', 'Allow: /', '', `Sitemap: ${new URL('sitemap-index.xml', site)}`, '']
+  return new Response(lines.join('\n'), { headers: { 'Content-Type': 'text/plain' } })
+}


### PR DESCRIPTION
### 🪻 Quick Summary

Builds the SEO surface on Starlight's head management and `@astrojs/sitemap`, one declared site URL feeding the auto-canonical, the sitemap, an allow-all `robots.txt`, and the per-route Open Graph, Twitter, and JSON-LD tags injected through a `defineRouteMiddleware` hook. Every docs page gets a satori-rendered card enriched from the content collections, stored content-addressed so only changed cards re-render, with the store restored in deploy as an inert integrity-checked cache.

---

### 🗞️ Key Changes

- Injects the per-route card image, description, and structured data onto `starlightRoute.head` in `site/src/lib/head/middleware.ts`, the JSON-LD authored against `schema-dts` types as a `TechArticle` per page and the landing `WebSite` and `SoftwareApplication` graph, serialized inline with no wrapper dependency.

- Renders the cards through satori templates under `site/src/lib/og/`, one shared parts layer carrying the card shell, rail, data panel, and the `monoLabel` label voice that the kicker, panel labels, badge, and caption code chips all compose.

- Enumerates one card per docs page plus the landing card in `site/src/lib/og/pages.ts`, enriched from the `docs`, `pipeline`, and `release` collections, with family warmth declared as index-page frontmatter and enforced by the corpus integrity pass.

- Stores rendered cards in a `cacache` store keyed off the render sources, brand assets, and crate version, pruned to the live card set each build, and restored in `deploy.yml` under a rolling sha key as an inert integrity-checked artifact rather than an active build input.

- Loads the brand SVGs and the static `@fontsource` faces once per build in `site/src/lib/og/assets.ts`, the title aspect derived from the SVG viewBox and every loaded face carrying an exact requester in the templates.

- Adds `resolveColor` in `site/src/lib/tokens/resolve.ts`, evaluating token aliases and `color-mix()` blends through `culori` so the cards and the `theme-color` meta read concrete hexes off the design-token map.

- Serves the allow-all `robots.txt` endpoint pointing crawlers at the sitemap index, with the sitemap `lastmod` read from the existing page-timestamps map.

- Carries the version nav-link through a `SocialIcons` override reading the `release` collection, and the `editLink` pattern onto the Starlight config off a shared `REPO_URL`.

- Excludes the statically rendered per-page edit links from the `lychee` link sweep, which rate-limited against them.

- Pins `satori`, `cacache`, `culori`, the three static `@fontsource` faces, and `schema-dts` in the site manifest, with `sharp` reaching the renderer through Astro's own dependency tree.

---

### 🧵 Related Issues

- Closes #365