### PR TITLE
[383] Finalize `0.7.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -8,7 +8,7 @@ name         = "prose"
 readme       = "../README.md"
 repository   = "https://github.com/Jybbs/prose"
 rust-version = "1.96"
-version      = "0.6.0"
+version      = "0.7.0"
 
 [dependencies]
 annotate-snippets  = "=0.12.16"

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -121,7 +121,7 @@ export default defineConfig({
     }
   },
   vite: {
-    build: { chunkSizeWarningLimit: 4000 },
+    build: { chunkSizeWarningLimit: 5000 },
     css: {
       postcss: {
         plugins: [

--- a/site/.vitepress/theme/components/glossary/GlossaryFolioIndex.vue
+++ b/site/.vitepress/theme/components/glossary/GlossaryFolioIndex.vue
@@ -20,15 +20,22 @@ const { filtered, grouped, ordered, query, selected } = useGlossaryFolio()
 
 <template>
   <aside v-if="visible" class="glossary-folio-index" aria-label="Glossary index">
-    <div class="glossary-folio-search panel">
-      <span class="vp-icon DocSearch-Search-Icon glossary-folio-search-glyph" aria-hidden="true"></span>
-      <input
-        v-model="query"
-        type="search"
-        class="glossary-folio-input"
-        aria-label="Filter glossary"
-      />
+    <div class="glossary-folio-search-header">
       <span class="glossary-folio-meta">{{ filtered.length }} of {{ ordered.length }}</span>
+      <div class="glossary-folio-search panel">
+        <svg class="glossary-folio-search-glyph" viewBox="0 0 24 24" aria-hidden="true">
+          <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+            <path d="m21 21l-4.34-4.34" />
+            <circle cx="11" cy="11" r="8" />
+          </g>
+        </svg>
+        <input
+          v-model="query"
+          type="search"
+          class="glossary-folio-input"
+          aria-label="Filter glossary"
+        />
+      </div>
     </div>
     <div v-if="filtered.length === 0" class="glossary-folio-empty">
       No entries match <code>{{ query }}</code>.

--- a/site/.vitepress/theme/components/glossary/styles/glossary-folio-index.css
+++ b/site/.vitepress/theme/components/glossary/styles/glossary-folio-index.css
@@ -54,6 +54,12 @@
   margin         : 20px 0 0;
 }
 
+.glossary-folio-search-header {
+  display        : flex;
+  flex-direction : column;
+  gap            : 4px;
+}
+
 .glossary-folio-search {
   display     : flex;
   align-items : center;
@@ -74,6 +80,7 @@
 }
 
 .glossary-folio-search-glyph {
+  display     : block;
   flex-shrink : 0;
   width       : 14px;
   height      : 14px;
@@ -92,6 +99,10 @@
   outline     : none;
 }
 
+.glossary-folio-input:focus-visible {
+  outline : none;
+}
+
 .glossary-folio-input::placeholder {
   font-family : inherit;
   font-size   : inherit;
@@ -100,9 +111,7 @@
 }
 
 .glossary-folio-meta {
-  flex-shrink    : 0;
   margin-left    : auto;
-  padding-left   : 8px;
   font-family    : var(--vp-font-family-mono);
   font-size      : var(--prose-text-meta);
   letter-spacing : var(--prose-meta-tracking);

--- a/site/.vitepress/theme/components/suppression/ScopeSpecimen.vue
+++ b/site/.vitepress/theme/components/suppression/ScopeSpecimen.vue
@@ -88,7 +88,7 @@ const legend = scopeBands(entries)
             :key="d.id"
             class="scope-specimen-legend-directive"
           >
-            <a class="body-link underline-draw" :href="d.href"><code>{{ d.form }}</code></a>
+            <a class="body-link" :href="d.href"><code>{{ d.form }}</code></a>
           </li>
         </ul>
       </li>

--- a/site/.vitepress/theme/components/suppression/styles/scope-specimen.css
+++ b/site/.vitepress/theme/components/suppression/styles/scope-specimen.css
@@ -171,12 +171,21 @@
 
 .vp-doc .scope-specimen-legend-directive code,
 .scope-specimen-legend-directive code {
-  font-family   : var(--vp-font-family-mono);
-  font-size     : 0.65rem;
-  padding       : 2px 6px;
-  border-radius : var(--prose-radius-sm);
-  background    : color-mix(in srgb, var(--scope-tint) 20%, var(--vp-c-bg));
-  color         : color-mix(in srgb, var(--scope-tint) 88%, var(--vp-c-text-1));
+  font-family        : var(--vp-font-family-mono);
+  font-size          : 0.65rem;
+  padding            : 2px 6px;
+  border-radius      : var(--prose-radius-sm);
+  color              : color-mix(in srgb, var(--scope-tint) 88%, var(--vp-c-text-1));
+  background-color   : color-mix(in srgb, var(--scope-tint) 20%, var(--vp-c-bg));
+  background-image   : linear-gradient(var(--underline-accent, var(--scope-tint)), var(--underline-accent, var(--scope-tint)));
+  background-repeat  : no-repeat;
+  background-position: left bottom;
+  background-size    : 0% 1px;
+  transition         : background-size var(--prose-transition-slow);
+}
+
+.scope-specimen-legend-directive a:hover code {
+  background-size : 100% 1px;
 }
 
 @media (--prose-bp-tablet) {

--- a/site/.vitepress/theme/styles/vitepress-chrome.css
+++ b/site/.vitepress/theme/styles/vitepress-chrome.css
@@ -106,8 +106,6 @@ div[class*='language-'] {
 .landing-cta-cmd > button.copy {
   direction              : ltr;
   position               : absolute;
-  top                    : 8px;
-  right                  : 8px;
   z-index                : 3;
   width                  : 28px;
   height                 : 28px;
@@ -121,6 +119,11 @@ div[class*='language-'] {
   opacity                : 0;
   cursor                 : pointer;
   transition             : border-color .25s, background-color .25s, opacity .25s;
+}
+
+:is(.vp-doc, body) div[class*='language-'] > button.copy {
+  top   : 8px;
+  right : 8px;
 }
 
 :is(.vp-doc, body) div[class*='language-']:hover > button.copy,


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes the seventh *Prose* release. Bumps `crate/Cargo.toml` from `0.6.0` to `0.7.0` and regenerates `Cargo.lock` against the new version. The `0.7` cycle added the `prose rules` subcommand and rebuilt the documentation site onto VitePress 2.

---

### 🗞️ Key Changes

- Bumps `crate/Cargo.toml` from `0.6.0` to `0.7.0` and regenerates `Cargo.lock` against the new version

- Splits the fence copy-button `top`/`right` position into its own selector, so the landing CTA's copy button no longer inherits it and stays inside its box under Vite 8's reordered cascade

- Layers the scope-decision chip underline onto the chip's own `<code>` above its fill, with an `--underline-accent` fallback, so it draws on hover instead of hiding behind the fill

- Replaces the glossary search glyph, blank after VitePress 2 dropped `DocSearch-Search-Icon`, with an inline `currentColor` SVG, groups the result count above the bar so the input fills the width, and opts the input out of the global focus ring

- Raises the docs-site `chunkSizeWarningLimit` to `5000` to clear the non-actionable warning the migration's unsplittable theme chunk trips

---

### 🧵 Related Issues

- Closes #383
