### PR TITLE
[443] Finalize `0.8.2` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -8,7 +8,7 @@ name                   = "prose"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.8.1"
+version                = "0.8.2"
 
 [[bin]]
 name              = "prose"

--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import postcssGlobalData                          from '@csstools/postcss-global-data'
 import postcssCustomMedia                         from 'postcss-custom-media'
 import githubDark                                 from 'shiki/themes/github-dark.mjs'
-import { defineConfig }                           from 'vitepress'
+import { defineConfig, type PageData }            from 'vitepress'
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons'
 import { tabsMarkdownPlugin }                     from 'vitepress-plugin-tabs'
 
@@ -32,11 +32,13 @@ import { SECTIONS }                                   from './lib/shared/registr
 import { sectionRoute }                               from './lib/shared/routes'
 import { toTitleCase }                                from './lib/shared/title-case'
 import { TOOL_SEEDS }                                 from './lib/shared/tools'
-import { readCargoVersion }                           from './lib/shared/version'
+import * as version                                   from './lib/shared/version'
 
 const crate                = paths.crateDir(import.meta.url)
 const rulesDirectory       = paths.rulesDir(import.meta.url)
-const version              = readCargoVersion(crate)
+const proseVersion         = version.readCargoVersion(crate)
+const requiresPython       = version.readRequiresPython(crate)
+const ruffTag              = version.readRuffTag(crate)
 const ruleDiscovery        = discoverRules(rulesDirectory)
 const ruleIndex            = discoverRuleIndex(rulesDirectory)
 const discoveredRules      = ruleDiscovery.rules
@@ -47,6 +49,16 @@ const shikiDarkBg          = githubDark.colors?.['editor.background'] as string
 const themeColor           = PALETTE.ube
 
 assertCorpusIntegrity(ruleDiscovery, discoveredPrimitives)
