### PR TITLE
[501] Finalize `0.8.3` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -8,7 +8,7 @@ name                   = "prose"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.8.2"
+version                = "0.8.3"
 
 [[bin]]
 name              = "prose"

--- a/site/.vitepress/lib/landing/pypi-releases.data.ts
+++ b/site/.vitepress/lib/landing/pypi-releases.data.ts
@@ -1,8 +1,9 @@
 import { defineLoader } from 'vitepress'
 
-import { conditionalFetch } from '../shared/conditional-fetch'
-import { PYPI_PACKAGE }     from '../shared/constants'
-import { fetchCacheDir }    from '../shared/paths'
+import { conditionalFetch }        from '../shared/conditional-fetch'
+import { PYPI_PACKAGE }            from '../shared/constants'
+import { crateDir, fetchCacheDir } from '../shared/paths'
+import { readCargoVersion }        from '../shared/version'
 
 export interface PyPIRelease {
   date      : string
@@ -25,6 +26,7 @@ interface PyPIPayload {
   releases : Record<string, readonly PyPIReleaseFile[]>
 }
 
+const CRATE     = crateDir(import.meta.url)
 const ENDPOINT  = `https://pypi.org/pypi/${PYPI_PACKAGE}/json`
 const MONTH_FMT = new Intl.DateTimeFormat('en', { month: 'short', timeZone: 'UTC' })
 
@@ -34,20 +36,18 @@ function projectUrl(version: string): string {
 
 function render(version: string, date: string): PyPIRelease {
   const d     = new Date(date)
-  const month = Number.isNaN(d.getTime()) ? '—' : MONTH_FMT.format(d).toUpperCase()
+  const dated = !Number.isNaN(d.getTime())
   return {
     date,
-    month,
+    month     : dated ? MONTH_FMT.format(d).toUpperCase() : '—',
     url       : projectUrl(version),
     version,
-    year      : date.slice(0, 4),
-    yearShort : date.slice(2, 4)
+    year      : dated ? date.slice(0, 4) : '—',
+    yearShort : dated ? date.slice(2, 4) : '—'
   }
 }
 
-const FALLBACK: readonly PyPIRelease[] = (
-  [['0.8.1', '2026-07-16'], ['0.8.0', '2026-07-13']] as const
-).map(([version, date]) => render(version, date))
+const FALLBACK: readonly PyPIRelease[] = [render(readCargoVersion(CRATE), '')]
 
 function compareDesc(a: PyPIRelease, b: PyPIRelease): number {
   return b.date.localeCompare(a.date)

--- a/site/.vitepress/lib/shared/conditional-fetch.ts
+++ b/site/.vitepress/lib/shared/conditional-fetch.ts
@@ -81,7 +81,7 @@ function settle<T>(
   stored : FetchStore<T> | null,
   reason : string
 ): T {
-  const note = stored ? 'keeping the last-good payload' : 'seeding the static fallback'
+  const note = stored ? 'keeping the last-good payload' : 'seeding the fallback'
   console.warn(`[data:${source.key}] ${reason}, ${note}`)
   return stored ? stored.payload : source.fallback
 }

--- a/site/.vitepress/lib/shared/paths.ts
+++ b/site/.vitepress/lib/shared/paths.ts
@@ -3,16 +3,6 @@ import fs                from 'node:fs'
 import path              from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-export function repoRoot(metaUrl: string): string {
-  let dir = path.dirname(fileURLToPath(metaUrl))
-  while (!fs.existsSync(path.join(dir, '.mise', 'config.toml'))) {
-    const parent = path.dirname(dir)
-    if (parent === dir) throw new Error(`repo root not found from ${metaUrl}`)
-    dir = parent
-  }
-  return dir
-}
-
 export function cacheDirFrom(root: string, name: string): string {
   return path.join(root, '.cache', name)
 }
@@ -43,6 +33,16 @@ export function primitivesDir(metaUrl: string): string {
 
 export function proseBinaryPath(root: string): string {
   return path.join(root, 'target', 'debug', 'prose')
+}
+
+export function repoRoot(metaUrl: string): string {
+  let dir = path.dirname(fileURLToPath(metaUrl))
+  while (!fs.existsSync(path.join(dir, '.git'))) {
+    const parent = path.dirname(dir)
+    if (parent === dir) throw new Error(`repo root not found from ${metaUrl}`)
+    dir = parent
+  }
+  return dir
 }
 
 export function rulesDir(metaUrl: string): string {

--- a/site/.vitepress/tests/shared/conditional-fetch.test.ts
+++ b/site/.vitepress/tests/shared/conditional-fetch.test.ts
@@ -88,14 +88,14 @@ describe('conditionalFetch', () => {
     vi.stubGlobal('fetch', fetchMock)
     await expect(conditionalFetch(makeSource())).resolves.toBe('fallback')
     expect(fetchMock).toHaveBeenCalledTimes(3)
-    expect(warn).toHaveBeenCalledWith('[data:probe] upstream returned 500, seeding the static fallback')
+    expect(warn).toHaveBeenCalledWith('[data:probe] upstream returned 500, seeding the fallback')
   })
 
   warnTest('falls back when a 200 payload rejects at parse', async ({ warn }) => {
     vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockResolvedValue(new Response('{}', { status: 200 })))
     const source = { ...makeSource(), parse: () => { throw new Error('no value field') } }
     await expect(conditionalFetch(source)).resolves.toBe('fallback')
-    expect(warn).toHaveBeenCalledWith('[data:probe] payload rejected (no value field), seeding the static fallback')
+    expect(warn).toHaveBeenCalledWith('[data:probe] payload rejected (no value field), seeding the fallback')
   })
 
   it('returns the stored payload offline without a request', async () => {

--- a/site/.vitepress/tests/shared/paths.test.ts
+++ b/site/.vitepress/tests/shared/paths.test.ts
@@ -1,16 +1,35 @@
-import fs   from 'node:fs'
-import path from 'node:path'
+import fs                from 'node:fs'
+import os                from 'node:os'
+import path              from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import * as paths from '../../lib/shared/paths'
 
 const meta = import.meta.url
 
 describe('repoRoot', () => {
-  it('walks up to the directory holding .mise/config.toml', () => {
-    expect(fs.existsSync(path.join(paths.repoRoot(meta), '.mise', 'config.toml'))).toBe(true)
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'prose-root-'))
   })
 
-  it('throws when no .mise/config.toml ancestor exists', () => {
+  afterEach(() => {
+    fs.rmSync(dir, { force: true, recursive: true })
+  })
+
+  it('walks up to the directory holding .git', () => {
+    expect(fs.existsSync(path.join(paths.repoRoot(meta), '.git'))).toBe(true)
+  })
+
+  it('stops at the nearest ancestor carrying .git', () => {
+    fs.writeFileSync(path.join(dir, '.git'), '')
+    const nested = path.join(dir, 'a', 'b')
+    fs.mkdirSync(nested, { recursive: true })
+    expect(paths.repoRoot(pathToFileURL(path.join(nested, 'probe.ts')).href)).toBe(dir)
+  })
+
+  it('throws when no .git ancestor exists', () => {
     expect(() => paths.repoRoot('file:///')).toThrow(/repo root not found/)
   })
 })


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes the patch closing the `0.8` line's correctness wave, carrying the pipeline reordering, the aligner's budget arithmetic, the docstring-wrap and `band-constants` corrections, and the `call-layout` fixes that a sweep over roughly a thousand real Python modules surfaced. Bumps `crate/Cargo.toml` from `0.8.2` to `0.8.3` and regenerates `Cargo.lock` against the new version. The patch's issues file under the closed `0.8` milestone.

---

### 🗞️ Key Changes

- Bumps `crate/Cargo.toml` from `0.8.2` to `0.8.3` and regenerates `Cargo.lock` against the new version

- Derives the landing page's cold-start release seed in `site/.vitepress/lib/landing/pypi-releases.data.ts` from `readCargoVersion`, retiring the two hand-written release literals a bump left stale each cycle

- Degrades an undated release entry's year and month to the placeholder its month already carried, since the derived seed names a version without an upload date

- Locates the repository root in `site/.vitepress/lib/shared/paths.ts` by walking to `.git` rather than to a `.mise/config.toml` sentinel, and pins the walk with a case asserting it stops at the nearest ancestor carrying one

- Sorts `repoRoot` into alphabetical position among that module's exports, leaving the private `resolveProseBinary` beside its sole caller

- Drops `static` from the degraded-path warning in `site/.vitepress/lib/shared/conditional-fetch.ts`, which one of its two callers now derives rather than declares

---

### 🧵 Related Issues

- Closes #501