### PR TITLE
[433] Finalize `0.8.1` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -8,7 +8,7 @@ name                   = "prose"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.8.0"
+version                = "0.8.1"
 
 [[bin]]
 name              = "prose"

--- a/site/primitives/source.md
+++ b/site/primitives/source.md
@@ -80,7 +80,7 @@ A downstream Rust crate consumes *Prose* the same way it consumes the `ruff_*` w
 
 ```toml
 [dependencies]
-prose = { git = "https://github.com/Jybbs/prose", tag = "0.8.0" }
+prose = { git = "https://github.com/Jybbs/prose", tag = "0.8.1" }
 ```
 
 The default `native` feature carries the command line, the cache, the language server, and the file walker. Depending with `default-features = false` drops that machinery, leaving the formatting core alone, which also builds for `wasm32-unknown-unknown`.

--- a/site/reference/output-formats.md
+++ b/site/reference/output-formats.md
@@ -125,7 +125,7 @@ A final record closes every `json` run, carrying run-wide rollup so a consumer r
   "diagnostics_total" : 12,
   "files_changed"     : 3,
   "files_visited"     : 47,
-  "prose_version"     : "0.8.0",
+  "prose_version"     : "0.8.1",
   "rules_fired"       : { "align-equals": 8, "alphabetize": 4 },
   "schema_version"    : 1
 }


### PR DESCRIPTION
### 🪻 Quick Summary

Ships the `miscased-constants` alias fix, the sandbox editor's height and editing-model work, and the CI wall-clock overhaul, bumping `crate/Cargo.toml` to `0.8.1` and regenerating `Cargo.lock` against the new version. The patch's issues file under the closed `0.8` milestone.

---

### 🗞️ Key Changes

- Bumps `crate/Cargo.toml` from `0.8.0` to `0.8.1` and regenerates `Cargo.lock` against the new version

- Refreshes the pinned dependency-tag and `prose_version` literals to `0.8.1`

---

### 🧵 Related Issues

- Closes #433
