### PR TITLE
[388] Serve the WebAssembly build from the docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ node_modules/
 site/.vitepress/dist/
 site/.vitepress/.temp/
 site/coverage/
+site/public/wasm/
 **/*.timestamp-*.mjs

--- a/.mise/tasks/module
+++ b/.mise/tasks/module
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash -euo pipefail
 #MISE description="Build the `prose_wasm` web module into `site/public/wasm` with `wasm-pack`"
 #MISE dir="wasm"
-#MISE tools={"aqua:wasm-bindgen/wasm-pack" = "0.15.0"}
+#MISE tools={"aqua:wasm-bindgen/wasm-pack" = "0.15.0", "github:rustwasm/wasm-bindgen" = "0.2.120"}
 
 out=../site/public/wasm
 wasm-pack build --target web --profile wasm-release --no-pack --out-dir "$out" -- --locked

--- a/.mise/tasks/module
+++ b/.mise/tasks/module
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S bash -euo pipefail
+#MISE description="Build the `prose_wasm` web module into `site/public/wasm` with `wasm-pack`"
+#MISE dir="wasm"
+#MISE tools={"aqua:wasm-bindgen/wasm-pack" = "0.15.0"}
+
+out=../site/public/wasm
+wasm-pack build --target web --profile wasm-release --no-pack --out-dir "$out" -- --locked
+rm -f "$out/.gitignore"

--- a/.mise/tasks/press
+++ b/.mise/tasks/press
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S bash -euo pipefail
 #MISE description="Produce the static docs bundle at `site/.vitepress/dist`"
-#MISE depends=["bake", "build bin"]
+#MISE depends=["bake", "build bin", "module"]
 #MISE dir="site"
 
 bunx vitepress build


### PR DESCRIPTION
### 🪻 Quick Summary

Serves the WebAssembly build from the docs site, so the deployed bundle carries the browser-loadable `prose_wasm` module beside the pages themselves. A new `module` mise task runs `wasm-pack` into `site/public/wasm` and joins `press`'s dependencies, so every path that builds the site (*the local sweep, `mise ci`, and the deploy workflow*) produces the module before VitePress copies it into the bundle.

---

### 🗞️ Key Changes

- Adds a `module` mise task that runs `wasm-pack build --target web` under the `wasm-release` profile into `site/public/wasm`, pinning `wasm-pack` through the task's own `#MISE tools` frontmatter so the site build provisions it on its own

- Joins `module` to `press`'s `depends` beside `build bin`, so the local sweep, `mise ci`, and the deploy workflow's `links` step each produce the module before VitePress copies `site/public` into the deployed bundle

- Builds with `--no-pack` to skip the npm `package.json` and `--locked` for a reproducible resolve, then strips wasm-pack's nested `.gitignore` so the bundle carries only the module and its bindings

- Pins `wasm-bindgen` beside `wasm-pack` through the `github:` backend at the version the locked crate expects, so wasm-pack's binding step resolves the CLI under mise rather than a version-less shim

- Ignores the generated `site/public/wasm/` output, keeping the build artifact out of git while VitePress serves it from the static-assets directory

---

### ☕ Implementation Notes

#### Pinning `wasm-bindgen` Explicitly

The task was meant to lean on `wasm-pack` to provision its own toolchain, with the `#MISE tools` frontmatter pinning only `wasm-pack` itself. In practice `wasm-pack` shells out to a separate `wasm-bindgen` binary to generate the JavaScript bindings, and under mise the shims directory sits on `PATH` and intercepts that call, so on any machine where `wasm-bindgen-cli` is installed through mise but left unpinned the task fails on a version-less shim. Pinning `github:rustwasm/wasm-bindgen` beside `wasm-pack` resolves the shim and, as a bonus, converts wasm-pack's ad-hoc runtime download of `wasm-bindgen` into a mise-managed, version-locked, attestation-verified dependency.

The `github:` backend downloads a prebuilt binary rather than the `cargo:` backend's source compile on every deploy, and unlike the `ubi:` backend it carries no deprecation clock. The one string attached is a version coupling, in that the pin must match the `wasm-bindgen` crate in `Cargo.lock` exactly, because the CLI and the runtime crate reject a schema-version mismatch, so a future crate bump has to move this pin in lockstep.

---

### 🧵 Related Issues

- Closes #388
