### PR TITLE
[557] Finalize `0.9.0` release

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -67,7 +67,7 @@ jobs:
         run  : mise run gha:plan corpus
 
   bake:
-    name            : 🧱 Bake
+    name            : 🥧 Bake
     if              : &push ${{ github.event_name != 'pull_request' }}
     permissions     : &prune-caches { actions: write, contents: read }
     runs-on         : *ubuntu

--- a/.mise/tasks/repo/ci
+++ b/.mise/tasks/repo/ci
@@ -6,6 +6,7 @@
 #MISE   "rust:check",
 #MISE   "rust:cruft",
 #MISE   "rust:lint",
+#MISE   "rust:test",
 #MISE   "rust:unused",
 #MISE   "site:cruft",
 #MISE   "site:links",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "prose"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream",

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -8,7 +8,7 @@ name                   = "prose"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.8.3"
+version                = "0.9.0"
 
 [package.metadata.ruff]
 release = "0.15.22"


### PR DESCRIPTION
### 🪻 Quick Summary

Finalizes a release that widens the rule catalog into the surfaces the formatter had left alone, covering comment shape, chain and string layout, comparison and literal spelling, and import statement form, with every rule outside the lint family moving onto a verb-noun slug shape and no alias standing behind a retired name.

The version moves to `0.9.0`, and the PyPI development-status classifier holds at `4 - Beta` rather than advancing, the retired slugs leaving the public taxonomy still in motion.

---

### 🗞️ Key Changes

- Bumps `crate/Cargo.toml` from `0.8.3` to `0.9.0` and regenerates `Cargo.lock` against the new version

- Adds `rust:test` to the `ci` task's depends list, so the local sweep runs the Rust test suite it had never covered, leaving runner behavior unchanged because `.github/workflows/ci.yml` already runs that task as its own matrix row

---

### 🧵 Related Issues

- Closes #557