+
+function injectSectionName(
+  pageData: PageData,
+  prefix: string,
+  resolve: (slug: string) => string | undefined
+): void {
+  const { relativePath } = pageData
+  if (!relativePath.startsWith(prefix) || relativePath.endsWith('index.md')) return
+  pageData.frontmatter.name ??= resolve(path.basename(relativePath, '.md'))
+}
 
 export default defineConfig({
   cacheDir      : paths.vitepressCacheDir(import.meta.url),
@@ -83,7 +95,7 @@ export default defineConfig({
     nav: [
       ...SECTIONS.map(({ label, slug }) =>
         ({ activeMatch: sectionRoute(slug), link: sectionRoute(slug), text: label })),
-      { link: `${constants.REPO_URL}/releases`, text: `v${version}` }
+      { link: `${constants.REPO_URL}/releases`, text: `v${proseVersion}` }
     ],
     outline   : { level: [2, 3] },
     search    : { provider: 'local' },
@@ -101,10 +113,13 @@ export default defineConfig({
     await buildOgCards(siteConfig.srcDir, siteConfig.pages, siteConfig.outDir)
   },
   transformHead({ pageData }) {
-    return pageHead(pageData, version)
+    return pageHead(pageData, proseVersion)
   },
   transformPageData(pageData) {
     pageData.frontmatter ||= {}
+    pageData.frontmatter.proseVersion   = proseVersion
+    pageData.frontmatter.requiresPython = requiresPython
+    pageData.frontmatter.ruffVersion    = ruffTag
     pageData.frontmatter.head ??= []
     pageData.frontmatter.head.push([
       'link',
@@ -113,13 +128,8 @@ export default defineConfig({
     if (!pageData.description && typeof pageData.frontmatter.caption === 'string') {
       pageData.description = pageData.frontmatter.caption
     }
-    if (pageData.relativePath.startsWith('rules/') && !pageData.relativePath.endsWith('index.md')) {
-      pageData.frontmatter.name ??= toTitleCase(path.basename(pageData.relativePath, '.md'), '-')
-    }
-    if (pageData.relativePath.startsWith('primitives/') && !pageData.relativePath.endsWith('index.md')) {
-      const slug = path.basename(pageData.relativePath, '.md')
-      pageData.frontmatter.name ??= primitiveIndex.get(slug)?.name
-    }
+    injectSectionName(pageData, 'rules/', slug => toTitleCase(slug, '-'))
+    injectSectionName(pageData, 'primitives/', slug => primitiveIndex.get(slug)?.name)
   },
   vite: {
     build: { chunkSizeWarningLimit: 5000 },
@@ -136,7 +146,8 @@ export default defineConfig({
     plugins: [{
       load      : id => id === '\0virtual:prose-palette.css' ? paletteCss() : undefined,
       name      : 'prose-palette',
-      resolveId : id => id === 'virtual:prose-palette.css' ? '\0virtual:prose-palette.css' : undefined
+      resolveId : id =>
+        id === 'virtual:prose-palette.css' ? '\0virtual:prose-palette.css' : undefined
     }, serveWasmPlugin(path.join(paths.siteDir(import.meta.url), 'public')), groupIconVitePlugin({
       customIcon: {
         ...Object.fromEntries(Object.entries(TOOL_SEEDS).map(([slug, { icon }]) => [slug, icon])),

--- a/site/.vitepress/lib/fixtures/walker.ts
+++ b/site/.vitepress/lib/fixtures/walker.ts
@@ -1,9 +1,8 @@
 import fs   from 'node:fs'
 import path from 'node:path'
 
-import { parse } from 'smol-toml'
-
 import { fixturesDirFrom } from '../shared/paths'
+import { parseToml }       from '../shared/toml'
 import * as lintFindings   from './lint-findings'
 
 const INPUT_FILE    = 'input.py'
@@ -47,7 +46,7 @@ export function fixtureWatchGlobs(crateDir: string): string[] {
 export function readFixtureDocs(inputPath: string): FixtureDocs | undefined {
   const metaPath = path.join(path.dirname(inputPath), META_FILE)
   if (!fs.existsSync(metaPath)) return undefined
-  return (parse(fs.readFileSync(metaPath, 'utf8')) as { docs?: FixtureDocs }).docs
+  return (parseToml(metaPath) as { docs?: FixtureDocs }).docs
 }
 
 export function snapshotPath(inputPath: string): string {

--- a/site/.vitepress/lib/landing/landing.data.ts
+++ b/site/.vitepress/lib/landing/landing.data.ts
@@ -2,6 +2,7 @@ import { defineLoader } from 'vitepress'
 
 import { inlineNodes, type InlineNode }  from '../markdown/inline-nodes'
 import * as renderer                     from '../markdown/renderer'
+import { PYPI_PACKAGE }                  from '../shared/constants'
 import { formatFolio }                   from '../shared/numerals'
 import { FAMILY_ORDER, type RuleFamily } from '../shared/registries'
 
@@ -53,7 +54,7 @@ type StepSource = Omit<Step, 'bodyNodes' | 'codeHtml'> & { body: string; code: s
 const STEP_SOURCES: readonly StepSource[] = [
   {
     body     : 'Fetch the wheel and expose the `prose` binary.',
-    code     : 'uv tool install prose-formatter',
+    code     : `uv tool install ${PYPI_PACKAGE}`,
     language : 'bash',
     number   : '01',
     title    : 'Install'

--- a/site/.vitepress/lib/landing/pypi-releases.data.ts
+++ b/site/.vitepress/lib/landing/pypi-releases.data.ts
@@ -1,6 +1,7 @@
 import { defineLoader } from 'vitepress'
 
 import { conditionalFetch } from '../shared/conditional-fetch'
+import { PYPI_PACKAGE }     from '../shared/constants'
 import { fetchCacheDir }    from '../shared/paths'
 
 export interface PyPIRelease {
@@ -24,12 +25,11 @@ interface PyPIPayload {
   releases : Record<string, readonly PyPIReleaseFile[]>
 }
 
-const PACKAGE   = 'prose-formatter'
-const ENDPOINT  = `https://pypi.org/pypi/${PACKAGE}/json`
+const ENDPOINT  = `https://pypi.org/pypi/${PYPI_PACKAGE}/json`
 const MONTH_FMT = new Intl.DateTimeFormat('en', { month: 'short', timeZone: 'UTC' })
 
 function projectUrl(version: string): string {
-  return `https://pypi.org/project/${PACKAGE}/${version}/`
+  return `https://pypi.org/project/${PYPI_PACKAGE}/${version}/`
 }
 
 function render(version: string, date: string): PyPIRelease {
@@ -46,7 +46,7 @@ function render(version: string, date: string): PyPIRelease {
 }
 
 const FALLBACK: readonly PyPIRelease[] = (
-  [['0.2.0', '2026-04-09'], ['0.1.0', '2026-01-14']] as const
+  [['0.8.1', '2026-07-16'], ['0.8.0', '2026-07-13']] as const
 ).map(([version, date]) => render(version, date))
 
 function compareDesc(a: PyPIRelease, b: PyPIRelease): number {

--- a/site/.vitepress/lib/shared/constants.ts
+++ b/site/.vitepress/lib/shared/constants.ts
@@ -1,4 +1,5 @@
 export const BODY_LINK_CLASSES = 'body-link underline-draw'
+export const PYPI_PACKAGE      = 'prose-formatter'
 export const REPO_SLUG         = 'Jybbs/prose'
 export const REPO_URL          = `https://github.com/${REPO_SLUG}`
 export const SHIKI_THEMES      = { dark: 'github-dark', light: 'github-light' } as const

--- a/site/.vitepress/lib/shared/toml.ts
+++ b/site/.vitepress/lib/shared/toml.ts
@@ -1,0 +1,7 @@
+import fs from 'node:fs'
+
+import { parse } from 'smol-toml'
+
+export function parseToml(manifestPath: string): unknown {
+  return parse(fs.readFileSync(manifestPath, 'utf8'))
+}

--- a/site/.vitepress/lib/shared/version.ts
+++ b/site/.vitepress/lib/shared/version.ts
@@ -1,12 +1,31 @@
-import fs   from 'node:fs'
 import path from 'node:path'
 
-import { parse } from 'smol-toml'
-
 import { requireString } from './require-string'
+import { parseToml }     from './toml'
 
 export function readCargoVersion(crateDir: string): string {
   const cargoPath = path.join(crateDir, 'Cargo.toml')
-  const parsed    = parse(fs.readFileSync(cargoPath, 'utf8')) as { package?: { version?: unknown } }
+  const parsed    = parseToml(cargoPath) as { package?: { version?: unknown } }
   return requireString(parsed.package?.version, `Could not find package.version in ${cargoPath}`)
+}
+
+export function readRequiresPython(crateDir: string): string {
+  const projectPath = path.join(crateDir, 'pyproject.toml')
+  const parsed      = parseToml(projectPath) as { project?: { 'requires-python'?: unknown } }
+  const bound       = requireString(
+    parsed.project?.['requires-python'],
+    `Could not find project.requires-python in ${projectPath}`
+  )
+  return bound.replace(/^>=/, '')
+}
+
+export function readRuffTag(crateDir: string): string {
+  const cargoPath = path.join(crateDir, 'Cargo.toml')
+  const parsed    = parseToml(cargoPath) as {
+    dependencies?: { ruff_python_ast?: { tag?: unknown } }
+  }
+  return requireString(
+    parsed.dependencies?.ruff_python_ast?.tag,
+    `Could not find dependencies.ruff_python_ast.tag in ${cargoPath}`
+  )
 }

--- a/site/.vitepress/tests/shared/fixtures/cargo-no-ruff-tag/Cargo.toml
+++ b/site/.vitepress/tests/shared/fixtures/cargo-no-ruff-tag/Cargo.toml
@@ -1,0 +1,2 @@
+[package]
+name = "no-ruff-tag"

--- a/site/.vitepress/tests/shared/fixtures/pyproject-no-floor/pyproject.toml
+++ b/site/.vitepress/tests/shared/fixtures/pyproject-no-floor/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+name = "no-floor"

--- a/site/.vitepress/tests/shared/fixtures/pyproject-no-floor/pyproject.toml
+++ b/site/.vitepress/tests/shared/fixtures/pyproject-no-floor/pyproject.toml
@@ -1,2 +1,3 @@
 [project]
-name = "no-floor"
+dynamic = ["version"]
+name    = "no-floor"

--- a/site/.vitepress/tests/shared/version.test.ts
+++ b/site/.vitepress/tests/shared/version.test.ts
@@ -1,14 +1,38 @@
-import { crateDir }         from '../../lib/shared/paths'
-import { readCargoVersion } from '../../lib/shared/version'
-import { fixtureDir }       from '../support'
+import { crateDir }   from '../../lib/shared/paths'
+import * as version   from '../../lib/shared/version'
+import { fixtureDir } from '../support'
+
+const crate = crateDir(import.meta.url)
 
 describe('readCargoVersion', () => {
   it('reads the crate version from Cargo.toml', () => {
-    expect(readCargoVersion(crateDir(import.meta.url))).toMatch(/^\d+\.\d+\.\d+/)
+    expect(version.readCargoVersion(crate)).toMatch(/^\d+\.\d+\.\d+/)
   })
 
   it('throws when the manifest carries no package version', () => {
     const dir = fixtureDir(import.meta.dirname, 'cargo-no-version')
-    expect(() => readCargoVersion(dir)).toThrow(/package\.version/)
+    expect(() => version.readCargoVersion(dir)).toThrow(/package\.version/)
+  })
+})
+
+describe('readRequiresPython', () => {
+  it('reads the floor from pyproject.toml with the bound stripped', () => {
+    expect(version.readRequiresPython(crate)).toMatch(/^\d+\.\d+$/)
+  })
+
+  it('throws when the project table carries no requires-python', () => {
+    const dir = fixtureDir(import.meta.dirname, 'pyproject-no-floor')
+    expect(() => version.readRequiresPython(dir)).toThrow(/requires-python/)
+  })
+})
+
+describe('readRuffTag', () => {
+  it('reads the ruff dependency tag from Cargo.toml', () => {
+    expect(version.readRuffTag(crate)).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+
+  it('throws when the manifest carries no ruff tag', () => {
+    const dir = fixtureDir(import.meta.dirname, 'cargo-no-ruff-tag')
+    expect(() => version.readRuffTag(dir)).toThrow(/ruff_python_ast\.tag/)
   })
 })

--- a/site/integrations/pre-commit.md
+++ b/site/integrations/pre-commit.md
@@ -43,9 +43,9 @@ The [**Ruff**](/integrations/ruff) integration page covers the `extend-ignore` c
 
 The [**`pre-commit`-managed Ruff hook**](https://github.com/astral-sh/ruff-pre-commit) handles the Ruff side without requiring a system install. Add this block above the `repo: local` from the Local Hook section:
 
-```yaml
+```yaml-vue
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.10
+  rev: v{{ $frontmatter.ruffVersion }}
   hooks:
     - id: ruff-format
 ```

--- a/site/primitives/source.md
+++ b/site/primitives/source.md
@@ -78,9 +78,9 @@ A consumer that wants the full rule loop instead builds a [[pipeline]] from a `C
 
 A downstream Rust crate consumes *Prose* the same way it consumes the `ruff_*` workspace, through a Git dependency pinned to a release tag:
 
-```toml
+```toml-vue
 [dependencies]
-prose = { git = "https://github.com/Jybbs/prose", tag = "0.8.1" }
+prose = { git = "https://github.com/Jybbs/prose", tag = "{{ $frontmatter.proseVersion }}" }
 ```
 
 The default `native` feature carries the command line, the cache, the language server, and the file walker. Depending with `default-features = false` drops that machinery, leaving the formatting core alone, which also builds for `wasm32-unknown-unknown`.

--- a/site/reference/output-formats.md
+++ b/site/reference/output-formats.md
@@ -119,13 +119,13 @@ The [**Editor**](/integrations/editor) integration page covers wiring this forma
 
 A final record closes every `json` run, carrying run-wide rollup so a consumer reads file and rule counts without re-aggregating the per-diagnostic stream. It emits even when the run surfaces zero diagnostics, where every count lands at zero and the envelope is the stream's only line.
 
-```json
+```json-vue
 {
   "kind"              : "summary",
   "diagnostics_total" : 12,
   "files_changed"     : 3,
   "files_visited"     : 47,
-  "prose_version"     : "0.8.1",
+  "prose_version"     : "{{ $frontmatter.proseVersion }}",
   "rules_fired"       : { "align-equals": 8, "alphabetize": 4 },
   "schema_version"    : 1
 }

--- a/site/usage/installation.md
+++ b/site/usage/installation.md
@@ -30,11 +30,11 @@ Pre-built wheels cover the following targets:
 | `aarch64-apple-darwin` | macOS Apple Silicon |
 | `x86_64-pc-windows-msvc` | Windows x86_64 |
 
-A source distribution rides alongside the wheels for any target outside this matrix *(musl-based Linux distros, FreeBSD, 32-bit architectures)*. Installing the sdist requires a Rust toolchain on the install host, because the installer builds the binary from source rather than fetching a pre-built artifact.
+A source distribution ships alongside the wheels for any target outside this matrix *(musl-based Linux distros, FreeBSD, 32-bit architectures)*. Installing the sdist requires a Rust toolchain on the install host, because the installer builds the binary from source rather than fetching a pre-built artifact.
 
 ## Python Compatibility
 
-The install path needs Python **3.10 or newer**, which is the lower bound declared in the wheel's `requires-python` metadata. The Python interpreter is used only by the installer *(uv, pip, pipx)* to land the binary on `PATH`, and the running formatter doesn't load it on the hot path. For the runtime version a project's source itself targets *(read by [[legacy-union-syntax]] and [[unused-future-annotations]] when judging safety)*, see the `target-version` field in the [**Configuration**](/reference/configuration) reference.
+The install path needs Python **{{ $frontmatter.requiresPython }} or newer**, which is the lower bound declared in the wheel's `requires-python` metadata. The Python interpreter is used only by the installer *(uv, pip, pipx)* to land the binary on `PATH`, and the running formatter doesn't load it on the hot path. For the runtime version a project's source itself targets *(read by [[legacy-union-syntax]] and [[unused-future-annotations]] when judging safety)*, see the `target-version` field in the [**Configuration**](/reference/configuration) reference.
 
 ## Next Steps
 


### PR DESCRIPTION
### 🪻 Quick Summary

Ships the `alphabetize` positional-constructor pinning, the `sort-dict-keys` facet, the widened `unsorted-positionals` lint, and the dependency modernization that clears the `serde_with` advisory, bumping `crate/Cargo.toml` to `0.8.2` and regenerating `Cargo.lock` against the new version. The patch's issues file under the closed `0.8` milestone.

---

### 🗞️ Key Changes

- Bumps `crate/Cargo.toml` from `0.8.1` to `0.8.2` and regenerates `Cargo.lock` against the new version

- Derives the docs-site version literals from the crate manifests, wherein `transformPageData` injects `proseVersion`, `requiresPython`, and `ruffVersion` and `-vue` fences interpolate them, so a release bumps `crate/Cargo.toml` alone from here on

- Adds `readRequiresPython` and `readRuffTag` beside `readCargoVersion` in `site/.vitepress/lib/shared/version.ts`, each pinned with happy and throw paths, with a shared `parseToml` folding the fixture walker's duplicate read

- Retires the pre-commit page's hand-pinned ruff rev, twelve patches stale against the tag the crate compiles against, in favor of the derived `ruffVersion`

- Canonicalizes `PYPI_PACKAGE` in the shared constants and refreshes the PyPI fetch fallback to the `0.8` line's releases

---

### 🧵 Related Issues

- Closes #443