### PR TITLE
[424] Profile the workflows and the site build for wall-clock savings

### DIFF
--- a/.github/actions/download-wheels/action.yml
+++ b/.github/actions/download-wheels/action.yml
@@ -1,4 +1,4 @@
-name        : Download wheel artifacts
+name        : Download wheels
 description : Pull every `wheels-*` artifact uploaded by the build matrix into `dist/`, with one site for the `actions/download-artifact` SHA pin.
 
 runs:

--- a/.github/actions/provision-bun/action.yml
+++ b/.github/actions/provision-bun/action.yml
@@ -1,4 +1,4 @@
-name        : Provision bun with a warm dep cache
+name        : Provision bun
 description : Restore `~/.bun/install/cache` and `site/node_modules` keyed off `site/bun.lock` so subsequent `bun install --frozen-lockfile` invocations skip the resolve and link work. Assumes bun is already on PATH from an earlier `provision-cargo` or `jdx/mise-action` step.
 
 inputs:

--- a/.github/actions/provision-cargo/action.yml
+++ b/.github/actions/provision-cargo/action.yml
@@ -1,4 +1,4 @@
-name        : Provision the Cargo toolchain with a warm build cache
+name        : Provision Cargo
 description : Install mise tools (provisioning the Rust toolchain `.mise/config.toml` pins) and restore the Swatinem Cargo cache for the given `shared-key`. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
 
 inputs:
@@ -18,9 +18,14 @@ runs:
   using: composite
 
   steps:
-    - name  : Point the rustup home into the cached mise directory
-      run   : echo "MISE_RUSTUP_HOME=$HOME/.local/share/mise/rustup" >> "$GITHUB_ENV"
+    - name  : Point rustup and Cargo at the shared environment
       shell : bash
+      run   : |
+        {
+          echo "CARGO_PROFILE_DEV_DEBUG=line-tables-only"
+          echo "CARGO_TERM_COLOR=always"
+          echo "MISE_RUSTUP_HOME=$HOME/.local/share/mise/rustup"
+        } >> "$GITHUB_ENV"
 
     - name : Install mise tools
       uses : jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d

--- a/.github/actions/provision-cargo/action.yml
+++ b/.github/actions/provision-cargo/action.yml
@@ -1,10 +1,10 @@
 name        : Provision Cargo
-description : Install mise tools (provisioning the Rust toolchain `.mise/config.toml` pins) and restore the Swatinem Cargo cache for the given `shared-key`. Setting `cache` to `false` skips both the Swatinem step and mise's toolchain write-back, for cells that touch neither `target/` nor the registry.
+description : Install mise tools (provisioning the Rust toolchain `.mise/config.toml` pins) and restore the Swatinem Cargo cache for the given `shared-key`.
 
 inputs:
   cache:
     default     : true
-    description : When `false` the Swatinem Cargo cache step is skipped and the mise toolchain cache is not written back. Use for cells (*`Format`, `Unused`*) that populate neither `target/` nor `~/.cargo/registry/`.
+    description : When `false` the Swatinem Cargo cache step is skipped and the mise toolchain cache is not written back, for cells that populate neither `target/` nor `~/.cargo/registry/`.
 
   save:
     default     : true

--- a/.github/actions/provision-uv/action.yml
+++ b/.github/actions/provision-uv/action.yml
@@ -1,4 +1,4 @@
-name        : Provision uv with a warm wheel cache
+name        : Provision uv
 description : Install the uv binary and restore `~/.cache/uv` keyed off the PEP 723 scripts so subsequent `uv run --script` invocations skip the PyPI fetch. Callers that do not run scripts (*publish job downloading wheels*) may pass an empty `cache-dependency-glob` to skip the cache key.
 
 inputs:

