### PR TITLE
[389] Derive a machine-readable schema for the config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1454,7 @@ dependencies = [
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",
+ "schemars",
  "serde",
  "serde-sarif",
  "serde_ignored",
@@ -1875,7 +1882,9 @@ dependencies = [
  "ruff_source_file",
  "ruff_text_size",
  "rustc-hash",
+ "schemars",
  "serde",
+ "serde_json",
  "thin-vec",
  "thiserror",
 ]
@@ -2103,6 +2112,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2198,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The trade-offs minimalist formatters were built to avoid (*wider diffs, more ver
 uv tool install prose-formatter
 ```
 
-The binary exposes `format`, `check`, `rules`, `server`, `cache`, `completions`, and `config-schema`:
+The binary exposes `format`, `check`, `rules`, `server`, `cache`, `completions`, and `schema`:
 
 ```bash
 prose format path/             # rewrite files in place
@@ -42,6 +42,7 @@ prose format --diff path/      # show the diff without writing
 prose check --stdin < file.py  # read from stdin
 prose format - < file.py       # `-` reads from stdin too
 prose rules                    # list the rules in pipeline order
+prose schema                   # print the config's JSON Schema
 prose server                   # language server over stdio
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The trade-offs minimalist formatters were built to avoid (*wider diffs, more ver
 uv tool install prose-formatter
 ```
 
-The binary exposes `format`, `check`, `rules`, `server`, `cache`, and `completions`:
+The binary exposes `format`, `check`, `rules`, `server`, `cache`, `completions`, and `config-schema`:
 
 ```bash
 prose format path/             # rewrite files in place

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -32,12 +32,13 @@ rayon              = "1.10"
 regex-lite         = "0.1"
 ruff_diagnostics   = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18", features = ["serde"] }
 ruff_notebook      = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18" }
-ruff_python_ast    = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18", features = ["serde"] }
+ruff_python_ast    = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18", features = ["schemars", "serde"] }
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18" }
 ruff_python_stdlib = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18" }
 ruff_python_trivia = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18" }
 ruff_source_file   = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18", features = ["serde"] }
 ruff_text_size     = { git = "https://github.com/astral-sh/ruff", tag = "0.15.18", features = ["serde"] }
+schemars           = "1"
 serde              = { version = "1.0", features = ["derive"] }
 serde-sarif        = "0.8"
 serde_ignored      = "0.1"

--- a/crate/src/cli/args/mod.rs
+++ b/crate/src/cli/args/mod.rs
@@ -26,6 +26,18 @@ Exit codes:
   3    Parse error: input could not be parsed as Python
   4    Config error: pyproject.toml, --select / --ignore, or arg validation";
 
+#[derive(Debug, Subcommand)]
+pub(crate) enum CacheAction {
+    /// Clear every cached entry and report the freed bytes.
+    Clean,
+
+    /// Evict oldest entries until the configured size cap is met.
+    Compact,
+
+    /// Print the cache directory, entry count, byte total, and mtimes.
+    Info,
+}
+
 #[derive(Debug, Parser)]
 #[command(
     about,
@@ -65,29 +77,17 @@ pub(crate) enum Command {
         shell: Shell,
     },
 
-    /// Print the configuration's JSON Schema to stdout.
-    ConfigSchema,
-
     /// Rewrite files to conform to the Prose style.
     Format(FormatArgs),
 
     /// List the registered rules in pipeline order.
     Rules(RulesArgs),
 
+    /// Print the configuration's JSON Schema to stdout.
+    Schema,
+
     /// Run the language server over stdio.
     Server(ServerArgs),
-}
-
-#[derive(Debug, Subcommand)]
-pub(crate) enum CacheAction {
-    /// Clear every cached entry and report the freed bytes.
-    Clean,
-
-    /// Evict oldest entries until the configured size cap is met.
-    Compact,
-
-    /// Print the cache directory, entry count, byte total, and mtimes.
-    Info,
 }
 
 #[cfg(test)]
@@ -359,12 +359,6 @@ mod tests {
     }
 
     #[test]
-    fn config_schema_parses() {
-        let cli = Cli::try_parse_from(["prose", "config-schema"]).expect("parses");
-        assert_matches!(cli.command, Command::ConfigSchema);
-    }
-
-    #[test]
     fn format_dash_routes_to_stdin() {
         let mut cli = Cli::try_parse_from(["prose", "format", "-"]).expect("parses");
         assert!(normalize_stdin_dash(&mut cli).is_none());
@@ -447,8 +441,8 @@ mod tests {
     fn normalize_stdin_dash_is_noop_for_pathless_commands(
         #[values(
             &["prose", "completions", "bash"][..],
-            &["prose", "config-schema"][..],
-            &["prose", "rules"][..]
+            &["prose", "rules"][..],
+            &["prose", "schema"][..]
         )]
         args: &[&str],
     ) {
@@ -478,6 +472,12 @@ mod tests {
             Cli::try_parse_from(["prose", "rules", "--output-format", "json"]).expect("parses");
         let args = command_args!(cli, Rules);
         assert_matches!(args.output_format, RulesFormat::Json);
+    }
+
+    #[test]
+    fn schema_parses() {
+        let cli = Cli::try_parse_from(["prose", "schema"]).expect("parses");
+        assert_matches!(cli.command, Command::Schema);
     }
 
     #[test]

--- a/crate/src/cli/args/mod.rs
+++ b/crate/src/cli/args/mod.rs
@@ -103,18 +103,13 @@ mod tests {
     use crate::cli::exit_status::ExitStatus;
     use crate::rule::RuleId;
 
-    fn check_command(cli: Cli) -> CheckArgs {
-        let Command::Check(args) = cli.command else {
-            panic!("expected Check variant");
-        };
-        args
-    }
-
-    fn format_command(cli: Cli) -> FormatArgs {
-        let Command::Format(args) = cli.command else {
-            panic!("expected Format variant");
-        };
-        args
+    macro_rules! command_args {
+        ($cli:expr, $variant:ident) => {{
+            let Command::$variant(args) = $cli.command else {
+                panic!(concat!("expected ", stringify!($variant), " variant"));
+            };
+            args
+        }};
     }
 
     #[fixture]
@@ -156,7 +151,7 @@ mod tests {
     fn check_dash_routes_to_stdin() {
         let mut cli = Cli::try_parse_from(["prose", "check", "-"]).expect("parses");
         assert!(normalize_stdin_dash(&mut cli).is_none());
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert!(args.paths.is_empty());
         assert!(args.common.stdin);
     }
@@ -164,7 +159,7 @@ mod tests {
     #[test]
     fn check_parses_with_no_input_source() {
         let cli = Cli::try_parse_from(["prose", "check"]).expect("parses");
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert!(args.paths.is_empty());
         assert!(!args.common.stdin);
     }
@@ -173,7 +168,7 @@ mod tests {
     fn check_parses_with_output_format_github() {
         let cli =
             Cli::try_parse_from(["prose", "check", "--output-format", "github"]).expect("parses");
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert_matches!(args.common.output_format, OutputFormat::Github);
     }
 
@@ -181,14 +176,14 @@ mod tests {
     fn check_parses_with_output_format_json() {
         let cli =
             Cli::try_parse_from(["prose", "check", "--output-format", "json"]).expect("parses");
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert_matches!(args.common.output_format, OutputFormat::Json);
     }
 
     #[test]
     fn check_parses_with_paths() {
         let cli = Cli::try_parse_from(["prose", "check", "a.py", "b/"]).expect("parses");
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert_eq!(args.paths, [PathBuf::from("a.py"), PathBuf::from("b/")]);
         assert!(!args.common.stdin);
     }
@@ -204,7 +199,7 @@ mod tests {
             "alphabetize",
         ])
         .expect("parses");
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert_eq!(
             args.common.rules.select,
             [RuleId::from("align-equals"), RuleId::from("align-colons")],
@@ -215,7 +210,7 @@ mod tests {
     #[test]
     fn check_parses_with_stdin() {
         let cli = Cli::try_parse_from(["prose", "check", "--stdin"]).expect("parses");
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert!(args.paths.is_empty());
         assert!(args.common.stdin);
     }
@@ -271,9 +266,10 @@ mod tests {
 
     #[test]
     fn check_validate_defaults_off_and_parses_when_set() {
-        assert!(!check_command(Cli::try_parse_from(["prose", "check"]).expect("parses")).validate);
+        let off = Cli::try_parse_from(["prose", "check"]).expect("parses");
+        assert!(!command_args!(off, Check).validate);
         let on = Cli::try_parse_from(["prose", "check", "--validate"]).expect("parses");
-        assert!(check_command(on).validate);
+        assert!(command_args!(on, Check).validate);
     }
 
     #[test]
@@ -372,7 +368,7 @@ mod tests {
     fn format_dash_routes_to_stdin() {
         let mut cli = Cli::try_parse_from(["prose", "format", "-"]).expect("parses");
         assert!(normalize_stdin_dash(&mut cli).is_none());
-        let args = format_command(cli);
+        let args = command_args!(cli, Format);
         assert!(args.paths.is_empty());
         assert!(args.common.stdin);
     }
@@ -380,7 +376,7 @@ mod tests {
     #[test]
     fn format_parses_with_diff_and_paths() {
         let cli = Cli::try_parse_from(["prose", "format", "--diff", "a.py"]).expect("parses");
-        let args = format_command(cli);
+        let args = command_args!(cli, Format);
         assert!(args.diff);
         assert_eq!(args.paths, [PathBuf::from("a.py")]);
         assert!(!args.common.stdin);
@@ -397,7 +393,7 @@ mod tests {
             "alphabetize",
         ])
         .expect("parses");
-        let args = format_command(cli);
+        let args = command_args!(cli, Format);
         assert_eq!(args.common.rules.select, [RuleId::from("align-equals")]);
         assert_eq!(args.common.rules.ignore, [RuleId::from("alphabetize")]);
     }
@@ -405,7 +401,7 @@ mod tests {
     #[test]
     fn format_parses_with_stdin() {
         let cli = Cli::try_parse_from(["prose", "format", "--stdin"]).expect("parses");
-        let args = format_command(cli);
+        let args = command_args!(cli, Format);
         assert!(args.paths.is_empty());
         assert!(args.common.stdin);
     }
@@ -447,21 +443,16 @@ mod tests {
         assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     }
 
-    #[test]
-    fn normalize_stdin_dash_is_noop_for_completions() {
-        let mut cli = Cli::try_parse_from(["prose", "completions", "bash"]).expect("parses");
-        assert!(normalize_stdin_dash(&mut cli).is_none());
-    }
-
-    #[test]
-    fn normalize_stdin_dash_is_noop_for_config_schema() {
-        let mut cli = Cli::try_parse_from(["prose", "config-schema"]).expect("parses");
-        assert!(normalize_stdin_dash(&mut cli).is_none());
-    }
-
-    #[test]
-    fn normalize_stdin_dash_is_noop_for_rules() {
-        let mut cli = Cli::try_parse_from(["prose", "rules"]).expect("parses");
+    #[rstest]
+    fn normalize_stdin_dash_is_noop_for_pathless_commands(
+        #[values(
+            &["prose", "completions", "bash"][..],
+            &["prose", "config-schema"][..],
+            &["prose", "rules"][..]
+        )]
+        args: &[&str],
+    ) {
+        let mut cli = Cli::try_parse_from(args).expect("parses");
         assert!(normalize_stdin_dash(&mut cli).is_none());
     }
 
@@ -469,7 +460,7 @@ mod tests {
     fn normalize_stdin_dash_leaves_dashless_paths_untouched() {
         let mut cli = Cli::try_parse_from(["prose", "check", "a.py", "b/"]).expect("parses");
         assert!(normalize_stdin_dash(&mut cli).is_none());
-        let args = check_command(cli);
+        let args = command_args!(cli, Check);
         assert_eq!(args.paths, [PathBuf::from("a.py"), PathBuf::from("b/")]);
         assert!(!args.common.stdin);
     }
@@ -477,9 +468,7 @@ mod tests {
     #[test]
     fn rules_parses_with_default_table_format() {
         let cli = Cli::try_parse_from(["prose", "rules"]).expect("parses");
-        let Command::Rules(args) = cli.command else {
-            panic!("expected Rules variant");
-        };
+        let args = command_args!(cli, Rules);
         assert_matches!(args.output_format, RulesFormat::Table);
     }
 
@@ -487,18 +476,14 @@ mod tests {
     fn rules_parses_with_output_format_json() {
         let cli =
             Cli::try_parse_from(["prose", "rules", "--output-format", "json"]).expect("parses");
-        let Command::Rules(args) = cli.command else {
-            panic!("expected Rules variant");
-        };
+        let args = command_args!(cli, Rules);
         assert_matches!(args.output_format, RulesFormat::Json);
     }
 
     #[test]
     fn server_parses_with_default_stdio_transport() {
         let cli = Cli::try_parse_from(["prose", "server"]).expect("parses");
-        let Command::Server(args) = cli.command else {
-            panic!("expected Server variant");
-        };
+        let args = command_args!(cli, Server);
         assert_matches!(args.transport, Transport::Stdio);
     }
 }

--- a/crate/src/cli/args/mod.rs
+++ b/crate/src/cli/args/mod.rs
@@ -65,6 +65,9 @@ pub(crate) enum Command {
         shell: Shell,
     },
 
+    /// Print the configuration's JSON Schema to stdout.
+    ConfigSchema,
+
     /// Rewrite files to conform to the Prose style.
     Format(FormatArgs),
 
@@ -360,6 +363,12 @@ mod tests {
     }
 
     #[test]
+    fn config_schema_parses() {
+        let cli = Cli::try_parse_from(["prose", "config-schema"]).expect("parses");
+        assert_matches!(cli.command, Command::ConfigSchema);
+    }
+
+    #[test]
     fn format_dash_routes_to_stdin() {
         let mut cli = Cli::try_parse_from(["prose", "format", "-"]).expect("parses");
         assert!(normalize_stdin_dash(&mut cli).is_none());
@@ -441,6 +450,12 @@ mod tests {
     #[test]
     fn normalize_stdin_dash_is_noop_for_completions() {
         let mut cli = Cli::try_parse_from(["prose", "completions", "bash"]).expect("parses");
+        assert!(normalize_stdin_dash(&mut cli).is_none());
+    }
+
+    #[test]
+    fn normalize_stdin_dash_is_noop_for_config_schema() {
+        let mut cli = Cli::try_parse_from(["prose", "config-schema"]).expect("parses");
         assert!(normalize_stdin_dash(&mut cli).is_none());
     }
 

--- a/crate/src/cli/args/validation.rs
+++ b/crate/src/cli/args/validation.rs
@@ -14,6 +14,7 @@ pub(crate) fn normalize_stdin_dash(cli: &mut Cli) -> Option<clap::Error> {
     let (paths, stdin) = match &mut cli.command {
         Command::Cache { .. }
         | Command::Completions { .. }
+        | Command::ConfigSchema
         | Command::Rules(_)
         | Command::Server(_) => {
             return None;

--- a/crate/src/cli/args/validation.rs
+++ b/crate/src/cli/args/validation.rs
@@ -8,14 +8,24 @@ use crate::cli::exit_status::ExitStatus;
 
 use super::{Cli, Command};
 
+/// Help / version land at `Clean`, every other clap error at `ConfigError`.
+pub(super) fn clap_error_status(kind: ErrorKind) -> ExitStatus {
+    match kind {
+        ErrorKind::DisplayHelp
+        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+        | ErrorKind::DisplayVersion => ExitStatus::Clean,
+        _ => ExitStatus::ConfigError,
+    }
+}
+
 /// Resolves a `-` positional into stdin mode, surfacing a clap
 /// error when `-` appears alongside other paths.
 pub(crate) fn normalize_stdin_dash(cli: &mut Cli) -> Option<clap::Error> {
     let (paths, stdin) = match &mut cli.command {
         Command::Cache { .. }
         | Command::Completions { .. }
-        | Command::ConfigSchema
         | Command::Rules(_)
+        | Command::Schema
         | Command::Server(_) => {
             return None;
         }
@@ -55,14 +65,4 @@ pub(crate) fn validate_diff_format_combination(cli: &Cli) -> Option<clap::Error>
             "`--diff` requires `--output-format text`",
         )
     })
-}
-
-/// Help / version land at `Clean`, every other clap error at `ConfigError`.
-pub(super) fn clap_error_status(kind: ErrorKind) -> ExitStatus {
-    match kind {
-        ErrorKind::DisplayHelp
-        | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
-        | ErrorKind::DisplayVersion => ExitStatus::Clean,
-        _ => ExitStatus::ConfigError,
-    }
 }

--- a/crate/src/cli/config_schema.rs
+++ b/crate/src/cli/config_schema.rs
@@ -1,0 +1,38 @@
+//! `prose config-schema` subcommand: the configuration's JSON Schema.
+
+use std::io::Write;
+
+use schemars::schema_for;
+
+use super::exit_status::ExitStatus;
+use crate::config::Config;
+
+/// Prints the JSON Schema derived from [`Config`], pretty-printed.
+pub(crate) fn print<W: Write>(mut stdout: W) -> anyhow::Result<ExitStatus> {
+    serde_json::to_writer_pretty(&mut stdout, &schema_for!(Config))?;
+    writeln!(stdout)?;
+    Ok(ExitStatus::Clean)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render() -> String {
+        let mut out = Vec::new();
+        print(&mut out).expect("schema emission succeeds");
+        String::from_utf8(out).expect("utf8 output")
+    }
+
+    #[test]
+    fn output_ends_with_a_newline() {
+        assert!(render().ends_with('\n'));
+    }
+
+    #[test]
+    fn output_is_a_json_schema_object() {
+        let schema: serde_json::Value = serde_json::from_str(&render()).expect("valid JSON");
+        assert!(schema["$schema"].as_str().is_some());
+        assert!(schema["properties"].is_object());
+    }
+}

--- a/crate/src/cli/mod.rs
+++ b/crate/src/cli/mod.rs
@@ -3,8 +3,8 @@
 //! Subcommands: `check` reports violations without modifying files,
 //! `format` rewrites in place (or prints a unified diff with
 //! `--diff`), `cache` manages the user-level content cache,
-//! `completions` emits a shell-completion script, `config-schema`
-//! prints the configuration's JSON Schema, and `rules` lists the
+//! `completions` emits a shell-completion script, `schema` prints
+//! the configuration's JSON Schema, and `rules` lists the
 //! registered rules in pipeline order. `check` and `format` accept
 //! positional paths, a `-` positional alias for stdin, and a
 //! `--stdin` flag, all mutually exclusive.
@@ -15,12 +15,12 @@
 //!
 //! Layout: `args` houses every clap-derived type and parse-time
 //! validation. `cache` houses the `prose cache` subcommand handlers.
-//! `config_schema` houses the `prose config-schema` emission.
 //! `rules` houses the `prose rules` listing. `runner` houses the
 //! pipeline-orchestration helpers that translate parsed args into
-//! source loading, emitter dispatch, and diff rendering. `output`
-//! houses the human-readable run summary and its palette.
-//! `exit_status` carries the matrix every subcommand resolves into.
+//! source loading, emitter dispatch, and diff rendering. `schema`
+//! houses the `prose schema` emission. `output` houses the
+//! human-readable run summary and its palette. `exit_status`
+//! carries the matrix every subcommand resolves into.
 
 use std::{
     io::{self, IsTerminal, Write},
@@ -34,11 +34,11 @@ use clap_complete::generate;
 
 pub(crate) mod args;
 mod cache;
-mod config_schema;
 pub(crate) mod exit_status;
 mod output;
 mod rules;
 mod runner;
+mod schema;
 
 use args::{
     CacheAction, Cli, Command, normalize_stdin_dash, report_clap_error,
@@ -86,11 +86,11 @@ pub fn run() -> ExitCode {
             generate(shell, &mut Cli::command(), "prose", &mut io::stdout());
             Ok(ExitStatus::Clean)
         }
-        Command::ConfigSchema => config_schema::print(stdout),
         Command::Format(args) => {
             runner::format_with_io(args, verbose, &present, io::stdin(), stdout, stderr)
         }
         Command::Rules(args) => rules::list(&args, stdout),
+        Command::Schema => schema::print(stdout),
         Command::Server(_) => unreachable!("Server dispatched before the stdout lock"),
     };
     finalize(result).into()
@@ -102,8 +102,8 @@ fn command_quiet(command: &Command) -> bool {
         Command::Format(args) => args.common.quiet,
         Command::Cache { .. }
         | Command::Completions { .. }
-        | Command::ConfigSchema
         | Command::Rules(_)
+        | Command::Schema
         | Command::Server(_) => false,
     }
 }

--- a/crate/src/cli/mod.rs
+++ b/crate/src/cli/mod.rs
@@ -3,9 +3,10 @@
 //! Subcommands: `check` reports violations without modifying files,
 //! `format` rewrites in place (or prints a unified diff with
 //! `--diff`), `cache` manages the user-level content cache,
-//! `completions` emits a shell-completion script, and `rules` lists
-//! the registered rules in pipeline order. `check` and `format`
-//! accept positional paths, a `-` positional alias for stdin, and a
+//! `completions` emits a shell-completion script, `config-schema`
+//! prints the configuration's JSON Schema, and `rules` lists the
+//! registered rules in pipeline order. `check` and `format` accept
+//! positional paths, a `-` positional alias for stdin, and a
 //! `--stdin` flag, all mutually exclusive.
 //!
 //! Path mode parallelizes across files via `rayon`. Set
@@ -14,6 +15,7 @@
 //!
 //! Layout: `args` houses every clap-derived type and parse-time
 //! validation. `cache` houses the `prose cache` subcommand handlers.
+//! `config_schema` houses the `prose config-schema` emission.
 //! `rules` houses the `prose rules` listing. `runner` houses the
 //! pipeline-orchestration helpers that translate parsed args into
 //! source loading, emitter dispatch, and diff rendering. `output`
@@ -32,6 +34,7 @@ use clap_complete::generate;
 
 pub(crate) mod args;
 mod cache;
+mod config_schema;
 pub(crate) mod exit_status;
 mod output;
 mod rules;
@@ -83,6 +86,7 @@ pub fn run() -> ExitCode {
             generate(shell, &mut Cli::command(), "prose", &mut io::stdout());
             Ok(ExitStatus::Clean)
         }
+        Command::ConfigSchema => config_schema::print(stdout),
         Command::Format(args) => {
             runner::format_with_io(args, verbose, &present, io::stdin(), stdout, stderr)
         }
@@ -98,6 +102,7 @@ fn command_quiet(command: &Command) -> bool {
         Command::Format(args) => args.common.quiet,
         Command::Cache { .. }
         | Command::Completions { .. }
+        | Command::ConfigSchema
         | Command::Rules(_)
         | Command::Server(_) => false,
     }

--- a/crate/src/cli/rules.rs
+++ b/crate/src/cli/rules.rs
@@ -1,6 +1,6 @@
 //! `prose rules` subcommand: the registered rules in pipeline order.
 
-use std::io::Write;
+use std::io::{self, Write};
 
 use serde::Serialize;
 
@@ -32,7 +32,7 @@ pub(crate) fn list<W: Write>(args: &RulesArgs, mut stdout: W) -> anyhow::Result<
         .collect();
     match args.output_format {
         RulesFormat::Json => {
-            serde_json::to_writer(&mut stdout, &rules)?;
+            serde_json::to_writer(&mut stdout, &rules).map_err(io::Error::from)?;
             writeln!(stdout)?;
         }
         RulesFormat::Table => write_table(&mut stdout, &rules)?,
@@ -40,7 +40,7 @@ pub(crate) fn list<W: Write>(args: &RulesArgs, mut stdout: W) -> anyhow::Result<
     Ok(ExitStatus::Clean)
 }
 
-fn write_table<W: Write>(mut stdout: W, rules: &[RuleInfo]) -> std::io::Result<()> {
+fn write_table<W: Write>(mut stdout: W, rules: &[RuleInfo]) -> io::Result<()> {
     let slug_width = rules.iter().map(|rule| rule.slug.len()).max().unwrap_or(0);
     let pos_width = rules.len().to_string().len();
     for rule in rules {

--- a/crate/src/cli/runner/report.rs
+++ b/crate/src/cli/runner/report.rs
@@ -204,19 +204,7 @@ mod tests {
     use crate::diagnostics::Severity;
     use crate::rule::RuleId;
     use crate::source::Source;
-    use crate::testing::{parse, range};
-
-    struct FailingWriter;
-
-    impl Write for FailingWriter {
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-
-        fn write(&mut self, _: &[u8]) -> io::Result<usize> {
-            Err(io::Error::other("simulated write failure"))
-        }
-    }
+    use crate::testing::{FailingWriter, parse, range};
 
     fn diagnostic(severity: Severity, range: TextRange, slug: &'static str) -> Diagnostic {
         Diagnostic {
@@ -283,7 +271,7 @@ mod tests {
     }
 
     #[test]
-    fn emit_outcomes_propagates_writer_failure() {
+    fn emit_outcomes_propagates_the_writer_failure_kind() {
         let source = parse("x = 1\n");
         let diags = vec![diagnostic(
             Severity::Format,
@@ -294,10 +282,14 @@ mod tests {
         let result = emit_outcomes(
             &outcomes,
             OutputFormat::Json,
-            &mut FailingWriter,
+            &mut FailingWriter(io::ErrorKind::BrokenPipe),
             &EmitterSummary::default(),
         );
-        assert!(result.is_err());
+        let err = result.expect_err("writer failure propagates");
+        assert_matches!(
+            err.downcast_ref::<io::Error>(),
+            Some(e) if e.kind() == io::ErrorKind::BrokenPipe
+        );
     }
 
     #[rstest]

--- a/crate/src/cli/schema.rs
+++ b/crate/src/cli/schema.rs
@@ -1,6 +1,6 @@
-//! `prose config-schema` subcommand: the configuration's JSON Schema.
+//! `prose schema` subcommand: the configuration's JSON Schema.
 
-use std::io::Write;
+use std::io::{self, Write};
 
 use schemars::schema_for;
 
@@ -9,7 +9,7 @@ use crate::config::Config;
 
 /// Prints the JSON Schema derived from [`Config`], pretty-printed.
 pub(crate) fn print<W: Write>(mut stdout: W) -> anyhow::Result<ExitStatus> {
-    serde_json::to_writer_pretty(&mut stdout, &schema_for!(Config))?;
+    serde_json::to_writer_pretty(&mut stdout, &schema_for!(Config)).map_err(io::Error::from)?;
     writeln!(stdout)?;
     Ok(ExitStatus::Clean)
 }
@@ -17,11 +17,18 @@ pub(crate) fn print<W: Write>(mut stdout: W) -> anyhow::Result<ExitStatus> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testing::FailingWriter;
 
     fn render() -> String {
         let mut out = Vec::new();
         print(&mut out).expect("schema emission succeeds");
         String::from_utf8(out).expect("utf8 output")
+    }
+
+    #[test]
+    fn broken_pipe_write_finalizes_to_the_clean_exit() {
+        let result = print(FailingWriter(io::ErrorKind::BrokenPipe));
+        assert_eq!(crate::cli::finalize(result), ExitStatus::Clean);
     }
 
     #[test]

--- a/crate/src/config/de.rs
+++ b/crate/src/config/de.rs
@@ -1,5 +1,6 @@
-//! Serde `deserialize_with` helpers: the bool-or-table rule reader,
-//! the optional-cap parser, and the regex round-trip.
+//! Serde `deserialize_with` and `serialize_with` helpers: the
+//! bool-or-table rule reader, and the optional-cap and regex
+//! round-trips.
 
 use std::{fmt, marker::PhantomData, num::NonZeroUsize};
 
@@ -12,36 +13,6 @@ use serde::{
 use super::load::ConfigNotice;
 use super::schema::RuleToggle;
 use super::{Config, ConfigError};
-
-/// Resolves a rule's config from either a bare bool toggle or a
-/// sub-table. `deserialize_any` dispatches on the TOML value so the
-/// sub-table arm forwards a live map, preserving `serde_ignored`'s
-/// unknown-key tracking inside the table.
-pub(crate) fn deserialize_rule<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-where
-    D: Deserializer<'de>,
-    T: RuleToggle + Deserialize<'de>,
-{
-    struct RuleVisitor<T>(PhantomData<T>);
-
-    impl<'de, T: RuleToggle + Deserialize<'de>> Visitor<'de> for RuleVisitor<T> {
-        type Value = T;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("a boolean toggle or a rule sub-table")
-        }
-
-        fn visit_bool<E: serde::de::Error>(self, enabled: bool) -> Result<T, E> {
-            Ok(T::with_enabled(enabled))
-        }
-
-        fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<T, A::Error> {
-            T::deserialize(MapAccessDeserializer::new(map))
-        }
-    }
-
-    deserializer.deserialize_any(RuleVisitor(PhantomData))
-}
 
 /// Deserializes an optional cap a positive integer sets and `false`
 /// disables. `true` is rejected so the disable spelling stays
@@ -88,6 +59,48 @@ pub(super) fn deserialize_regex<'de, D: Deserializer<'de>>(
 ) -> Result<Regex, D::Error> {
     let pattern = String::deserialize(deserializer)?;
     Regex::new(&pattern).map_err(serde::de::Error::custom)
+}
+
+/// Resolves a rule's config from either a bare bool toggle or a
+/// sub-table. `deserialize_any` dispatches on the TOML value so the
+/// sub-table arm forwards a live map, preserving `serde_ignored`'s
+/// unknown-key tracking inside the table.
+pub(crate) fn deserialize_rule<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: RuleToggle + Deserialize<'de>,
+{
+    struct RuleVisitor<T>(PhantomData<T>);
+
+    impl<'de, T: RuleToggle + Deserialize<'de>> Visitor<'de> for RuleVisitor<T> {
+        type Value = T;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a boolean toggle or a rule sub-table")
+        }
+
+        fn visit_bool<E: serde::de::Error>(self, enabled: bool) -> Result<T, E> {
+            Ok(T::with_enabled(enabled))
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<T, A::Error> {
+            T::deserialize(MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(RuleVisitor(PhantomData))
+}
+
+/// Serializes an optional cap as its integer, or `false` when uncapped,
+/// mirroring `deserialize_optional_cap`.
+pub(super) fn serialize_optional_cap<S: Serializer>(
+    cap: &Option<NonZeroUsize>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    match cap {
+        Some(n) => serializer.serialize_u64(n.get() as u64),
+        None => serializer.serialize_bool(false),
+    }
 }
 
 pub(super) fn serialize_regex<S: Serializer>(

--- a/crate/src/config/de.rs
+++ b/crate/src/config/de.rs
@@ -14,9 +14,32 @@ use super::load::ConfigNotice;
 use super::schema::RuleToggle;
 use super::{Config, ConfigError};
 
+/// Deserializes a cap of integer type `T`, or `false` lifting it to
+/// `None`. `true` is rejected with `on_true` so the disable spelling
+/// stays unambiguous.
+pub(super) fn deserialize_cap_or_false<'de, T, D>(
+    deserializer: D,
+    on_true: &'static str,
+) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Value<T> {
+        Cap(T),
+        Off(bool),
+    }
+    match Value::deserialize(deserializer)? {
+        Value::Cap(n) => Ok(Some(n)),
+        Value::Off(false) => Ok(None),
+        Value::Off(true) => Err(serde::de::Error::custom(on_true)),
+    }
+}
+
 /// Deserializes an optional cap a positive integer sets and `false`
-/// disables. `true` is rejected so the disable spelling stays
-/// unambiguous. Shared by the `InlineBudget` layout caps and the
+/// disables. Shared by the `InlineBudget` layout caps and the
 /// top-level `import-line-length` key.
 pub(super) fn deserialize_optional_cap<'de, D>(
     deserializer: D,
@@ -24,19 +47,10 @@ pub(super) fn deserialize_optional_cap<'de, D>(
 where
     D: Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Value {
-        Cap(NonZeroUsize),
-        Off(bool),
-    }
-    match Value::deserialize(deserializer)? {
-        Value::Cap(n) => Ok(Some(n)),
-        Value::Off(false) => Ok(None),
-        Value::Off(true) => Err(serde::de::Error::custom(
-            "expected a positive integer or `false`, not `true`",
-        )),
-    }
+    deserialize_cap_or_false(
+        deserializer,
+        "expected a positive integer or `false`, not `true`",
+    )
 }
 
 pub(super) fn deserialize_prose<F>(

--- a/crate/src/config/json_schema.rs
+++ b/crate/src/config/json_schema.rs
@@ -1,0 +1,43 @@
+//! `JsonSchema` helpers for the custom-serde config spellings: the
+//! bool-or-table rule entry, the optional cap, and the regex knob.
+
+use std::num::NonZeroUsize;
+
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
+use serde::Serialize;
+
+use super::schema::SingleUseVariablesConfig;
+
+/// Schema for `allow-pattern`, a regex carried as a string.
+pub(super) fn allow_pattern_schema(_generator: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "type": "string",
+        "format": "regex",
+        "default": SingleUseVariablesConfig::default().allow_pattern.as_str(),
+    })
+}
+
+/// Schema for a cap of integer type `T`, or `false` lifting it.
+pub(super) fn cap_or_false_schema<T: JsonSchema>(generator: &mut SchemaGenerator) -> Schema {
+    json_schema!({
+        "anyOf": [generator.subschema_for::<T>(), { "const": false }],
+    })
+}
+
+/// Schema for an optional cap a positive integer sets and `false`
+/// lifts, the shape `deserialize_optional_cap` reads.
+pub(super) fn optional_cap_schema(generator: &mut SchemaGenerator) -> Schema {
+    cap_or_false_schema::<NonZeroUsize>(generator)
+}
+
+/// Schema for one `[tool.prose.rules]` entry, a bare bool toggle or the
+/// rule's sub-table, the shape `deserialize_rule` reads.
+pub(crate) fn rule_schema<T>(generator: &mut SchemaGenerator) -> Schema
+where
+    T: Default + JsonSchema + Serialize,
+{
+    json_schema!({
+        "anyOf": [{ "type": "boolean" }, generator.subschema_for::<T>()],
+        "default": T::default(),
+    })
+}

--- a/crate/src/config/mod.rs
+++ b/crate/src/config/mod.rs
@@ -18,8 +18,8 @@
 //! block onto that base, lives in [`ConfigSource`].
 //!
 //! The whole tree implements `schemars::JsonSchema`, so `prose
-//! config-schema` prints a JSON Schema carrying every key's type,
-//! default, and range.
+//! schema` prints a JSON Schema carrying every key's type, default,
+//! and range.
 
 use std::{collections::HashSet, num::NonZeroUsize, path::Path};
 

--- a/crate/src/config/mod.rs
+++ b/crate/src/config/mod.rs
@@ -16,16 +16,22 @@
 //! `Config::load` yields the base config. Per-file resolution, layering
 //! `[[tool.prose.overrides]]` globs and a standalone script's PEP 723
 //! block onto that base, lives in [`ConfigSource`].
+//!
+//! The whole tree implements `schemars::JsonSchema`, so `prose
+//! config-schema` prints a JSON Schema carrying every key's type,
+//! default, and range.
 
 use std::{collections::HashSet, num::NonZeroUsize, path::Path};
 
 use ruff_python_ast::PythonVersion;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub use crate::rule::RuleConfigs;
 
 mod de;
+mod json_schema;
 mod load;
 mod merge;
 mod overrides;
@@ -34,7 +40,8 @@ mod script;
 mod source;
 
 pub(crate) use de::deserialize_rule;
-use de::{deserialize_optional_cap, deserialize_prose};
+use de::{deserialize_optional_cap, deserialize_prose, serialize_optional_cap};
+pub(crate) use json_schema::rule_schema;
 pub(crate) use load::config_rel_paths;
 use load::{ConfigNotice, emit_notice, prose_table_from_str, walk_prose_table};
 pub use schema::*;
@@ -50,14 +57,18 @@ pub(crate) use source::ConfigSource;
 /// `docstring_structured_policy` defaults to `CodeLineLength`.
 /// `imports.first_party` defaults to empty. `target_version` defaults
 /// to `None`. Per-rule settings live under `rules`.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
     pub cache: CacheConfig,
     pub code_line_length: Option<NonZeroUsize>,
     pub docstring_line_length: Option<NonZeroUsize>,
     pub docstring_structured_policy: DocstringStructuredPolicy,
-    #[serde(deserialize_with = "deserialize_optional_cap")]
+    #[schemars(schema_with = "json_schema::optional_cap_schema")]
+    #[serde(
+        deserialize_with = "deserialize_optional_cap",
+        serialize_with = "serialize_optional_cap"
+    )]
     pub import_line_length: Option<NonZeroUsize>,
     pub imports: ImportsConfig,
     pub rules: RuleConfigs,
@@ -203,3 +214,5 @@ pub enum ConfigError {
 mod load_tests;
 #[cfg(test)]
 mod parse_tests;
+#[cfg(test)]
+mod schema_tests;

--- a/crate/src/config/parse_tests.rs
+++ b/crate/src/config/parse_tests.rs
@@ -1,10 +1,22 @@
 //! String-parsing-surface tests for `Config::from_prose_toml_str` and
 //! `Config::from_pyproject_str`.
 
+use std::fmt::Debug;
+
 use assert_matches::assert_matches;
 use rstest::rstest;
 
 use super::*;
+
+/// Asserts a parsed config survives a TOML dump and re-parse,
+/// comparing through `project`.
+fn assert_round_trips<T: Debug + PartialEq>(pyproject: &str, project: impl Fn(&Config) -> T) {
+    let config = Config::from_pyproject_str(pyproject).expect("parses");
+    let dumped = toml::to_string(&config).expect("Config serializes");
+    let reparsed = Config::from_prose_toml_str(&dumped).expect("reparses");
+
+    assert_eq!(project(&reparsed), project(&config));
+}
 
 fn assert_toml_error(toml: &str) {
     assert_matches!(Config::from_pyproject_str(toml), Err(ConfigError::Toml(_)));
@@ -169,6 +181,16 @@ fn import_line_length_negative_returns_toml_error() {
     assert_toml_error("[tool.prose]\nimport-line-length = -1\n");
 }
 
+#[rstest]
+#[case("100")]
+#[case("false")]
+fn import_line_length_round_trips_through_toml(#[case] value: &str) {
+    assert_round_trips(
+        &format!("[tool.prose]\nimport-line-length = {value}\n"),
+        |c| c.import_line_length,
+    );
+}
+
 #[test]
 fn import_line_length_true_returns_toml_error() {
     assert_toml_error("[tool.prose]\nimport-line-length = true\n");
@@ -246,13 +268,10 @@ fn inline_budget_round_trips_through_toml(
     #[case] cap_of: fn(&Config) -> Option<usize>,
     #[values("5", "false")] value: &str,
 ) {
-    let config =
-        Config::from_pyproject_str(&format!("[tool.prose.rules.{table}]\n{key} = {value}\n"))
-            .expect("parses");
-    let dumped = toml::to_string(&config).expect("Config serializes");
-    let reparsed = Config::from_prose_toml_str(&dumped).expect("reparses");
-
-    assert_eq!(cap_of(&reparsed), cap_of(&config));
+    assert_round_trips(
+        &format!("[tool.prose.rules.{table}]\n{key} = {value}\n"),
+        cap_of,
+    );
 }
 
 #[test]
@@ -285,16 +304,9 @@ fn max_shift_reads_each_value_form(#[case] value: &str, #[case] expected: MaxShi
 #[case("4")]
 #[case("false")]
 fn max_shift_round_trips_through_toml(#[case] value: &str) {
-    let config = Config::from_pyproject_str(&format!(
-        "[tool.prose.rules.align-equals]\nmax-shift = {value}\n"
-    ))
-    .expect("parses");
-    let dumped = toml::to_string(&config).expect("Config serializes");
-    let reparsed = Config::from_prose_toml_str(&dumped).expect("reparses");
-
-    assert_eq!(
-        reparsed.rules.align_equals.max_shift,
-        config.rules.align_equals.max_shift,
+    assert_round_trips(
+        &format!("[tool.prose.rules.align-equals]\nmax-shift = {value}\n"),
+        |c| c.rules.align_equals.max_shift,
     );
 }
 
@@ -448,4 +460,12 @@ fn target_version_extra_period_returns_toml_error() {
 #[test]
 fn target_version_invalid_value_returns_toml_error() {
     assert_toml_error("[tool.prose]\ntarget-version = \"py310\"\n");
+}
+
+#[test]
+fn uncapped_import_line_length_serializes_as_false() {
+    let config =
+        Config::from_pyproject_str("[tool.prose]\nimport-line-length = false\n").expect("parses");
+
+    assert!(config.to_toml().contains("import-line-length = false"));
 }

--- a/crate/src/config/schema.rs
+++ b/crate/src/config/schema.rs
@@ -1,17 +1,21 @@
 //! The per-rule config sub-tables, the rule-toggle macro, and the
 //! shared `MaxShift` and docstring-policy enums.
 
-use std::num::NonZeroUsize;
+use std::{borrow::Cow, num::NonZeroUsize};
 
 use regex_lite::Regex;
+use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::de::{deserialize_optional_cap, deserialize_regex, serialize_regex};
+use super::de::{
+    deserialize_optional_cap, deserialize_regex, serialize_optional_cap, serialize_regex,
+};
+use super::json_schema::{cap_or_false_schema, optional_cap_schema};
 
 /// Alignment-rule config shared by every rule that aligns a token
 /// across consecutive lines. `max_shift` caps how far a row may shift
 /// to reach the column.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct AlignmentConfig {
     pub enabled: bool,
@@ -35,7 +39,7 @@ impl Default for AlignmentConfig {
 /// `false`. `sort_docstring_entries` gates the Google-style
 /// entry-section reorder. `sort_dunder_lists` reorders the `__all__`
 /// and `__slots__` string lists.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct AlphabetizeConfig {
     pub enabled: bool,
@@ -58,7 +62,7 @@ impl Default for AlphabetizeConfig {
 }
 
 /// Configuration for the `bare_imports` rule.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct BareImportsConfig {
     pub allow: Vec<String>,
@@ -79,7 +83,7 @@ impl Default for BareImportsConfig {
 }
 
 /// Cache settings parsed from `[tool.prose.cache]`.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct CacheConfig {
     pub enabled: bool,
@@ -99,7 +103,7 @@ impl Default for CacheConfig {
 ///
 /// `max_args` caps the count threshold. A positive integer enforces the
 /// cap. `false` disables the count trigger.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct CallLayoutConfig {
     pub enabled: bool,
@@ -128,7 +132,7 @@ impl Default for CallLayoutConfig {
 /// `max_atomics` and `max_dict_entries` each take a positive integer or
 /// `false`. The integer sets the cap, and `false` disables it, leaving
 /// width as the only gate.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct CollectionLayoutConfig {
     pub collapse: bool,
@@ -156,7 +160,7 @@ impl Default for CollectionLayoutConfig {
 ///
 /// `CodeLineLength` reuses `Config::code_line_length`.
 /// `DocstringLineLength` reuses `Config::docstring_line_length`.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum DocstringStructuredPolicy {
     #[default]
@@ -167,7 +171,7 @@ pub enum DocstringStructuredPolicy {
 /// Settings parsed from `[tool.prose.imports]`. `first_party` lists
 /// the package names whose imports group with relative imports as
 /// local-package, keyed kebab-case under `first-party`.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct ImportsConfig {
     pub first_party: Vec<String>,
@@ -193,12 +197,19 @@ impl<'de> Deserialize<'de> for InlineBudget {
     }
 }
 
+impl JsonSchema for InlineBudget {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("InlineBudget")
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        optional_cap_schema(generator)
+    }
+}
+
 impl Serialize for InlineBudget {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self.0 {
-            Some(n) => serializer.serialize_u64(n.get() as u64),
-            None => serializer.serialize_bool(false),
-        }
+        serialize_optional_cap(&self.0, serializer)
     }
 }
 
@@ -238,6 +249,16 @@ impl<'de> Deserialize<'de> for MaxShift {
     }
 }
 
+impl JsonSchema for MaxShift {
+    fn schema_name() -> Cow<'static, str> {
+        Cow::Borrowed("MaxShift")
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        cap_or_false_schema::<usize>(generator)
+    }
+}
+
 impl Serialize for MaxShift {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match *self {
@@ -249,7 +270,7 @@ impl Serialize for MaxShift {
 }
 
 /// Configuration for the `reassigned_constants` rule.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct ReassignedConstantsConfig {
     pub allow: Vec<String>,
@@ -269,7 +290,7 @@ impl Default for ReassignedConstantsConfig {
 ///
 /// `max_params` caps the count threshold. A positive integer enforces
 /// the cap. `false` disables the count trigger.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct SignatureLayoutConfig {
     pub enabled: bool,
@@ -286,9 +307,10 @@ impl Default for SignatureLayoutConfig {
 }
 
 /// Configuration for the `single_use_variables` rule.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct SingleUseVariablesConfig {
+    #[schemars(schema_with = "super::json_schema::allow_pattern_schema")]
     #[serde(
         deserialize_with = "deserialize_regex",
         serialize_with = "serialize_regex"
@@ -307,7 +329,7 @@ impl Default for SingleUseVariablesConfig {
 }
 
 /// Sub-table shape for rules whose only knob is `enabled`.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct ToggleOnly {
     pub enabled: bool,

--- a/crate/src/config/schema.rs
+++ b/crate/src/config/schema.rs
@@ -7,10 +7,13 @@ use regex_lite::Regex;
 use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::de::{
-    deserialize_optional_cap, deserialize_regex, serialize_optional_cap, serialize_regex,
+use super::{
+    de::{
+        deserialize_cap_or_false, deserialize_optional_cap, deserialize_regex,
+        serialize_optional_cap, serialize_regex,
+    },
+    json_schema::{cap_or_false_schema, optional_cap_schema},
 };
-use super::json_schema::{cap_or_false_schema, optional_cap_schema};
 
 /// Alignment-rule config shared by every rule that aligns a token
 /// across consecutive lines. `max_shift` caps how far a row may shift
@@ -233,18 +236,12 @@ impl Default for MaxShift {
 
 impl<'de> Deserialize<'de> for MaxShift {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Repr {
-            Cap(usize),
-            Switch(bool),
-        }
-        match Repr::deserialize(deserializer)? {
-            Repr::Cap(n) => Ok(NonZeroUsize::new(n).map_or(Self::NoShift, Self::Cap)),
-            Repr::Switch(false) => Ok(Self::Unlimited),
-            Repr::Switch(true) => Err(serde::de::Error::custom(
-                "`max-shift` accepts a non-negative integer or `false`, not `true`",
-            )),
+        match deserialize_cap_or_false::<usize, _>(
+            deserializer,
+            "`max-shift` accepts a non-negative integer or `false`, not `true`",
+        )? {
+            Some(n) => Ok(NonZeroUsize::new(n).map_or(Self::NoShift, Self::Cap)),
+            None => Ok(Self::Unlimited),
         }
     }
 }

--- a/crate/src/config/schema_tests.rs
+++ b/crate/src/config/schema_tests.rs
@@ -1,0 +1,121 @@
+//! Schema-shape tests for the `JsonSchema` derive across the `Config`
+//! tree and the hand-written impls for the custom-serde spellings.
+
+use rstest::{fixture, rstest};
+use schemars::schema_for;
+use serde_json::{Value, json};
+
+use super::*;
+use crate::pipeline::Pipeline;
+
+#[fixture]
+fn schema() -> Value {
+    serde_json::to_value(schema_for!(Config)).expect("schema serializes")
+}
+
+#[rstest]
+fn allow_pattern_reads_a_regex_string_with_the_config_default(schema: Value) {
+    assert_eq!(
+        schema["$defs"]["SingleUseVariablesConfig"]["properties"]["allow-pattern"],
+        json!({ "type": "string", "format": "regex", "default": "^_" }),
+    );
+}
+
+#[rstest]
+#[case::code_line_length("code-line-length", json!(88))]
+#[case::docstring_line_length("docstring-line-length", json!(76))]
+#[case::import_line_length("import-line-length", json!(120))]
+fn defaults_mirror_config_default(schema: Value, #[case] key: &str, #[case] expected: Value) {
+    assert_eq!(schema["properties"][key]["default"], expected);
+}
+
+#[rstest]
+fn docstring_structured_policy_enumerates_kebab_variants(schema: Value) {
+    assert_eq!(
+        schema["$defs"]["DocstringStructuredPolicy"]["enum"],
+        json!(["code-line-length", "docstring-line-length"]),
+    );
+}
+
+#[rstest]
+fn import_line_length_accepts_a_positive_integer_or_false(schema: Value) {
+    let any_of = &schema["properties"]["import-line-length"]["anyOf"];
+
+    assert_eq!(any_of[0]["minimum"], json!(1));
+    assert_eq!(any_of[1], json!({ "const": false }));
+}
+
+#[rstest]
+fn inline_budget_accepts_a_positive_integer_or_false(schema: Value) {
+    let any_of = &schema["$defs"]["InlineBudget"]["anyOf"];
+
+    assert_eq!(any_of[0]["minimum"], json!(1));
+    assert_eq!(any_of[1], json!({ "const": false }));
+}
+
+#[rstest]
+fn max_shift_accepts_a_non_negative_integer_or_false(schema: Value) {
+    let any_of = &schema["$defs"]["MaxShift"]["anyOf"];
+
+    assert_eq!(any_of[0]["minimum"], json!(0));
+    assert_eq!(any_of[1], json!({ "const": false }));
+}
+
+#[rstest]
+fn rule_entry_accepts_a_bool_toggle_or_a_sub_table(schema: Value) {
+    let entry = &schema["$defs"]["RuleConfigs"]["properties"]["align-equals"];
+
+    assert_eq!(entry["anyOf"][0], json!({ "type": "boolean" }));
+    assert_eq!(
+        entry["anyOf"][1],
+        json!({ "$ref": "#/$defs/AlignmentConfig" }),
+    );
+    assert_eq!(entry["default"]["max-shift"], json!(16));
+}
+
+#[rstest]
+fn rules_schema_carries_every_registered_slug(schema: Value) {
+    let properties = schema["$defs"]["RuleConfigs"]["properties"]
+        .as_object()
+        .expect("rules schema is an object");
+
+    assert_eq!(properties.len(), Pipeline::known_ids().len());
+    for id in Pipeline::known_ids() {
+        assert!(
+            properties.contains_key(id.as_str()),
+            "missing rule entry `{id}`",
+        );
+    }
+}
+
+#[rstest]
+fn schema_document_snapshot(schema: Value) {
+    insta::assert_snapshot!(serde_json::to_string_pretty(&schema).expect("renders"));
+}
+
+#[rstest]
+fn target_version_reads_the_upstream_python_version_schema(schema: Value) {
+    assert_eq!(
+        schema["properties"]["target-version"]["anyOf"][0],
+        json!({ "$ref": "#/$defs/PythonVersion" }),
+    );
+    assert!(schema["$defs"]["PythonVersion"]["anyOf"].is_array());
+}
+
+#[rstest]
+fn top_level_properties_are_the_serialized_config_keys(schema: Value) {
+    let config = serde_json::to_value(Config::default()).expect("Config serializes");
+
+    assert_eq!(
+        schema["properties"]
+            .as_object()
+            .expect("an object")
+            .keys()
+            .collect::<Vec<_>>(),
+        config
+            .as_object()
+            .expect("an object")
+            .keys()
+            .collect::<Vec<_>>(),
+    );
+}

--- a/crate/src/config/schema_tests.rs
+++ b/crate/src/config/schema_tests.rs
@@ -10,7 +10,7 @@ use crate::pipeline::Pipeline;
 
 #[fixture]
 fn schema() -> Value {
-    serde_json::to_value(schema_for!(Config)).expect("schema serializes")
+    schema_for!(Config).to_value()
 }
 
 #[rstest]
@@ -19,6 +19,22 @@ fn allow_pattern_reads_a_regex_string_with_the_config_default(schema: Value) {
         schema["$defs"]["SingleUseVariablesConfig"]["properties"]["allow-pattern"],
         json!({ "type": "string", "format": "regex", "default": "^_" }),
     );
+}
+
+#[rstest]
+#[case::import_line_length("properties", "import-line-length", 1)]
+#[case::inline_budget("$defs", "InlineBudget", 1)]
+#[case::max_shift("$defs", "MaxShift", 0)]
+fn cap_schemas_accept_an_integer_or_false(
+    schema: Value,
+    #[case] section: &str,
+    #[case] key: &str,
+    #[case] minimum: u64,
+) {
+    let any_of = &schema[section][key]["anyOf"];
+
+    assert_eq!(any_of[0]["minimum"], json!(minimum));
+    assert_eq!(any_of[1], json!({ "const": false }));
 }
 
 #[rstest]
@@ -35,30 +51,6 @@ fn docstring_structured_policy_enumerates_kebab_variants(schema: Value) {
         schema["$defs"]["DocstringStructuredPolicy"]["enum"],
         json!(["code-line-length", "docstring-line-length"]),
     );
-}
-
-#[rstest]
-fn import_line_length_accepts_a_positive_integer_or_false(schema: Value) {
-    let any_of = &schema["properties"]["import-line-length"]["anyOf"];
-
-    assert_eq!(any_of[0]["minimum"], json!(1));
-    assert_eq!(any_of[1], json!({ "const": false }));
-}
-
-#[rstest]
-fn inline_budget_accepts_a_positive_integer_or_false(schema: Value) {
-    let any_of = &schema["$defs"]["InlineBudget"]["anyOf"];
-
-    assert_eq!(any_of[0]["minimum"], json!(1));
-    assert_eq!(any_of[1], json!({ "const": false }));
-}
-
-#[rstest]
-fn max_shift_accepts_a_non_negative_integer_or_false(schema: Value) {
-    let any_of = &schema["$defs"]["MaxShift"]["anyOf"];
-
-    assert_eq!(any_of[0]["minimum"], json!(0));
-    assert_eq!(any_of[1], json!({ "const": false }));
 }
 
 #[rstest]

--- a/crate/src/config/snapshots/prose__config__schema_tests__schema_document_snapshot.snap
+++ b/crate/src/config/snapshots/prose__config__schema_tests__schema_document_snapshot.snap
@@ -1,0 +1,846 @@
+---
+source: crate/src/config/schema_tests.rs
+expression: "serde_json::to_string_pretty(&schema).expect(\"renders\")"
+---
+{
+  "$defs": {
+    "AlignmentConfig": {
+      "description": "Alignment-rule config shared by every rule that aligns a token\nacross consecutive lines. `max_shift` caps how far a row may shift\nto reach the column.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "max-shift": {
+          "$ref": "#/$defs/MaxShift",
+          "default": 16
+        }
+      },
+      "type": "object"
+    },
+    "AlphabetizeConfig": {
+      "description": "Configuration for the `alphabetize` rule. Each facet gates one sort\npass and defaults `true`. `group_methods` keys methods on\n`(group, name)` for the dunder-property-private-public grouping,\ndropping to `name` alone when `false`. `sort_definitions` reorders\nclass and function definitions, freezing them in source order when\n`false`. `sort_docstring_entries` gates the Google-style\nentry-section reorder. `sort_dunder_lists` reorders the `__all__`\nand `__slots__` string lists.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "group-methods": {
+          "default": true,
+          "type": "boolean"
+        },
+        "sort-definitions": {
+          "default": true,
+          "type": "boolean"
+        },
+        "sort-docstring-entries": {
+          "default": true,
+          "type": "boolean"
+        },
+        "sort-dunder-lists": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "BareImportsConfig": {
+      "description": "Configuration for the `bare_imports` rule.",
+      "properties": {
+        "allow": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "exempt-aliased": {
+          "default": true,
+          "type": "boolean"
+        },
+        "max-attributes": {
+          "default": 4,
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "CacheConfig": {
+      "description": "Cache settings parsed from `[tool.prose.cache]`.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "max-size-mib": {
+          "default": 100,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "CallLayoutConfig": {
+      "description": "Configuration for the `call_layout` rule.\n\n`max_args` caps the count threshold. A positive integer enforces the\ncap. `false` disables the count trigger.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "max-args": {
+          "$ref": "#/$defs/InlineBudget",
+          "default": 3
+        }
+      },
+      "type": "object"
+    },
+    "CollectionLayoutConfig": {
+      "description": "Configuration for the `collection_layout` rule.\n\n`collapse`, `explode`, and `wrap_dict_entries` each gate one shape\nmove and default `true`. `collapse` joins a fitting multi-line\nliteral, subscript, or dict key back to one line. `explode` drives\nevery expansion, the width-driven spread and the `max_dict_entries`\ncount trigger alike, so `false` leaves the count cap inert.\n`wrap_dict_entries` breaks an over-wide `key: value` at its `:` and\nhangs the value beneath.\n\n`max_atomics` and `max_dict_entries` each take a positive integer or\n`false`. The integer sets the cap, and `false` disables it, leaving\nwidth as the only gate.",
+      "properties": {
+        "collapse": {
+          "default": true,
+          "type": "boolean"
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "explode": {
+          "default": true,
+          "type": "boolean"
+        },
+        "max-atomics": {
+          "$ref": "#/$defs/InlineBudget",
+          "default": 8
+        },
+        "max-dict-entries": {
+          "$ref": "#/$defs/InlineBudget",
+          "default": 3
+        },
+        "wrap-dict-entries": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "DocstringStructuredPolicy": {
+      "description": "Which budget structured docstring sections wrap to.\n\n`CodeLineLength` reuses `Config::code_line_length`.\n`DocstringLineLength` reuses `Config::docstring_line_length`.",
+      "enum": [
+        "code-line-length",
+        "docstring-line-length"
+      ],
+      "type": "string"
+    },
+    "ImportsConfig": {
+      "description": "Settings parsed from `[tool.prose.imports]`. `first_party` lists\nthe package names whose imports group with relative imports as\nlocal-package, keyed kebab-case under `first-party`.",
+      "properties": {
+        "first-party": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "InlineBudget": {
+      "anyOf": [
+        {
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "const": false
+        }
+      ]
+    },
+    "MaxShift": {
+      "anyOf": [
+        {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "const": false
+        }
+      ]
+    },
+    "PythonVersion": {
+      "anyOf": [
+        {
+          "pattern": "^\\d+\\.\\d+$",
+          "type": "string"
+        },
+        {
+          "const": "3.7",
+          "description": "Python 3.7"
+        },
+        {
+          "const": "3.8",
+          "description": "Python 3.8"
+        },
+        {
+          "const": "3.9",
+          "description": "Python 3.9"
+        },
+        {
+          "const": "3.10",
+          "description": "Python 3.10"
+        },
+        {
+          "const": "3.11",
+          "description": "Python 3.11"
+        },
+        {
+          "const": "3.12",
+          "description": "Python 3.12"
+        },
+        {
+          "const": "3.13",
+          "description": "Python 3.13"
+        },
+        {
+          "const": "3.14",
+          "description": "Python 3.14"
+        },
+        {
+          "const": "3.15",
+          "description": "Python 3.15"
+        }
+      ]
+    },
+    "ReassignedConstantsConfig": {
+      "description": "Configuration for the `reassigned_constants` rule.",
+      "properties": {
+        "allow": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "RuleConfigs": {
+      "description": "Per-rule configuration under `[tool.prose.rules]`.",
+      "properties": {
+        "align-colons": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/AlignmentConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "max-shift": 16
+          }
+        },
+        "align-comparisons": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/AlignmentConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "max-shift": 16
+          }
+        },
+        "align-equals": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/AlignmentConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "max-shift": 16
+          }
+        },
+        "align-imports": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/AlignmentConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "max-shift": 16
+          }
+        },
+        "align-match-case": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/AlignmentConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "max-shift": 16
+          }
+        },
+        "alphabetize": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/AlphabetizeConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "group-methods": true,
+            "sort-definitions": true,
+            "sort-docstring-entries": true,
+            "sort-dunder-lists": true
+          }
+        },
+        "band-constants": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "bare-imports": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/BareImportsConfig"
+            }
+          ],
+          "default": {
+            "allow": [],
+            "enabled": true,
+            "exempt-aliased": true,
+            "max-attributes": 4
+          }
+        },
+        "blank-lines": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "call-layout": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/CallLayoutConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "max-args": 3
+          }
+        },
+        "collection-layout": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/CollectionLayoutConfig"
+            }
+          ],
+          "default": {
+            "collapse": true,
+            "enabled": true,
+            "explode": true,
+            "max-atomics": 8,
+            "max-dict-entries": 3,
+            "wrap-dict-entries": true
+          }
+        },
+        "docstring-expand": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "docstring-frame": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "docstring-wrap": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "group-imports": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "import-layout": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "legacy-union-syntax": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "reassigned-constants": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ReassignedConstantsConfig"
+            }
+          ],
+          "default": {
+            "allow": [],
+            "enabled": true
+          }
+        },
+        "shed-parentheses": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "signature-annotations": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "signature-layout": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/SignatureLayoutConfig"
+            }
+          ],
+          "default": {
+            "enabled": true,
+            "max-params": 4
+          }
+        },
+        "single-use-variables": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/SingleUseVariablesConfig"
+            }
+          ],
+          "default": {
+            "allow-pattern": "^_",
+            "enabled": true
+          }
+        },
+        "step-narration": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "strip-align-padding": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "strip-none-return": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "strip-trailing-commas": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "unsorted-parameters": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        },
+        "unused-future-annotations": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/$defs/ToggleOnly"
+            }
+          ],
+          "default": {
+            "enabled": true
+          }
+        }
+      },
+      "type": "object"
+    },
+    "SignatureLayoutConfig": {
+      "description": "Configuration for the `signature_layout` rule.\n\n`max_params` caps the count threshold. A positive integer enforces\nthe cap. `false` disables the count trigger.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "max-params": {
+          "$ref": "#/$defs/InlineBudget",
+          "default": 4
+        }
+      },
+      "type": "object"
+    },
+    "SingleUseVariablesConfig": {
+      "description": "Configuration for the `single_use_variables` rule.",
+      "properties": {
+        "allow-pattern": {
+          "default": "^_",
+          "format": "regex",
+          "type": "string"
+        },
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "ToggleOnly": {
+      "description": "Sub-table shape for rules whose only knob is `enabled`.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The resolved `prose` configuration, read from a `prose.toml` or\n`.config/prose.toml` document root, or a `pyproject.toml`\n`[tool.prose]` table.\n\n`code_line_length` defaults to `Some(88)`. `docstring_line_length`\ndefaults to `Some(76)`. `import_line_length` defaults to `Some(120)`,\nfalling back to `code_line_length` when `false`.\n`docstring_structured_policy` defaults to `CodeLineLength`.\n`imports.first_party` defaults to empty. `target_version` defaults\nto `None`. Per-rule settings live under `rules`.",
+  "properties": {
+    "cache": {
+      "$ref": "#/$defs/CacheConfig",
+      "default": {
+        "enabled": true,
+        "max-size-mib": 100
+      }
+    },
+    "code-line-length": {
+      "default": 88,
+      "format": "uint",
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "docstring-line-length": {
+      "default": 76,
+      "format": "uint",
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "docstring-structured-policy": {
+      "$ref": "#/$defs/DocstringStructuredPolicy",
+      "default": "code-line-length"
+    },
+    "import-line-length": {
+      "anyOf": [
+        {
+          "format": "uint",
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "const": false
+        }
+      ],
+      "default": 120
+    },
+    "imports": {
+      "$ref": "#/$defs/ImportsConfig",
+      "default": {
+        "first-party": []
+      }
+    },
+    "rules": {
+      "$ref": "#/$defs/RuleConfigs",
+      "default": {
+        "align-colons": {
+          "enabled": true,
+          "max-shift": 16
+        },
+        "align-comparisons": {
+          "enabled": true,
+          "max-shift": 16
+        },
+        "align-equals": {
+          "enabled": true,
+          "max-shift": 16
+        },
+        "align-imports": {
+          "enabled": true,
+          "max-shift": 16
+        },
+        "align-match-case": {
+          "enabled": true,
+          "max-shift": 16
+        },
+        "alphabetize": {
+          "enabled": true,
+          "group-methods": true,
+          "sort-definitions": true,
+          "sort-docstring-entries": true,
+          "sort-dunder-lists": true
+        },
+        "band-constants": {
+          "enabled": true
+        },
+        "bare-imports": {
+          "allow": [],
+          "enabled": true,
+          "exempt-aliased": true,
+          "max-attributes": 4
+        },
+        "blank-lines": {
+          "enabled": true
+        },
+        "call-layout": {
+          "enabled": true,
+          "max-args": 3
+        },
+        "collection-layout": {
+          "collapse": true,
+          "enabled": true,
+          "explode": true,
+          "max-atomics": 8,
+          "max-dict-entries": 3,
+          "wrap-dict-entries": true
+        },
+        "docstring-expand": {
+          "enabled": true
+        },
+        "docstring-frame": {
+          "enabled": true
+        },
+        "docstring-wrap": {
+          "enabled": true
+        },
+        "group-imports": {
+          "enabled": true
+        },
+        "import-layout": {
+          "enabled": true
+        },
+        "legacy-union-syntax": {
+          "enabled": true
+        },
+        "reassigned-constants": {
+          "allow": [],
+          "enabled": true
+        },
+        "shed-parentheses": {
+          "enabled": true
+        },
+        "signature-annotations": {
+          "enabled": true
+        },
+        "signature-layout": {
+          "enabled": true,
+          "max-params": 4
+        },
+        "single-use-variables": {
+          "allow-pattern": "^_",
+          "enabled": true
+        },
+        "step-narration": {
+          "enabled": true
+        },
+        "strip-align-padding": {
+          "enabled": true
+        },
+        "strip-none-return": {
+          "enabled": true
+        },
+        "strip-trailing-commas": {
+          "enabled": true
+        },
+        "unsorted-parameters": {
+          "enabled": true
+        },
+        "unused-future-annotations": {
+          "enabled": true
+        }
+      }
+    },
+    "target-version": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PythonVersion"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "title": "Config",
+  "type": "object"
+}

--- a/crate/src/diagnostics/mod.rs
+++ b/crate/src/diagnostics/mod.rs
@@ -93,6 +93,6 @@ fn line_columns(file: &SourceFile, range: TextRange) -> (LineColumn, LineColumn)
 }
 
 fn write_json_line<T: Serialize>(writer: &mut dyn Write, value: &T) -> io::Result<()> {
-    serde_json::to_writer(&mut *writer, value).map_err(io::Error::other)?;
+    serde_json::to_writer(&mut *writer, value).map_err(io::Error::from)?;
     writer.write_all(b"\n")
 }

--- a/crate/src/rule.rs
+++ b/crate/src/rule.rs
@@ -7,17 +7,19 @@
 //! [`Pipeline::for_rule`], [`Pipeline::with_defaults`], and
 //! [`Pipeline::with_filters`] from a registry table.
 
-use std::{fmt, str::FromStr};
+use std::{borrow::Cow, fmt, str::FromStr};
 
 use ruff_diagnostics::Edit;
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 use serde::{Deserialize, Serialize};
+use serde_json::Map;
 use thiserror::Error;
 
 use crate::{
     config::{
         AlignmentConfig, AlphabetizeConfig, BareImportsConfig, CallLayoutConfig,
         CollectionLayoutConfig, Config, ReassignedConstantsConfig, SignatureLayoutConfig,
-        SingleUseVariablesConfig, ToggleOnly,
+        SingleUseVariablesConfig, ToggleOnly, rule_schema,
     },
     diagnostics::Diagnostic,
     pipeline::Pipeline,
@@ -180,14 +182,15 @@ const fn slug_bytes_equal(a: &[u8], b: &[u8]) -> bool {
     true
 }
 
-/// Generates [`KNOWN_IDS`], [`RuleConfigs`], [`message_for_id`],
-/// [`Pipeline::for_rule`], [`Pipeline::with_defaults`], and
-/// [`Pipeline::with_filters`] from a registry table. Each row leads
-/// with the rule's kebab-case slug, then its `[tool.prose.rules]`
-/// field name, config sub-table type, rule struct, and one-line
-/// imperative. The slug is the single source consumed by
-/// `RuleId::from_str`, the `[tool.prose.rules.<slug>]` section name,
-/// the `# prose: ignore[<slug>]` directive, and `--select` / `--ignore`.
+/// Generates [`KNOWN_IDS`], [`RuleConfigs`] with its bool-or-table
+/// `JsonSchema` impl, [`message_for_id`], [`Pipeline::for_rule`],
+/// [`Pipeline::with_defaults`], and [`Pipeline::with_filters`] from a
+/// registry table. Each row leads with the rule's kebab-case slug,
+/// then its `[tool.prose.rules]` field name, config sub-table type,
+/// rule struct, and one-line imperative. The slug is the single source
+/// consumed by `RuleId::from_str`, the `[tool.prose.rules.<slug>]`
+/// section name, the `# prose: ignore[<slug>]` directive, and
+/// `--select` / `--ignore`.
 ///
 /// The macro asserts each slug's kebab shape and cross-row uniqueness
 /// at compile time, and emits a `pub(crate) const SLUG: RuleId` on
@@ -211,6 +214,27 @@ macro_rules! register_rules {
                 #[serde(deserialize_with = "crate::config::deserialize_rule")]
                 pub $field: $config,
             )*
+        }
+
+        impl JsonSchema for RuleConfigs {
+            fn schema_name() -> Cow<'static, str> {
+                Cow::Borrowed("RuleConfigs")
+            }
+
+            fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+                let mut properties = Map::new();
+                $(
+                    properties.insert(
+                        $slug.to_owned(),
+                        rule_schema::<$config>(generator).to_value(),
+                    );
+                )*
+                json_schema!({
+                    "type": "object",
+                    "description": "Per-rule configuration under `[tool.prose.rules]`.",
+                    "properties": properties,
+                })
+            }
         }
 
         // Routes a missing-`Default` error to the offending `$config`

--- a/crate/src/rule.rs
+++ b/crate/src/rule.rs
@@ -222,13 +222,9 @@ macro_rules! register_rules {
             }
 
             fn json_schema(generator: &mut SchemaGenerator) -> Schema {
-                let mut properties = Map::new();
-                $(
-                    properties.insert(
-                        $slug.to_owned(),
-                        rule_schema::<$config>(generator).to_value(),
-                    );
-                )*
+                let properties = Map::from_iter([$(
+                    ($slug.to_owned(), rule_schema::<$config>(generator).to_value()),
+                )*]);
                 json_schema!({
                     "type": "object",
                     "description": "Per-rule configuration under `[tool.prose.rules]`.",

--- a/crate/src/testing.rs
+++ b/crate/src/testing.rs
@@ -1,6 +1,10 @@
 //! Helpers shared across `#[cfg(test)] mod tests` blocks.
 
-use std::{path::Path, str::FromStr};
+use std::{
+    io::{self, Write},
+    path::Path,
+    str::FromStr,
+};
 
 use lsp_types::Uri;
 use ruff_diagnostics::Edit;
@@ -17,6 +21,19 @@ use crate::{
     rule::{Rule, RuleId},
     source::Source,
 };
+
+/// Test-only writer whose `write` fails with the supplied kind.
+pub(crate) struct FailingWriter(pub(crate) io::ErrorKind);
+
+impl Write for FailingWriter {
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn write(&mut self, _: &[u8]) -> io::Result<usize> {
+        Err(self.0.into())
+    }
+}
 
 /// Test-only rule that returns the fix groups supplied at
 /// construction.

--- a/crate/tests/cli.rs
+++ b/crate/tests/cli.rs
@@ -661,6 +661,14 @@ fn config_errors_exit_four(#[case] args: &[&str]) {
     prose().args(args).assert().code(4);
 }
 
+#[test]
+fn config_schema_subcommand_exits_zero_and_prints_the_schema() {
+    let assert = prose().arg("config-schema").assert().success();
+    let schema: serde_json::Value =
+        serde_json::from_str(&stdout_utf8(&assert)).expect("valid JSON");
+    assert!(schema["properties"]["rules"].is_object());
+}
+
 /// Each input drives a rule that net-shrinks the buffer (`collection-layout`
 /// collapsing or re-laying-out a literal), the shape that overran the
 /// rewritten buffer before reporting anchored to the source as written. A

--- a/crate/tests/cli.rs
+++ b/crate/tests/cli.rs
@@ -661,14 +661,6 @@ fn config_errors_exit_four(#[case] args: &[&str]) {
     prose().args(args).assert().code(4);
 }
 
-#[test]
-fn config_schema_subcommand_exits_zero_and_prints_the_schema() {
-    let assert = prose().arg("config-schema").assert().success();
-    let schema: serde_json::Value =
-        serde_json::from_str(&stdout_utf8(&assert)).expect("valid JSON");
-    assert!(schema["properties"]["rules"].is_object());
-}
-
 /// Each input drives a rule that net-shrinks the buffer (`collection-layout`
 /// collapsing or re-laying-out a literal), the shape that overran the
 /// rewritten buffer before reporting anchored to the source as written. A
@@ -1093,6 +1085,14 @@ fn quiet_check_reduces_summary_to_a_bare_count() {
     assert_eq!(err.trim(), "1 diagnostic in 1 file.");
     assert!(!err.contains('🔖'), "quiet kept the anchor: {err:?}");
     assert!(!err.contains('\u{1b}'), "quiet kept color: {err:?}");
+}
+
+#[test]
+fn schema_subcommand_exits_zero_and_prints_the_schema() {
+    let assert = prose().arg("schema").assert().success();
+    let schema: serde_json::Value =
+        serde_json::from_str(&stdout_utf8(&assert)).expect("valid JSON");
+    assert!(schema["properties"]["rules"].is_object());
 }
 
 #[test]

--- a/site/.vitepress/lib/tokens/sources.ts
+++ b/site/.vitepress/lib/tokens/sources.ts
@@ -75,9 +75,9 @@ export const SOURCES: Record<Domain, readonly TokenSource[]> = {
     { key: 'prose cache info',    href: '/reference/cache#prose-cache-info',    blurb: 'Print cache path, entry count, byte total, and mtimes.' },
     { key: 'prose check',         href: '/reference/cli#prose-check',           blurb: 'Verify without rewriting, resolving to a non-zero exit code when any rewrite pends.' },
     { key: 'prose completions',   href: '/reference/cli#prose-completions',     blurb: 'Emit shell-completion scripts for the active shell.' },
-    { key: 'prose config-schema', href: '/reference/cli#prose-config-schema',   blurb: 'Print the configuration\'s JSON Schema, every key with its type, default, and range.' },
     { key: 'prose format',        href: '/reference/cli#prose-format',          blurb: 'Apply every pending rewrite in place.' },
     { key: 'prose rules',         href: '/reference/cli#prose-rules',           blurb: 'List every registered rule in pipeline order.' },
+    { key: 'prose schema',        href: '/reference/cli#prose-schema',          blurb: 'Print the configuration\'s JSON Schema, every key with its type, default, and range.' },
     { key: 'prose server',        href: '/reference/cli#prose-server',          blurb: 'Serve format-on-save and live diagnostics over the language-server protocol.' }
   ],
   'suppression': [

--- a/site/.vitepress/lib/tokens/sources.ts
+++ b/site/.vitepress/lib/tokens/sources.ts
@@ -75,6 +75,7 @@ export const SOURCES: Record<Domain, readonly TokenSource[]> = {
     { key: 'prose cache info',    href: '/reference/cache#prose-cache-info',    blurb: 'Print cache path, entry count, byte total, and mtimes.' },
     { key: 'prose check',         href: '/reference/cli#prose-check',           blurb: 'Verify without rewriting, resolving to a non-zero exit code when any rewrite pends.' },
     { key: 'prose completions',   href: '/reference/cli#prose-completions',     blurb: 'Emit shell-completion scripts for the active shell.' },
+    { key: 'prose config-schema', href: '/reference/cli#prose-config-schema',   blurb: 'Print the configuration\'s JSON Schema, every key with its type, default, and range.' },
     { key: 'prose format',        href: '/reference/cli#prose-format',          blurb: 'Apply every pending rewrite in place.' },
     { key: 'prose rules',         href: '/reference/cli#prose-rules',           blurb: 'List every registered rule in pipeline order.' },
     { key: 'prose server',        href: '/reference/cli#prose-server',          blurb: 'Serve format-on-save and live diagnostics over the language-server protocol.' }

--- a/site/reference/cli.md
+++ b/site/reference/cli.md
@@ -128,17 +128,6 @@ prose completions zsh > "${fpath[1]}/_prose"
 
 The [**Shell Completions**](/integrations/shell-completions) integration page covers the install path for each shell.
 
-## `prose config-schema`
-
-Prints the [JSON Schema](https://json-schema.org) for the `[tool.prose]` configuration, carrying every key's type, default, allowed values, and numeric range, with each `[rules]` entry mirroring the bare-bool-or-sub-table shape the loader reads. The output is pretty-printed, so redirecting it to a file lands a schema an editor or validator consumes directly.
-
-```bash
-prose config-schema
-prose config-schema > prose.schema.json
-```
-
-The [**Configuration**](/reference/configuration) reference walks the keys the schema describes.
-
 ## `prose rules`
 
 Lists every registered rule in pipeline order, one row per rule carrying its one-based position, slug, and imperative. The JSON form emits the same listing as an array of `{slug, position, imperative}` records for scripting consumers.
@@ -153,6 +142,17 @@ prose rules --output-format json
 ```
 
 The [**Pipeline Order**](/reference/pipeline-order) reference covers how the registry sequences the rules the listing reflects.
+
+## `prose schema`
+
+Prints the [JSON Schema](https://json-schema.org) for the `[tool.prose]` configuration, carrying every key's type, default, allowed values, and numeric range, with each `[rules]` entry mirroring the bare-bool-or-sub-table shape the loader reads. The output is pretty-printed, so redirecting it to a file lands a schema an editor or validator consumes directly.
+
+```bash
+prose schema
+prose schema > prose.schema.json
+```
+
+The [**Configuration**](/reference/configuration) reference walks the keys the schema describes.
 
 ## `prose server`
 

--- a/site/reference/cli.md
+++ b/site/reference/cli.md
@@ -128,6 +128,17 @@ prose completions zsh > "${fpath[1]}/_prose"
 
 The [**Shell Completions**](/integrations/shell-completions) integration page covers the install path for each shell.
 
+## `prose config-schema`
+
+Prints the [JSON Schema](https://json-schema.org) for the `[tool.prose]` configuration, carrying every key's type, default, allowed values, and numeric range, with each `[rules]` entry mirroring the bare-bool-or-sub-table shape the loader reads. The output is pretty-printed, so redirecting it to a file lands a schema an editor or validator consumes directly.
+
+```bash
+prose config-schema
+prose config-schema > prose.schema.json
+```
+
+The [**Configuration**](/reference/configuration) reference walks the keys the schema describes.
+
 ## `prose rules`
 
 Lists every registered rule in pipeline order, one row per rule carrying its one-based position, slug, and imperative. The JSON form emits the same listing as an array of `{slug, position, imperative}` records for scripting consumers.

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-*Prose* loads its configuration from a `prose.toml` file, a `.config/prose.toml`, or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically. The whole key set is also available as a machine-readable [JSON Schema](https://json-schema.org) through [`prose config-schema`](/reference/cli#prose-config-schema).
+*Prose* loads its configuration from a `prose.toml` file, a `.config/prose.toml`, or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically. The whole key set is also available as a machine-readable [JSON Schema](https://json-schema.org) through [`prose schema`](/reference/cli#prose-schema).
 
 A `prose.toml` keeps its keys at the document root, the form this page shows throughout, and a `.config/prose.toml` reads the same way for a project that keeps its tool config under a `.config/` directory. A `pyproject.toml` carries the same keys under a `[tool.prose]` prefix so the manifest can house other tools too, leaving every key below a `[tool.prose.<…>]` equivalent for projects that prefer one file.
 

--- a/site/reference/configuration.md
+++ b/site/reference/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-*Prose* loads its configuration from a `prose.toml` file, a `.config/prose.toml`, or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically.
+*Prose* loads its configuration from a `prose.toml` file, a `.config/prose.toml`, or the `[tool.prose]` table of a `pyproject.toml`, walking upward from each input file's directory to the nearest one. With no configuration, every rule runs at its default, in that a project that writes no config gets the canonical *Prose* shape automatically. The whole key set is also available as a machine-readable [JSON Schema](https://json-schema.org) through [`prose config-schema`](/reference/cli#prose-config-schema).
 
 A `prose.toml` keeps its keys at the document root, the form this page shows throughout, and a `.config/prose.toml` reads the same way for a project that keeps its tool config under a `.config/` directory. A `pyproject.toml` carries the same keys under a `[tool.prose]` prefix so the manifest can house other tools too, leaving every key below a `[tool.prose.<…>]` equivalent for projects that prefer one file.
 


### PR DESCRIPTION
### 🪻 Quick Summary

Derives a JSON Schema for the `[tool.prose]` configuration from the config structs themselves, so every key's type, default, allowed values, and numeric range comes from one source that grows with the tree. A new `prose schema` subcommand prints the document, giving editors, validators, and the docs site a machine-readable description of the whole key set.

---

### 🗞️ Key Changes

- Derives `JsonSchema` across the `Config` tree through a new `schemars` dependency

- Hand-writes the schemas for the custom-serde spellings (*`MaxShift`, `InlineBudget`, the optional cap, the `allow-pattern` regex*) so the integer-or-`false` and regex forms reach the schema with their ranges and defaults

- Emits `RuleConfigs`' bool-or-table entries from the `register_rules!` registry rows, so every rule slug lands in the schema without a second hand-kept list

- Enables `ruff_python_ast`'s `schemars` feature so `target-version` reads the upstream `PythonVersion` schema

- Serializes an uncapped `import-line-length` as `false`, so a serialized effective config carries every key including the uncapped one

- Adds the `prose schema` subcommand printing the pretty-printed document, covered by parse, dispatch, snapshot, and end-to-end binary tests

- Maps `serde_json` write errors through `io::Error::from` at the three JSON emission sites, so a truncated pipe exits clean, with a shared `FailingWriter` test double pinning the kind end to end

- Documents the subcommand on the CLI reference with a token-source entry and a README usage line, and cross-links it from the configuration reference

---

### 🧵 Related Issues

- Closes #389