### PR TITLE
[386] Refresh the landing-page release stamp against PyPI

### DIFF
--- a/.github/actions/restore-og-cache/action.yml
+++ b/.github/actions/restore-og-cache/action.yml
@@ -1,4 +1,4 @@
-name        : Restore the OG card cache
+name        : Restore the OG card cache with a rolling commit key
 description : Restore `.cache/og` under a rolling commit-keyed entry with a prefix fallback, so every run reuses the newest card store and saves its own forward.
 
 runs:

--- a/.github/actions/restore-og-cache/action.yml
+++ b/.github/actions/restore-og-cache/action.yml
@@ -1,0 +1,13 @@
+name        : Restore the OG card cache
+description : Restore `.cache/og` under a rolling commit-keyed entry with a prefix fallback, so every run reuses the newest card store and saves its own forward.
+
+runs:
+  using: composite
+
+  steps:
+    - name : Restore the OG card cache
+      uses : actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+      with:
+        key          : og-cards-${{ runner.os }}-${{ github.sha }}
+        path         : .cache/og
+        restore-keys : og-cards-${{ runner.os }}-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
       - .mise/tasks/**
       - .nvmrc
       - crate/Cargo.toml
-      - 'site/**'
+      - site/**
 
   push:
     branches : [main]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - .github/actions/provision-bun/**
       - .github/actions/provision-cargo/**
       - .github/actions/provision-uv/**
+      - .github/actions/restore-og-cache/**
       - .github/workflows/deploy.yml
       - .mise/tasks/**
       - .nvmrc
@@ -17,6 +18,8 @@ on:
   push:
     branches : [main]
     paths    : *paths
+
+  workflow_dispatch:
 
 concurrency:
   cancel-in-progress : ${{ github.event_name == 'pull_request' }}
@@ -90,11 +93,7 @@ jobs:
       - *provision-bun
 
       - name : Restore the OG card cache
-        uses : actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          key          : og-cards-${{ runner.os }}-${{ github.sha }}
-          path         : .cache/og
-          restore-keys : og-cards-${{ runner.os }}-
+        uses : ./.github/actions/restore-og-cache
 
       - name : Build the site and check internal links
         run  : mise run links

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,18 @@ jobs:
       - name : Publish to PyPI
         run  : uv publish --trusted-publishing=always dist/*
 
+  deploy:
+    name            : 🪁 Deploy
+    needs           : publish
+    permissions     : { actions: write }
+    runs-on         : *ubuntu
+    timeout-minutes : 5
+
+    steps:
+      - name : Dispatch the deploy workflow
+        env  : { GH_TOKEN: "${{ github.token }}" }
+        run  : gh workflow run deploy.yml --ref main --repo ${{ github.repository }}
+
   gate:
     name            : 🗞️ Brief
     if              : always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ permissions : { contents: read }
 on:
   pull_request:
     paths:
-      - crate/pyproject.toml
-      - crate/Cargo.toml
       - .github/workflows/release.yml
+      - crate/Cargo.toml
+      - crate/pyproject.toml
 
   push:
     tags: ['[0-9]*']

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -33,14 +33,10 @@ jobs:
         run  : mise run build bin
 
       - name : Restore the OG card cache
-        uses : &cache-action actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          key          : og-cards-${{ runner.os }}-${{ github.sha }}
-          path         : .cache/og
-          restore-keys : og-cards-${{ runner.os }}-
+        uses : ./.github/actions/restore-og-cache
 
       - name : Restore the lychee cache
-        uses : *cache-action
+        uses : actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           key          : lychee-${{ runner.os }}-${{ github.sha }}
           path         : .cache/.lycheecache


### PR DESCRIPTION
### 🪻 Quick Summary

Refreshes the landing page's release stamp by redeploying the docs site the moment a release reaches PyPI. `release.yml` gains a tail job that dispatches the deploy workflow on `main` after its publish job succeeds, so the build-time loader reads the release just published as the newest one and the stamp shows the current version without a browser-side fetch.

---

### 🗞️ Key Changes

- Adds a `workflow_dispatch` trigger to `deploy.yml`, giving the release workflow (*and a maintainer*) a way to redeploy the site on demand

- Adds a `🪁 Deploy` tail job to `release.yml` that runs after `publish` succeeds and dispatches the deploy workflow on `main` through `gh workflow run` under a job-scoped `actions: write` grant, skipping with the publish job on dry runs so the dispatch adds no runs to any other pull request

- Extracts the Open Graph card cache block duplicated across `deploy.yml` and `sweep.yml` into a zero-input `restore-og-cache` composite, adding the composite's directory to the deploy paths filter so edits to it re-run the deploy checks

---

### 🧵 Related Issues

- Closes #386