--- a/.github/actions/restore-og-cache/action.yml
+++ b/.github/actions/restore-og-cache/action.yml
@@ -1,4 +1,4 @@
-name        : Restore the OG card cache with a rolling commit key
+name        : Restore OG cache
 description : Restore `.cache/og` under a rolling commit-keyed entry with a prefix fallback, so every run reuses the newest card store and saves its own forward.
 
 runs:

--- a/.github/actions/restore-wasm-cache/action.yml
+++ b/.github/actions/restore-wasm-cache/action.yml
@@ -1,0 +1,12 @@
+name        : Restore wasm cache
+description : Restore the `prose-wasm` Swatinem cache so the site build's `wasm-pack` step compiles the wasm module incrementally against a warm `target/`. `save-if` stays false, so the deploy path reuses the cache the `🛶 Wasm` row owns without writing its own variant.
+
+runs:
+  using: composite
+
+  steps:
+    - name : Restore the wasm build cache
+      uses : Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      with:
+        save-if    : 'false'
+        shared-key : prose-wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ permissions : { contents: read }
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - LICENSE
-      - site/**
+    paths:
+      - '**'
+      - '!**.md'
+      - '!LICENSE'
+      - '!site/**'
+      - site/.vitepress/tests/wasm/**
 
   workflow_dispatch:
 
@@ -29,17 +31,13 @@ jobs:
 
       matrix:
         include:
-          - cache      : false
-            command    : mise run check
+          - command    : mise run check
             name       : 🪶 Format
-          - cache      : false
-            command    : mise run lockfile
+          - command    : mise run lockfile
             name       : 🪵 Lockfile
-          - cache      : false
-            command    : ./.github/scripts/audit-parity.py
+          - command    : ./.github/scripts/audit-parity.py
             name       : 🪷 Parity
-          - cache      : false
-            command    : mise run audit
+          - command    : mise run audit
             name       : 🪓 Unused
           - command    : mise run lint rust
             name       : 📎 Clippy
@@ -50,7 +48,7 @@ jobs:
           - command    : mise run build wasm
             name       : 🛶 Wasm
             shared-key : prose-wasm
-          - bun        : true
+          - bun-lock   : site/bun.lock
             command    : mise run smoke
             name       : 🪃 Browser
             save       : false
@@ -67,14 +65,13 @@ jobs:
       - name : Provision Cargo
         uses : ./.github/actions/provision-cargo
         with:
-          cache      : ${{ matrix.cache }}
+          cache      : ${{ matrix.shared-key != '' }}
           save       : ${{ matrix.save }}
           shared-key : ${{ matrix.shared-key }}
 
       - name : Provision bun
-        if   : ${{ matrix.bun }}
         uses : ./.github/actions/provision-bun
-        with : { cache-dependency-glob: site/bun.lock }
+        with : { cache-dependency-glob: "${{ matrix.bun-lock }}" }
 
       - name : ${{ matrix.command }}
         run  : ${{ matrix.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ concurrency:
   cancel-in-progress : ${{ github.event_name == 'pull_request' }}
   group              : ${{ github.workflow }}-${{ github.head_ref || github.ref }}
 
-env:
-  CARGO_PROFILE_DEV_DEBUG : line-tables-only
-  CARGO_TERM_COLOR        : always
-
 jobs:
   check:
     name    : ${{ matrix.name }}
@@ -57,10 +53,8 @@ jobs:
           - bun        : true
             command    : mise run smoke
             name       : 🪃 Browser
-            shared-key : prose-smoke
-          - command    : mise run test rust
-            name       : ⚖️ Test
-            shared-key : prose-test
+            save       : false
+            shared-key : prose-wasm
           - command    : mise run upload rust
             name       : ☂️ Coverage
             shared-key : prose-coverage
@@ -74,6 +68,7 @@ jobs:
         uses : ./.github/actions/provision-cargo
         with:
           cache      : ${{ matrix.cache }}
+          save       : ${{ matrix.save }}
           shared-key : ${{ matrix.shared-key }}
 
       - name : Provision bun

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - .github/actions/provision-cargo/**
       - .github/actions/provision-uv/**
       - .github/actions/restore-og-cache/**
+      - .github/actions/restore-wasm-cache/**
       - .github/workflows/deploy.yml
       - .mise/tasks/**
       - .nvmrc
@@ -43,9 +44,6 @@ jobs:
             name    : 🪡 Typecheck
           - command : mise run lint site
             name    : 🧶 Lint
-          - binary  : true
-            command : mise run test site
-            name    : ⚖️ Test
           - binary  : true
             command : mise run upload site
             name    : ☂️ Coverage
@@ -89,6 +87,9 @@ jobs:
       - name : Provision Cargo
         uses : ./.github/actions/provision-cargo
         with : { save: false, shared-key: prose-build }
+
+      - name : Restore the wasm build cache
+        uses : ./.github/actions/restore-wasm-cache
 
       - *provision-bun
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
       - .github/actions/restore-og-cache/**
       - .github/actions/restore-wasm-cache/**
       - .github/workflows/deploy.yml
+      - .mise/lib/**
       - .mise/tasks/**
       - .nvmrc
       - crate/Cargo.toml
@@ -62,7 +63,7 @@ jobs:
       - name : Provision Cargo
         if   : ${{ matrix.binary }}
         uses : ./.github/actions/provision-cargo
-        with : { save: false, shared-key: prose-build }
+        with : &prose-build { save: false, shared-key: prose-build }
 
       - &provision-bun
         name : Provision bun
@@ -86,7 +87,7 @@ jobs:
 
       - name : Provision Cargo
         uses : ./.github/actions/provision-cargo
-        with : { save: false, shared-key: prose-build }
+        with : *prose-build
 
       - name : Restore the wasm build cache
         uses : ./.github/actions/restore-wasm-cache

--- a/.github/workflows/warm.yml
+++ b/.github/workflows/warm.yml
@@ -7,16 +7,16 @@ on:
     branches:
       - main
     paths:
-      - Cargo.toml
-      - crate/Cargo.toml
-      - Cargo.lock
-      - .mise/config.toml
-      - site/package.json
-      - site/bun.lock
       - .github/actions/provision-bun/**
       - .github/actions/provision-cargo/**
       - .github/scripts/platforms.toml
       - .github/workflows/warm.yml
+      - .mise/config.toml
+      - Cargo.lock
+      - Cargo.toml
+      - crate/Cargo.toml
+      - site/bun.lock
+      - site/package.json
 
   workflow_dispatch:
 
@@ -36,7 +36,8 @@ jobs:
         name : Check out repository
         uses : actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-      - name : Provision uv
+      - &provision-uv
+        name : Provision uv
         uses : ./.github/actions/provision-uv
 
       - name : Emit build matrix
@@ -57,7 +58,6 @@ jobs:
       matrix:
         include:
           - bun-lock   : site/bun.lock
-            cache      : false
             command    : mise run bake
             name       : 🥐 Bun
           - command    : mise run lint rust
@@ -84,7 +84,7 @@ jobs:
       - name : Provision Cargo
         uses : ./.github/actions/provision-cargo
         with:
-          cache      : ${{ matrix.cache }}
+          cache      : ${{ matrix.shared-key != '' }}
           save       : ${{ matrix.save }}
           shared-key : ${{ matrix.shared-key }}
 
@@ -124,8 +124,7 @@ jobs:
     steps:
       - *checkout
 
-      - name : Provision uv
-        uses : ./.github/actions/provision-uv
+      - *provision-uv
 
       - name : Summarize and gate
         env:

--- a/.github/workflows/warm.yml
+++ b/.github/workflows/warm.yml
@@ -72,10 +72,8 @@ jobs:
           - bun-lock   : site/bun.lock
             command    : mise run smoke
             name       : 🪃 Browser
-            shared-key : prose-smoke
-          - command    : mise run test rust
-            name       : ⚖️ Test
-            shared-key : prose-test
+            save       : false
+            shared-key : prose-wasm
           - command    : mise run upload rust
             name       : ☂️ Coverage
             shared-key : prose-coverage
@@ -87,6 +85,7 @@ jobs:
         uses : ./.github/actions/provision-cargo
         with:
           cache      : ${{ matrix.cache }}
+          save       : ${{ matrix.save }}
           shared-key : ${{ matrix.shared-key }}
 
       - name : Provision bun

--- a/.mise/lib/scope.bash
+++ b/.mise/lib/scope.bash
@@ -6,3 +6,8 @@ scope() {
     *)    echo "usage: mise $MISE_TASK_NAME [rust|site]" >&2; exit 2 ;;
   esac
 }
+
+split_workspace() {
+  "$@" --workspace --exclude prose_wasm --locked
+  "$@" --package prose_wasm --locked
+}

--- a/.mise/tasks/coverage
+++ b/.mise/tasks/coverage
@@ -3,6 +3,11 @@
 #MISE tools={"aqua:taiki-e/cargo-llvm-cov" = "0.8.7"}
 
 source "$MISE_PROJECT_ROOT/.mise/lib/scope.bash"
-rust() { rustup component add llvm-tools-preview && cargo llvm-cov --workspace --locked --lcov --output-path target/lcov.info; }
+rust() {
+  rustup component add llvm-tools-preview
+  cargo llvm-cov --no-report --workspace --exclude prose_wasm --locked
+  cargo llvm-cov --no-report --package prose_wasm --locked
+  cargo llvm-cov report --lcov --output-path target/lcov.info
+}
 site() { mise run test site --coverage; }
 scope "$@"

--- a/.mise/tasks/coverage
+++ b/.mise/tasks/coverage
@@ -4,9 +4,8 @@
 
 source "$MISE_PROJECT_ROOT/.mise/lib/scope.bash"
 rust() {
-  rustup component add llvm-tools-preview
-  cargo llvm-cov --no-report --workspace --exclude prose_wasm --locked
-  cargo llvm-cov --no-report --package prose_wasm --locked
+  cargo llvm-cov clean --workspace
+  split_workspace cargo llvm-cov --no-report
   cargo llvm-cov report --lcov --output-path target/lcov.info
 }
 site() { mise run test site --coverage; }

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -3,6 +3,6 @@
 #MISE wait_for=["bake"]
 
 source "$MISE_PROJECT_ROOT/.mise/lib/scope.bash"
-rust() { cargo test --workspace --exclude prose_wasm --locked && cargo test --package prose_wasm --locked; }
+rust() { split_workspace cargo test; }
 site() { mise run build bin && (cd site && bunx vitest run --project docs "$@"); }
 scope "$@"

--- a/.mise/tasks/upload
+++ b/.mise/tasks/upload
@@ -3,6 +3,7 @@
 #MISE tools={"pipx:codecov-cli" = "11.2.8"}
 
 source "$MISE_PROJECT_ROOT/.mise/lib/scope.bash"
-rust() { mise run coverage rust && codecovcli upload-process --flag rust --file target/lcov.info --sha "$SHA"; }
-site() { mise run coverage site && codecovcli upload-process --flag site --file site/coverage/lcov.info --sha "$SHA"; }
+rust()   { upload rust target/lcov.info; }
+site()   { upload site site/coverage/lcov.info; }
+upload() { mise run coverage "$1" && codecovcli upload-process --flag "$1" --file "$2" --sha "$SHA"; }
 scope "$@"


### PR DESCRIPTION
### 🪻 Quick Summary

Profiles the three workflows and the site build against live run data, then lands the cuts the numbers support. The headline find is that `🪻 Warm` and CI never derived the same cache keys, so every first run on a fresh branch compiled its Cargo caches cold despite Warm existing to prevent exactly that, and the fix is one shared env definition. The duplicate test executions collapse into the instrumented coverage runs, and the deploy path's wasm compile goes incremental against the cache the `🛶 Wasm` row already maintains.

---

### 🗞️ Key Changes

- Moves the `CARGO_` env into `provision-cargo`, so every caller derives identical Swatinem cache keys. Warm saved under env hash `12409740` while CI restored under `8fbc7208`, because the workflow-level env lived only in `ci.yml`, and a fresh branch's first run reported *"No cache found"* in all six cache-bearing jobs

- Drops the `⚖️ Test` rows from CI, Deploy, and Warm, whose 51s, 91s, and 65s re-ran suites their `☂️ Coverage` siblings already execute under instrumentation, leaving Coverage the sole test gate

- Rewrites the coverage task as a `cargo llvm-cov` merge, a clean followed by two `--no-report` runs and one merged lcov report, so it executes the same workspace-minus-wasm split the test task runs, both sourcing a shared `split_workspace` helper

- Opens that task with `cargo llvm-cov clean --workspace`, because `--no-report` disables the tool's default cleaning and stale profile data would otherwise merge into later reports, locally and through the `prose-coverage` cache

- Points `🪃 Browser` at the `prose-wasm` cache with `save: false`, retiring the parallel `prose-smoke` scope so the smoke build compiles incrementally from the artifacts the `🛶 Wasm` row saves

- Adds a `restore-wasm-cache` composite to the deploy job, warming the `wasm-pack` compile inside the 147s site build, whereas the OG card render already rides its rolling commit-keyed cache

- Derives the provision `cache` input from `shared-key` presence, deleting the hand-set per-row flags, and provisions bun through the `bun-lock` matrix key in CI to match Warm's mechanism

- Collapses the upload task's twin `codecovcli` invocations into one `upload()` helper, and anchors the twin read-only `prose-build` restores and Warm's twin uv provisions

- Re-includes `site/.vitepress/tests/wasm/**` in CI's triggers, which `site/**` had excluded, so a smoke-harness edit runs the `🪃 Browser` row that executes it, and adds `.mise/lib/**` to Deploy's paths since the shared task helpers sit in its call path

- Drops the coverage task's `rustup component add llvm-tools-preview` line, because `cargo-llvm-cov` installs the component itself in non-interactive environments

---

### ☕ Implementation Notes

#### The Measured Baseline

Per-job wall-clock from the most recent successful run of each workflow before this branch:

| Workflow | Jobs |
|---|---|
| `🪻 CI` | ☂️ Coverage 67s · 🪃 Browser 57s · ⚖️ Test 51s · 🪵 Lockfile 47s · 🛶 Wasm 46s · 🗜️ Build 44s · 📎 Clippy 36s · 🪷 Parity 28s · 🪓 Unused 24s · 🪶 Format 23s · 🗞️ Brief 7s |
| `🪻 Deploy` | 🪁 Deploy 147s · ☂️ Coverage 92s · ⚖️ Test 91s · 🪡 Typecheck 33s · 🧶 Lint 30s · 🧹 Cruft 30s · 🗞️ Brief 11s |
| `🪻 Warm` | 🔥 wheels 50s to 190s per platform · ⚖️ Test 65s · ☂️ Coverage 63s · 🗜️ Build 49s · 🪃 Browser 44s · 📎 Clippy 39s · 🥐 Bun 35s · 🗞️ Brief 6s |

The matrices run in parallel, so each workflow's critical path is its slowest row plus the serial `🗞️ Brief` gate, with Deploy adding its 147s deploy job after the checks settle. In the sampled logs every later run on an already-run branch hit its exact cache keys (*mise tools, rust-cache, bun deps, uv*), while a branch's first run found nothing.

The measurement spared one candidate, folding the four uncached cells (*Format, Lockfile, Parity, Unused*). Each pays roughly 20s of checkout and provisioning for a command that runs in a few seconds, but none sits on the critical path (*Coverage's 67s does*), so the fold buys no wall-clock.

---

### 🧵 Related Issues

- Closes #424
