### PR TITLE
[598] Gate the `imports` sweep's flaky bucket so a break cannot leave through it

### DIFF
--- a/crate/tests/imports/baseline.json
+++ b/crate/tests/imports/baseline.json
@@ -31,6 +31,7 @@
     "default": {
       "candidates": 997,
       "comparable": 898,
+      "flaky": 2,
       "raises": 0,
       "rebinds": 3,
       "refused": 0
@@ -436,5 +437,5 @@
       }
     }
   },
-  "version": 6
+  "version": 7
 }

--- a/crate/tests/imports/compare.rs
+++ b/crate/tests/imports/compare.rs
@@ -110,27 +110,15 @@ pub(crate) fn divergence(formatted: &Outcome, original: &Outcome) -> Option<Dive
             reason: formatted.error.clone(),
         });
     }
-    let lost: Vec<_> = missing(&original.names, &formatted.names)
-        .cloned()
-        .collect();
-    if let [name, rest @ ..] = lost.as_slice() {
-        let reason = format!("leaves {} unbound", named(name, rest.len()));
-        return Some(Divergence {
-            kind: "unbound",
-            names: lost,
-            reason,
-        });
+    if let Some(lost) = sided(&original.names, &formatted.names, "unbound", |whom| {
+        format!("leaves {whom} unbound")
+    }) {
+        return Some(lost);
     }
-    let gained: Vec<_> = missing(&formatted.names, &original.names)
-        .cloned()
-        .collect();
-    if let [name, rest @ ..] = gained.as_slice() {
-        let reason = format!("binds {} the original does not", named(name, rest.len()));
-        return Some(Divergence {
-            kind: "extra",
-            names: gained,
-            reason,
-        });
+    if let Some(gained) = sided(&formatted.names, &original.names, "extra", |whom| {
+        format!("binds {whom} the original does not")
+    }) {
+        return Some(gained);
     }
     let differing = respelt(original, formatted).min()?;
     let was = original
@@ -190,4 +178,25 @@ fn respelt<'a>(one: &'a Outcome, other: &'a Outcome) -> impl Iterator<Item = &'a
         .keys()
         .chain(other.constants.keys())
         .filter(move |name| one.constants.get(*name) != other.constants.get(*name))
+}
+
+/// The divergence one direction of a name difference makes, `None` where
+/// `held` carries every name `from` binds. `reason` takes the first name
+/// beside however many followed it.
+fn sided(
+    from: &[String],
+    held: &[String],
+    kind: &'static str,
+    reason: impl Fn(&str) -> String,
+) -> Option<Divergence> {
+    let names: Vec<_> = missing(from, held).cloned().collect();
+    let [first, rest @ ..] = names.as_slice() else {
+        return None;
+    };
+    let reason = reason(&named(first, rest.len()));
+    Some(Divergence {
+        kind,
+        names,
+        reason,
+    })
 }

--- a/crate/tests/imports/compare.rs
+++ b/crate/tests/imports/compare.rs
@@ -1,7 +1,7 @@
 //! Comparing what two trees left behind, meaning why one module's run counts
 //! as broken beside the original, and which modules of a sweep broke at all.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
     outcome::{Kind, Outcome},
@@ -110,13 +110,9 @@ pub(crate) fn divergence(formatted: &Outcome, original: &Outcome) -> Option<Dive
             reason: formatted.error.clone(),
         });
     }
-    let missing = |from: &[String], held: &[String]| -> Vec<String> {
-        from.iter()
-            .filter(|name| held.binary_search(name).is_err())
-            .cloned()
-            .collect()
-    };
-    let lost = missing(&original.names, &formatted.names);
+    let lost: Vec<_> = missing(&original.names, &formatted.names)
+        .cloned()
+        .collect();
     if let [name, rest @ ..] = lost.as_slice() {
         let reason = format!("leaves {} unbound", named(name, rest.len()));
         return Some(Divergence {
@@ -125,7 +121,9 @@ pub(crate) fn divergence(formatted: &Outcome, original: &Outcome) -> Option<Dive
             reason,
         });
     }
-    let gained = missing(&formatted.names, &original.names);
+    let gained: Vec<_> = missing(&formatted.names, &original.names)
+        .cloned()
+        .collect();
     if let [name, rest @ ..] = gained.as_slice() {
         let reason = format!("binds {} the original does not", named(name, rest.len()));
         return Some(Divergence {
@@ -134,12 +132,7 @@ pub(crate) fn divergence(formatted: &Outcome, original: &Outcome) -> Option<Dive
             reason,
         });
     }
-    let differing = original
-        .constants
-        .keys()
-        .chain(formatted.constants.keys())
-        .filter(|name| original.constants.get(*name) != formatted.constants.get(*name))
-        .min()?;
+    let differing = respelt(original, formatted).min()?;
     let was = original
         .constants
         .get(differing)
@@ -155,6 +148,31 @@ pub(crate) fn divergence(formatted: &Outcome, original: &Outcome) -> Option<Dive
     })
 }
 
+/// Every name two runs of one tree bound differently, covering a name only
+/// one side bound and a constant the two spelt differently. [`divergence`]
+/// stops at the first of these it finds, where this returns every one.
+pub(crate) fn varying(one: &Outcome, other: &Outcome) -> BTreeSet<String> {
+    missing(&one.names, &other.names)
+        .chain(missing(&other.names, &one.names))
+        .chain(respelt(one, other))
+        .cloned()
+        .collect()
+}
+
+/// The kind a run of one module left behind, `unmeasured` where the tree was
+/// never asked about it.
+fn kind(held: &BTreeMap<String, Outcome>, module: &str) -> Kind {
+    held.get(module)
+        .map_or(Kind::Unmeasured, |outcome| outcome.kind)
+}
+
+/// The names of `from` that `held` does not carry. Both slices arrive
+/// sorted, which is what lets the lookup bisect `held`.
+fn missing<'a>(from: &'a [String], held: &'a [String]) -> impl Iterator<Item = &'a String> {
+    from.iter()
+        .filter(move |name| held.binary_search(name).is_err())
+}
+
 /// One name and however many followed it, which is the sentence a report
 /// shows rather than the key a baseline holds.
 fn named(first: &str, rest: usize) -> String {
@@ -165,9 +183,11 @@ fn named(first: &str, rest: usize) -> String {
     }
 }
 
-/// The kind a run of one module left behind, `unmeasured` where the tree was
-/// never asked about it.
-fn kind(held: &BTreeMap<String, Outcome>, module: &str) -> Kind {
-    held.get(module)
-        .map_or(Kind::Unmeasured, |outcome| outcome.kind)
+/// The names under which two runs spelt a plain constant differently. A
+/// name both runs carry arrives twice.
+fn respelt<'a>(one: &'a Outcome, other: &'a Outcome) -> impl Iterator<Item = &'a String> {
+    one.constants
+        .keys()
+        .chain(other.constants.keys())
+        .filter(move |name| one.constants.get(*name) != other.constants.get(*name))
 }

--- a/crate/tests/imports/outcome.rs
+++ b/crate/tests/imports/outcome.rs
@@ -2,7 +2,10 @@
 //! the tagged rows the probe writes, the names a comparison drops, and what
 //! a run amounted to.
 
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+};
 
 /// The names the formatter reorders by design, whose value a comparison
 /// therefore leaves out.
@@ -119,6 +122,15 @@ impl Outcome {
         read.loaded.dedup();
         read.names.sort();
         read
+    }
+
+    /// This run with `names` left out of both the names it bound and the
+    /// constants among them.
+    pub(crate) fn without(&self, names: &BTreeSet<String>) -> Self {
+        let mut kept = self.clone();
+        kept.constants.retain(|name, _| !names.contains(name));
+        kept.names.retain(|name| !names.contains(name));
+        kept
     }
 }
 

--- a/crate/tests/imports/ratchet.rs
+++ b/crate/tests/imports/ratchet.rs
@@ -17,6 +17,10 @@ use crate::{
     records::{Blocked, Break, Width},
 };
 
+/// The exception a module raises where the machine lacks a package or a
+/// platform module it imports.
+const ABSENT: &str = "ModuleNotFoundError";
+
 /// The break set the repository tracks beside the harness, which every
 /// judging run reads.
 const BAKED: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/imports/baseline.json");
@@ -24,13 +28,9 @@ const BAKED: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/imports/baseline
 /// The environment variable naming a file the break set is written to.
 const BAKE_VAR: &str = "PROSE_IMPORTS_BAKE";
 
-/// The exception a module raises where the machine lacks a package or a
-/// platform module it imports.
-const ABSENT: &str = "ModuleNotFoundError";
-
 /// The generation a baked set is written and read at, raised by every
 /// change to what a set carries or to the key that holds one break.
-pub(crate) const VERSION: u32 = 6;
+pub(crate) const VERSION: u32 = 7;
 
 /// What one run recorded for a later run to ratchet against, the breaks
 /// it left beside the modules it could not compare, each keyed by width
@@ -74,7 +74,8 @@ pub(crate) struct Carried {
 
 /// What one width counted. The first two are floors a later run must
 /// reach, so a shrinking corpus fails, and the rest are ceilings it must
-/// not exceed, so a growing defect class fails. Splitting a raise from a
+/// not exceed, so a growing defect class fails and so does a run that sets
+/// more modules aside than the baseline did. Splitting a raise from a
 /// rebind keeps a module that fails to import apart from one that ran and
 /// bound a different namespace, since only the first is broken.
 #[derive(Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -84,6 +85,9 @@ pub(crate) struct Counts {
     pub(crate) candidates: usize,
     /// How many of those the original tree ran cleanly.
     pub(crate) comparable: usize,
+    /// How many modules a run set aside because two runs of the original
+    /// bound different namespaces.
+    pub(crate) flaky: usize,
     /// How many modules failed to import at all.
     pub(crate) raises: usize,
     /// How many ran and bound a different namespace.
@@ -97,6 +101,7 @@ impl From<&Width> for Counts {
         Self {
             candidates: found.candidates,
             comparable: found.comparable,
+            flaky: found.flaky.len(),
             raises: found.unimported(),
             rebinds: found.counting(Kind::Ok),
             refused: found.refused,
@@ -110,15 +115,9 @@ pub(crate) fn bake(path: &Path, widths: &[Width]) {
         fs_err::create_dir_all(parent).expect("create the break set's directory");
     }
     let baked = Baseline {
-        breaks: keyed(widths, |found| found.breaks.iter().map(carried).collect()),
-        counts: widths
-            .iter()
-            .map(|found| (found.label.clone(), Counts::from(found)))
-            .collect(),
-        uncomparable: widths
-            .iter()
-            .map(|found| (found.label.clone(), found.uncomparable.clone()))
-            .collect(),
+        breaks: keyed(widths, entries),
+        counts: keyed(widths, |found| Counts::from(found)),
+        uncomparable: keyed(widths, |found| found.uncomparable.clone()),
         version: VERSION,
     };
     let rendered = serde_json::to_string_pretty(&baked).expect("render the break set");
@@ -170,16 +169,50 @@ pub(crate) fn dropped(found: &Width, held: &Baseline) -> BTreeSet<String> {
 }
 
 /// The broken modules of one width the baseline already holds, matched on
-/// the module, the file its frame names, and the reason.
+/// the module, the file its frame names, the kind of difference, and every
+/// name it turns on.
 pub(crate) fn judge(found: &Width, held: &Baseline) -> BTreeSet<String> {
     let Some(known) = held.breaks.get(&found.label) else {
         return BTreeSet::new();
     };
-    found
-        .breaks
-        .iter()
-        .filter(|brk| known.contains(&carried(brk)))
-        .map(|brk| brk.module.clone())
+    entries(found)
+        .intersection(known)
+        .map(|entry| entry.module.clone())
+        .collect()
+}
+
+/// How one width moved the wrong way against the counts the baseline
+/// recorded, empty where every one held. A baseline recording nothing at
+/// this width has nothing to move against.
+pub(crate) fn regressions(found: &Width, held: &Baseline) -> Vec<String> {
+    let Some(baked) = held.counts.get(&found.label) else {
+        return Vec::new();
+    };
+    let Counts {
+        candidates,
+        comparable,
+        flaky,
+        raises,
+        rebinds,
+        refused,
+    } = Counts::from(found);
+    let short = [
+        ("candidates", candidates, baked.candidates),
+        ("comparable", comparable, baked.comparable),
+    ]
+    .into_iter()
+    .filter(|(_, reached, want)| reached < want);
+    let grown = [
+        ("flaky", flaky, baked.flaky),
+        ("raises", raises, baked.raises),
+        ("rebinds", rebinds, baked.rebinds),
+        ("refused", refused, baked.refused),
+    ]
+    .into_iter()
+    .filter(|(_, reached, want)| reached > want);
+    short
+        .chain(grown)
+        .map(|(what, reached, want)| format!("{what} {reached} against {want} baked"))
         .collect()
 }
 
@@ -192,37 +225,10 @@ pub(crate) fn stale(found: &Width, held: &Baseline) -> BTreeSet<String> {
     let Some(known) = held.breaks.get(&found.label) else {
         return BTreeSet::new();
     };
-    let reproduced: BTreeSet<_> = found.breaks.iter().map(carried).collect();
+    let reproduced = entries(found);
     known
         .difference(&reproduced)
         .map(|entry| entry.module.clone())
-        .collect()
-}
-
-/// How one width moved the wrong way against the counts the baseline
-/// recorded, empty where every one held. A baseline recording nothing at
-/// this width has nothing to move against.
-pub(crate) fn regressions(found: &Width, held: &Baseline) -> Vec<String> {
-    let Some(baked) = held.counts.get(&found.label) else {
-        return Vec::new();
-    };
-    let reached = Counts::from(found);
-    let short = [
-        ("candidates", reached.candidates, baked.candidates),
-        ("comparable", reached.comparable, baked.comparable),
-    ]
-    .into_iter()
-    .filter(|(_, reached, want)| reached < want);
-    let grown = [
-        ("raises", reached.raises, baked.raises),
-        ("rebinds", reached.rebinds, baked.rebinds),
-        ("refused", reached.refused, baked.refused),
-    ]
-    .into_iter()
-    .filter(|(_, reached, want)| reached > want);
-    short
-        .chain(grown)
-        .map(|(what, reached, want)| format!("{what} {reached} against {want} baked"))
         .collect()
 }
 
@@ -236,11 +242,13 @@ fn carried(brk: &Break) -> Carried {
     }
 }
 
-/// The set each width projects, keyed by that width's label.
-fn keyed<T: Ord>(
-    widths: &[Width],
-    of: impl Fn(&Width) -> BTreeSet<T>,
-) -> BTreeMap<String, BTreeSet<T>> {
+/// The entries a baseline holds for one width's breaks.
+fn entries(found: &Width) -> BTreeSet<Carried> {
+    found.breaks.iter().map(carried).collect()
+}
+
+/// The value each width projects, keyed by that width's label.
+fn keyed<T>(widths: &[Width], of: impl Fn(&Width) -> T) -> BTreeMap<String, T> {
     widths
         .iter()
         .map(|found| (found.label.clone(), of(found)))

--- a/crate/tests/imports/records.rs
+++ b/crate/tests/imports/records.rs
@@ -12,6 +12,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::outcome::{Kind, Outcome};
 
+/// What one uncomparable module's own run left, the exception it named
+/// beside the sentence a report shows, so a later read matches the
+/// exception rather than searching the sentence for it.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default)]
+pub(crate) struct Blocked {
+    /// The exception the run named, empty where it named none.
+    pub(crate) raised: String,
+    /// The sentence a report shows.
+    pub(crate) reason: String,
+}
+
 /// A module the rewrite breaks.
 pub(crate) struct Break {
     /// The rules and binding the run traced it to.
@@ -61,18 +73,6 @@ pub(crate) struct EditRows {
 /// The safe fixes one format run recorded, keyed by the file each rewrote.
 pub(crate) type Fixes = BTreeMap<String, Vec<(RuleId, Vec<EditRows>)>>;
 
-/// What one uncomparable module's own run left, the exception it named
-/// beside the sentence a report shows, so a later read matches the
-/// exception rather than searching the sentence for it.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(default)]
-pub(crate) struct Blocked {
-    /// The exception the run named, empty where it named none.
-    pub(crate) raised: String,
-    /// The sentence a report shows.
-    pub(crate) reason: String,
-}
-
 /// The file and row a break points at.
 #[derive(Clone, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct Frame {
@@ -91,8 +91,11 @@ pub(crate) struct Width {
     pub(crate) candidates: usize,
     /// How many of those the original tree ran cleanly.
     pub(crate) comparable: usize,
-    /// The modules whose two runs of the original differed.
-    pub(crate) flaky: Vec<String>,
+    /// The modules whose two runs of the original differed, each beside the
+    /// names it varied on. An empty set stands for a module whose entire
+    /// namespace varied, which a comparison sets aside rather than
+    /// narrowing.
+    pub(crate) flaky: BTreeMap<String, BTreeSet<String>>,
     /// The width, or `default` where none was pinned.
     pub(crate) label: String,
     /// How many modules the format run could not read, parse, or write.
@@ -132,5 +135,11 @@ impl Width {
             .iter()
             .filter(|brk| brk.formatted.kind != Kind::Ok)
             .count()
+    }
+
+    /// How many names this width set aside across its flaky modules,
+    /// counting a name once per module that varies on it.
+    pub(crate) fn varying(&self) -> usize {
+        self.flaky.values().map(BTreeSet::len).sum()
     }
 }

--- a/crate/tests/imports/report.rs
+++ b/crate/tests/imports/report.rs
@@ -39,8 +39,9 @@ pub(crate) fn render(carried: &BTreeSet<String>, found: &Width) -> String {
         row("rebinds", &found.counting(Kind::Ok)),
         row("timeouts", &found.counting(Kind::Timeout)),
         row("flaky", &found.flaky.len()),
+        row("varying", &found.varying()),
+        row("carried", &carried.len()),
     ];
-    lines.push(row("carried", &carried.len()));
     if found.refused > 0 {
         lines.push(row("refused", &found.refused));
     }
@@ -48,8 +49,9 @@ pub(crate) fn render(carried: &BTreeSet<String>, found: &Width) -> String {
     rendered.push_str(&raising.render("raises"));
     rendered.push_str(&rebinding.render("runs and binds a different namespace"));
     rendered.push_str(&timeouts.render("times out"));
+    let varied = excluded(found);
     for (heading, listed) in [
-        ("flaky, a second run did not confirm it", &found.flaky),
+        ("flaky, a second run varied", &varied),
         ("unmeasured, a run left no record", &found.unmeasured),
     ] {
         if !listed.is_empty() {
@@ -71,6 +73,23 @@ fn defect(brk: &Break) -> String {
     let Frame { file, row } = &brk.frame;
     let at = row.map_or_else(|| file.clone(), |row| format!("{file}:{row}"));
     format!("{at} {}, {}", brk.reason, brk.attribution)
+}
+
+/// The rows naming each module a run set aside, one per module beside the
+/// names it varied on. A module whose whole namespace varied carries no
+/// names, so its row reads `the whole namespace` in their place.
+fn excluded(found: &Width) -> Vec<String> {
+    found
+        .flaky
+        .iter()
+        .map(|(module, names)| {
+            if names.is_empty() {
+                format!("{module}  the whole namespace")
+            } else {
+                format!("{module}  {}", names.iter().format(", "))
+            }
+        })
+        .collect()
 }
 
 /// The command that runs one module on its own, carrying every knob the

--- a/crate/tests/imports/sweep.rs
+++ b/crate/tests/imports/sweep.rs
@@ -3,7 +3,7 @@
 //! confirmed and attributed.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     num::NonZeroUsize,
     path::Path,
     sync::{Mutex, MutexGuard},
@@ -15,7 +15,7 @@ use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterato
 use crate::{
     attribution::Attributor,
     common::setting,
-    compare::{compare, divergence},
+    compare::{compare, divergence, varying},
     corpus::candidates,
     execute::Runner,
     format::format_tree,
@@ -29,13 +29,18 @@ pub(crate) const DEFAULT_LABEL: &str = "default";
 /// The environment variable narrowing a run to one module.
 pub(crate) const MODULE_VAR: &str = "PROSE_IMPORTS_MODULE";
 
-/// What a second run of both sides made of a break.
-enum Confirmed {
-    /// Both reruns agree the break is real.
-    Break,
-    /// The original disagrees with its own rerun, so nothing is proven.
-    Flaky,
-    /// The formatted rerun left no record, so the break is unmeasured.
+/// What a second run of both sides made of a break, each measured variant
+/// carrying the names the original's two runs bound differently.
+#[derive(Debug)]
+pub(crate) enum Confirmed {
+    /// The two reruns still diverge past those names, so the break is real.
+    Break(BTreeSet<String>),
+    /// The two reruns agree once those names are set aside, so the variance
+    /// accounts for the whole difference. An empty set stands for a module
+    /// whose entire namespace varied, which a run sets aside rather than
+    /// narrowing.
+    Flaky(BTreeSet<String>),
+    /// A rerun left no record, so nothing about the module is measured.
     Unmeasured,
 }
 
@@ -58,25 +63,18 @@ impl Sweep {
         }
     }
 
-    /// What a second run of both sides makes of a break, reading
-    /// `Unmeasured` where the formatted rerun left no record so a lost
-    /// record does not read as flake.
+    /// What a second run of both sides makes of a break, running the
+    /// original again and then the formatted copy.
     fn confirm(&self, brk: &Break, formatted: &Path) -> Confirmed {
         let before = self
             .runner
             .run(&brk.module, &[self.runner.stage.original.as_path()]);
-        if before.kind != Kind::Ok || divergence(&before, &brk.original).is_some() {
-            return Confirmed::Flaky;
+        if let Some(reached) = settled(before.kind) {
+            return reached;
         }
+        let varies = varying(&before, &brk.original);
         let after = self.runner.run(&brk.module, &[formatted]);
-        if after.kind == Kind::Unmeasured {
-            return Confirmed::Unmeasured;
-        }
-        if divergence(&after, &before).is_some() {
-            Confirmed::Break
-        } else {
-            Confirmed::Flaky
-        }
+        verdict(&after, &before, varies)
     }
 
     /// The memo of what the original tree left for each module it has
@@ -135,12 +133,19 @@ impl Sweep {
             .map(|brk| (self.confirm(&brk, &formatted), brk))
             .collect();
         let mut breaks = Vec::new();
-        let mut flaky = Vec::new();
+        let mut flaky = BTreeMap::new();
         let mut unmeasured = partition.unmeasured;
         for (verdict, brk) in judged {
             match verdict {
-                Confirmed::Break => breaks.push(brk),
-                Confirmed::Flaky => flaky.push(brk.module),
+                Confirmed::Break(varies) => {
+                    if !varies.is_empty() {
+                        flaky.insert(brk.module.clone(), varies);
+                    }
+                    breaks.push(brk);
+                }
+                Confirmed::Flaky(varies) => {
+                    flaky.insert(brk.module, varies);
+                }
                 Confirmed::Unmeasured => unmeasured.push(brk.module),
             }
         }
@@ -169,4 +174,31 @@ impl Sweep {
 /// report all read.
 pub(crate) fn label(width: Option<NonZeroUsize>) -> String {
     width.map_or_else(|| DEFAULT_LABEL.to_owned(), |width| width.to_string())
+}
+
+/// The verdict a rerun of the original reaches on its own, `None` where it
+/// ran cleanly and the formatted side is worth running. A rerun that timed
+/// out or left no record measures nothing, and one that raised bound no
+/// namespace to compare, so its variance carries no names.
+pub(crate) fn settled(kind: Kind) -> Option<Confirmed> {
+    match kind {
+        Kind::Ok => None,
+        Kind::Raised => Some(Confirmed::Flaky(BTreeSet::new())),
+        Kind::Timeout | Kind::Unmeasured => Some(Confirmed::Unmeasured),
+    }
+}
+
+/// The verdict two reruns reach once `varies` is set aside, which is a
+/// break wherever they still diverge on some name outside it. A formatted
+/// rerun that left no record measures nothing, whatever the first pair
+/// showed.
+pub(crate) fn verdict(after: &Outcome, before: &Outcome, varies: BTreeSet<String>) -> Confirmed {
+    if after.kind == Kind::Unmeasured {
+        return Confirmed::Unmeasured;
+    }
+    if divergence(&after.without(&varies), &before.without(&varies)).is_some() {
+        Confirmed::Break(varies)
+    } else {
+        Confirmed::Flaky(varies)
+    }
 }

--- a/crate/tests/imports/tests/compare.rs
+++ b/crate/tests/imports/tests/compare.rs
@@ -2,29 +2,22 @@
 //! formatted run counts as broken beside the original and how a width
 //! sorts its candidates into buckets.
 
-use itertools::Itertools;
+use std::collections::BTreeSet;
+
 use rstest::rstest;
 
+use super::*;
 use crate::{
-    compare::{Divergence, compare, divergence},
+    compare::{Divergence, compare, divergence, varying},
     outcome::{Kind, Outcome},
 };
 
-/// An outcome that ran cleanly, binding `names` and the constants `spelt`.
-fn bound(names: &[&str], spelt: &[(&str, &str)]) -> Outcome {
-    Outcome {
-        constants: spelt
-            .iter()
-            .map(|(name, value)| ((*name).to_owned(), (*value).to_owned()))
-            .collect(),
-        kind: Kind::Ok,
-        names: names
-            .iter()
-            .map(|name| (*name).to_owned())
-            .sorted()
-            .collect(),
-        ..Outcome::default()
-    }
+#[test]
+fn a_constant_only_one_run_binds_counts_as_varying() {
+    assert_eq!(
+        varying(&bound(&["N"], &[("N", "1")]), &bound(&["N"], &[])),
+        ["N".to_owned()].into()
+    );
 }
 
 #[rstest]
@@ -137,4 +130,19 @@ fn comparing_sorts_each_module_into_one_bucket() {
 fn identical_namespaces_do_not_diverge() {
     let same = bound(&["N"], &[("N", "1")]);
     assert_eq!(divergence(&same, &same), None);
+}
+
+#[test]
+fn varying_reads_both_directions_and_the_constants_where_divergence_stops_at_one() {
+    let one = bound(&["N", "a", "b"], &[("N", "1")]);
+    let other = bound(&["N", "a", "c"], &[("N", "2")]);
+    assert_eq!(
+        varying(&one, &other),
+        ["N".to_owned(), "b".to_owned(), "c".to_owned()].into()
+    );
+    assert_eq!(
+        divergence(&one, &other).expect("diverges").names,
+        ["c".to_owned()]
+    );
+    assert_eq!(varying(&one, &one), BTreeSet::new());
 }

--- a/crate/tests/imports/tests/mod.rs
+++ b/crate/tests/imports/tests/mod.rs
@@ -9,7 +9,8 @@ use itertools::Itertools;
 
 use crate::{
     outcome::{Kind, Outcome},
-    records::{Blocked, Break, Frame},
+    records::{Blocked, Break, Frame, Width},
+    sweep::DEFAULT_LABEL,
 };
 
 mod bindings;
@@ -68,12 +69,29 @@ fn broken(module: &str, frame: &str, reason: &str) -> Break {
     }
 }
 
+/// Asserts `rendered` hides `unwanted`, printing the whole render where it
+/// does not.
+#[track_caller]
+fn hides(rendered: &str, unwanted: &str) {
+    assert!(
+        !rendered.contains(unwanted),
+        "unwanted `{unwanted}` in:\n{rendered}"
+    );
+}
+
 /// A break at `frame` for `module`, losing `name` and nothing else.
 fn losing(module: &str, frame: &str, name: &str) -> Break {
     Break {
         names: vec![name.to_owned()],
         ..broken(module, frame, &format!("leaves `{name}` unbound"))
     }
+}
+
+/// Asserts `rendered` shows `want`, printing the whole render where it does
+/// not.
+#[track_caller]
+fn shows(rendered: &str, want: &str) {
+    assert!(rendered.contains(want), "want `{want}` in:\n{rendered}");
 }
 
 /// The uncomparable map holding each of `modules`, every one raising a
@@ -98,4 +116,13 @@ fn varied<const N: usize>(modules: [(&str, &[&str]); N]) -> BTreeMap<String, BTr
             )
         })
         .collect()
+}
+
+/// A width at the default label carrying nothing else, which a case
+/// overrides with the fields it measures.
+fn width() -> Width {
+    Width {
+        label: DEFAULT_LABEL.to_owned(),
+        ..Width::default()
+    }
 }

--- a/crate/tests/imports/tests/mod.rs
+++ b/crate/tests/imports/tests/mod.rs
@@ -3,10 +3,12 @@
 //! rule a break is blamed on, so an off-by-one in it misattributes the
 //! break instead of failing a test.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+
+use itertools::Itertools;
 
 use crate::{
-    outcome::Outcome,
+    outcome::{Kind, Outcome},
     records::{Blocked, Break, Frame},
 };
 
@@ -19,12 +21,49 @@ mod outcome;
 mod ratchet;
 mod records;
 mod report;
+mod sweep;
 
 /// A module the original tree did not run cleanly, whose run raised
 /// `raised` and reads as `reason`.
 fn blocked(raised: &str, reason: &str) -> Blocked {
     Blocked {
         raised: raised.to_owned(),
+        reason: reason.to_owned(),
+    }
+}
+
+/// An outcome that ran cleanly, binding `names` and the constants `spelt`.
+fn bound(names: &[&str], spelt: &[(&str, &str)]) -> Outcome {
+    Outcome {
+        constants: spelt
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), (*value).to_owned()))
+            .collect(),
+        kind: Kind::Ok,
+        names: names
+            .iter()
+            .map(|name| (*name).to_owned())
+            .sorted()
+            .collect(),
+        ..Outcome::default()
+    }
+}
+
+/// A break at `frame` for `module`, diverging for `reason`.
+fn broken(module: &str, frame: &str, reason: &str) -> Break {
+    Break {
+        attribution: String::new(),
+        formatted: Outcome::default(),
+        frame: Frame {
+            file: frame.to_owned(),
+            row: None,
+        },
+        hunk: Vec::new(),
+        kind: "unbound",
+        module: module.to_owned(),
+        name: None,
+        names: Vec::new(),
+        original: Outcome::default(),
         reason: reason.to_owned(),
     }
 }
@@ -47,21 +86,16 @@ fn stalled<const N: usize>(modules: [&str; N]) -> BTreeMap<String, Blocked> {
         .collect()
 }
 
-/// A break at `frame` for `module`, diverging for `reason`.
-fn broken(module: &str, frame: &str, reason: &str) -> Break {
-    Break {
-        attribution: String::new(),
-        formatted: Outcome::default(),
-        frame: Frame {
-            file: frame.to_owned(),
-            row: None,
-        },
-        hunk: Vec::new(),
-        kind: "unbound",
-        module: module.to_owned(),
-        name: None,
-        names: Vec::new(),
-        original: Outcome::default(),
-        reason: reason.to_owned(),
-    }
+/// The flaky map holding each of `modules` beside the names it varies on,
+/// an empty slice standing for a module whose entire namespace varied.
+fn varied<const N: usize>(modules: [(&str, &[&str]); N]) -> BTreeMap<String, BTreeSet<String>> {
+    modules
+        .iter()
+        .map(|(module, names)| {
+            (
+                (*module).to_owned(),
+                names.iter().map(|name| (*name).to_owned()).collect(),
+            )
+        })
+        .collect()
 }

--- a/crate/tests/imports/tests/outcome.rs
+++ b/crate/tests/imports/tests/outcome.rs
@@ -1,9 +1,28 @@
 //! Tests for the record `probe.py` writes and the harness reads back,
 //! covering its tagged rows and the module paths a run names.
 
-use std::path::Path;
+use std::{collections::BTreeSet, path::Path};
 
 use crate::outcome::{Kind, Outcome, relative_to};
+
+#[test]
+fn a_name_set_aside_leaves_the_names_the_constants_and_nothing_else() {
+    let ran = Outcome {
+        constants: [
+            ("KEPT".to_owned(), "1".to_owned()),
+            ("VARIES".to_owned(), "0x7f".to_owned()),
+        ]
+        .into(),
+        kind: Kind::Ok,
+        names: vec!["KEPT".to_owned(), "VARIES".to_owned(), "other".to_owned()],
+        ..Outcome::default()
+    };
+    let kept = ran.without(&["VARIES".to_owned()].into());
+    assert_eq!(kept.names, ["KEPT", "other"]);
+    assert_eq!(kept.constants, [("KEPT".to_owned(), "1".to_owned())].into());
+    assert_eq!(kept.kind, Kind::Ok);
+    assert_eq!(ran.without(&BTreeSet::new()).names, ran.names);
+}
 
 #[test]
 fn a_path_names_itself_against_the_first_tree_carrying_it() {

--- a/crate/tests/imports/tests/ratchet.rs
+++ b/crate/tests/imports/tests/ratchet.rs
@@ -4,6 +4,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use rstest::rstest;
+
 use super::*;
 use crate::{
     ratchet::{
@@ -48,6 +50,7 @@ fn a_baked_break_set_reads_back_as_the_set_that_wrote_it() {
         breaks: vec![losing("m.py", "re/_parser.py", "X")],
         candidates: 1,
         comparable: 1,
+        flaky: varied([("varies.py", &["N"])]),
         ..stalling(stalled(["blocked.py"]))
     };
     let dir = tempfile::tempdir().expect("a scratch directory");
@@ -62,7 +65,22 @@ fn a_baked_break_set_reads_back_as_the_set_that_wrote_it() {
         [carried("m.py", "re/_parser.py", "X")].into()
     );
     assert_eq!(held.uncomparable[DEFAULT_LABEL], stalled(["blocked.py"]));
+    assert_eq!(held.counts[DEFAULT_LABEL].flaky, 1);
     assert_eq!(held.version, VERSION);
+}
+
+#[rstest]
+#[case::dropped(dropped)]
+#[case::judge(judge)]
+#[case::stale(stale)]
+fn a_baseline_recording_no_width_names_nothing(
+    #[case] reading: fn(&Width, &Baseline) -> BTreeSet<String>,
+) {
+    let found = Width {
+        breaks: vec![losing("m.py", "m.py", "X")],
+        ..stalling(stalled(["blocked.py"]))
+    };
+    assert_eq!(reading(&found, &Baseline::default()), BTreeSet::new());
 }
 
 #[test]
@@ -119,10 +137,6 @@ fn dropped_names_nothing_for_a_package_the_machine_lacks() {
         .into(),
     );
     assert_eq!(
-        dropped(&found, &Baseline::default()),
-        BTreeSet::<String>::new()
-    );
-    assert_eq!(
         dropped(&found, &recording(BTreeMap::new())),
         ["lost.py".to_owned()].into()
     );
@@ -153,12 +167,6 @@ fn dropped_reads_the_exception_a_run_named_rather_than_its_sentence() {
 }
 
 #[test]
-fn dropped_names_nothing_where_the_baseline_records_no_width() {
-    let found = stalling(stalled(["blocked.py"]));
-    assert_eq!(dropped(&found, &Baseline::default()), BTreeSet::new());
-}
-
-#[test]
 fn regressions_name_every_count_that_moved_the_wrong_way() {
     let held = Baseline {
         counts: [(
@@ -166,6 +174,7 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
             Counts {
                 candidates: 997,
                 comparable: 898,
+                flaky: 2,
                 raises: 0,
                 rebinds: 0,
                 refused: 0,
@@ -177,6 +186,7 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
     let short = Width {
         candidates: 900,
         comparable: 800,
+        flaky: varied([("a.py", &[]), ("b.py", &[]), ("c.py", &[])]),
         label: DEFAULT_LABEL.to_owned(),
         refused: 2,
         ..Width::default()
@@ -186,6 +196,7 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
         [
             "candidates 900 against 997 baked",
             "comparable 800 against 898 baked",
+            "flaky 3 against 2 baked",
             "refused 2 against 0 baked",
         ]
     );
@@ -212,26 +223,6 @@ fn regressions_name_nothing_where_the_baseline_records_no_counts() {
 }
 
 #[test]
-fn the_ratchet_carries_a_break_the_baseline_holds_at_the_same_width() {
-    let found = Width {
-        breaks: vec![losing("m.py", "re/_parser.py", "X")],
-        ..stalling(BTreeMap::new())
-    };
-    let held = Baseline {
-        breaks: [(
-            DEFAULT_LABEL.to_owned(),
-            [carried("m.py", "re/_parser.py", "X")].into(),
-        )]
-        .into(),
-        version: VERSION,
-        ..recording(stalled(["a.py"]))
-    };
-    assert_eq!(judge(&found, &held), ["m.py".to_owned()].into());
-    assert_eq!(judge(&found, &Baseline::default()), BTreeSet::new());
-    assert_eq!(held.uncomparable[DEFAULT_LABEL], stalled(["a.py"]));
-}
-
-#[test]
 fn stale_names_a_baked_break_the_run_no_longer_reproduces() {
     let held = Baseline {
         breaks: [(
@@ -250,7 +241,6 @@ fn stale_names_a_baked_break_the_run_no_longer_reproduces() {
         ..stalling(BTreeMap::new())
     };
     assert_eq!(stale(&found, &held), ["gone.py".to_owned()].into());
-    assert_eq!(stale(&found, &Baseline::default()), BTreeSet::new());
 }
 
 #[test]
@@ -268,6 +258,25 @@ fn stale_names_a_break_whose_names_changed_under_one_module() {
         ..stalling(BTreeMap::new())
     };
     assert_eq!(stale(&found, &held), ["m.py".to_owned()].into());
+}
+
+#[test]
+fn the_ratchet_carries_a_break_the_baseline_holds_at_the_same_width() {
+    let found = Width {
+        breaks: vec![losing("m.py", "re/_parser.py", "X")],
+        ..stalling(BTreeMap::new())
+    };
+    let held = Baseline {
+        breaks: [(
+            DEFAULT_LABEL.to_owned(),
+            [carried("m.py", "re/_parser.py", "X")].into(),
+        )]
+        .into(),
+        version: VERSION,
+        ..recording(stalled(["a.py"]))
+    };
+    assert_eq!(judge(&found, &held), ["m.py".to_owned()].into());
+    assert_eq!(held.uncomparable[DEFAULT_LABEL], stalled(["a.py"]));
 }
 
 #[test]

--- a/crate/tests/imports/tests/ratchet.rs
+++ b/crate/tests/imports/tests/ratchet.rs
@@ -38,9 +38,8 @@ fn recording(uncomparable: BTreeMap<String, Blocked>) -> Baseline {
 /// A width at the default label holding `uncomparable` and nothing else.
 fn stalling(uncomparable: BTreeMap<String, Blocked>) -> Width {
     Width {
-        label: DEFAULT_LABEL.to_owned(),
         uncomparable,
-        ..Width::default()
+        ..width()
     }
 }
 
@@ -187,9 +186,8 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
         candidates: 900,
         comparable: 800,
         flaky: varied([("a.py", &[]), ("b.py", &[]), ("c.py", &[])]),
-        label: DEFAULT_LABEL.to_owned(),
         refused: 2,
-        ..Width::default()
+        ..width()
     };
     assert_eq!(
         regressions(&short, &held),
@@ -203,8 +201,7 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
     let reached = Width {
         candidates: 997,
         comparable: 900,
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     assert_eq!(regressions(&reached, &held), Vec::<String>::new());
 }
@@ -213,8 +210,7 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
 fn regressions_name_nothing_where_the_baseline_records_no_counts() {
     let found = Width {
         candidates: 1,
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     assert_eq!(
         regressions(&found, &Baseline::default()),
@@ -294,8 +290,7 @@ fn two_modules_at_one_frame_bake_as_separate_entries() {
             broken("a.py", "compat.py", "raises ImportError: no shutil"),
             broken("b.py", "compat.py", "raises ImportError: no shutil"),
         ],
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     let dir = tempfile::tempdir().expect("a scratch directory");
     let baked = dir.path().join("baseline.json");

--- a/crate/tests/imports/tests/records.rs
+++ b/crate/tests/imports/tests/records.rs
@@ -45,6 +45,21 @@ fn a_carried_break_leaves_the_tally_the_report_renders() {
 }
 
 #[test]
+fn a_flaky_module_counts_its_names_where_one_varying_whole_counts_none() {
+    let found = Width {
+        flaky: varied([
+            ("ctypes/__init__.py", &["_cast_addr", "_string_at_addr"]),
+            ("logging/__init__.py", &["_startTime", "raiseExceptions"]),
+            ("whole.py", &[]),
+        ]),
+        label: DEFAULT_LABEL.to_owned(),
+        ..Width::default()
+    };
+    assert_eq!(found.flaky.len(), 3);
+    assert_eq!(found.varying(), 4);
+}
+
+#[test]
 fn a_timing_out_break_counts_as_a_module_rather_than_a_defect() {
     let timed = |module: &str| {
         let mut brk = broken(module, "socket.py", "times out after 30s");

--- a/crate/tests/imports/tests/records.rs
+++ b/crate/tests/imports/tests/records.rs
@@ -8,7 +8,6 @@ use crate::{
     outcome::{Kind, Outcome},
     records::Width,
     report::render,
-    sweep::DEFAULT_LABEL,
 };
 
 #[test]
@@ -26,8 +25,7 @@ fn a_carried_break_leaves_the_tally_the_report_renders() {
             broken("carried.py", "re/_parser.py", "leaves `X` unbound"),
             broken("fresh.py", "re/_parser.py", "leaves `Y` unbound"),
         ],
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     let carried = ["carried.py".to_owned()].into();
     assert_eq!(
@@ -38,10 +36,10 @@ fn a_carried_break_leaves_the_tally_the_report_renders() {
         ["fresh.py"]
     );
     let shown = render(&carried, &found);
-    assert!(shown.contains("  breaks           2"), "{shown}");
-    assert!(shown.contains("  carried          1"), "{shown}");
-    assert!(shown.contains("fresh.py"), "{shown}");
-    assert!(!shown.contains("carried.py"), "{shown}");
+    shows(&shown, "  breaks           2");
+    shows(&shown, "  carried          1");
+    shows(&shown, "fresh.py");
+    hides(&shown, "carried.py");
 }
 
 #[test]
@@ -52,8 +50,7 @@ fn a_flaky_module_counts_its_names_where_one_varying_whole_counts_none() {
             ("logging/__init__.py", &["_startTime", "raiseExceptions"]),
             ("whole.py", &[]),
         ]),
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     assert_eq!(found.flaky.len(), 3);
     assert_eq!(found.varying(), 4);
@@ -70,11 +67,10 @@ fn a_timing_out_break_counts_as_a_module_rather_than_a_defect() {
         breaks: vec![timed("a.py"), timed("b.py")],
         candidates: 2,
         comparable: 2,
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     assert_eq!(found.counting(Kind::Timeout), 2);
     let shown = render(&BTreeSet::new(), &found);
-    assert!(shown.contains("  timeouts         2"), "{shown}");
-    assert!(shown.contains("times out (1):"), "{shown}");
+    shows(&shown, "  timeouts         2");
+    shows(&shown, "times out (1):");
 }

--- a/crate/tests/imports/tests/report.rs
+++ b/crate/tests/imports/tests/report.rs
@@ -5,7 +5,7 @@
 use std::collections::BTreeSet;
 
 use super::*;
-use crate::{common::SHOWN, records::Width, report::render, sweep::DEFAULT_LABEL};
+use crate::{common::SHOWN, records::Width, report::render};
 
 #[test]
 fn a_break_the_report_names_carries_its_frame_reason_and_repro() {
@@ -21,24 +21,18 @@ fn a_break_the_report_names_carries_its_frame_reason_and_repro() {
         breaks: vec![brk],
         candidates: 4,
         comparable: 3,
-        label: DEFAULT_LABEL.to_owned(),
         refused: 1,
-        ..Width::default()
+        ..width()
     };
     let shown = render(&["kept.py".to_owned()].into(), &found);
-    assert!(shown.contains("  carried          1"), "{shown}");
-    assert!(shown.contains("  refused          1"), "{shown}");
-    assert!(
-        shown.contains(
-            "re/_parser.py:111 raises NameError: no MAXGROUPS, under `prune-inert-imports`"
-        ),
-        "{shown}"
+    shows(&shown, "  carried          1");
+    shows(&shown, "  refused          1");
+    shows(
+        &shown,
+        "re/_parser.py:111 raises NameError: no MAXGROUPS, under `prune-inert-imports`",
     );
-    assert!(
-        shown.contains("reproduce with mise run imports _colorize.py"),
-        "{shown}"
-    );
-    assert!(shown.contains("-from _sre import MAXGROUPS"), "{shown}");
+    shows(&shown, "reproduce with mise run imports _colorize.py");
+    shows(&shown, "-from _sre import MAXGROUPS");
 }
 
 #[test]
@@ -49,27 +43,20 @@ fn a_repro_at_a_pinned_width_carries_the_width_knob() {
         ..Width::default()
     };
     let shown = render(&BTreeSet::new(), &found);
-    assert!(
-        shown.contains("PROSE_SETTLE_WIDTHS=100 mise run imports pydoc.py"),
-        "{shown}"
-    );
+    shows(&shown, "PROSE_SETTLE_WIDTHS=100 mise run imports pydoc.py");
 }
 
 #[test]
 fn an_unmeasured_module_replaces_the_uncomparable_count() {
     let found = Width {
-        label: DEFAULT_LABEL.to_owned(),
         uncomparable: stalled(["a.py"]),
         unmeasured: vec!["u.py".to_owned()],
-        ..Width::default()
+        ..width()
     };
     let shown = render(&BTreeSet::new(), &found);
-    assert!(shown.contains("  uncomparable unmeasured"), "{shown}");
-    assert!(
-        shown.contains("unmeasured, a run left no record (1):"),
-        "{shown}"
-    );
-    assert!(shown.contains("u.py"), "{shown}");
+    shows(&shown, "  uncomparable unmeasured");
+    shows(&shown, "unmeasured, a run left no record (1):");
+    shows(&shown, "u.py");
 }
 
 #[test]
@@ -80,16 +67,15 @@ fn the_flaky_list_caps_at_the_shown_limit() {
         flaky: (0..SHOWN + 3)
             .map(|n| (format!("m{n:02}.py"), ["N".to_owned()].into()))
             .collect(),
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     let shown = render(&BTreeSet::new(), &found);
-    assert!(
-        shown.contains(&format!("flaky, a second run varied ({}):", SHOWN + 3)),
-        "{shown}"
+    shows(
+        &shown,
+        &format!("flaky, a second run varied ({}):", SHOWN + 3),
     );
-    assert!(shown.contains("... and 3 more"), "{shown}");
-    assert!(!shown.contains(&format!("m{SHOWN}.py")), "{shown}");
+    shows(&shown, "... and 3 more");
+    hides(&shown, &format!("m{SHOWN}.py"));
 }
 
 #[test]
@@ -102,18 +88,17 @@ fn the_flaky_listing_names_each_module_beside_the_names_it_varies_on() {
             ),
             ("whole.py", &[]),
         ]),
-        label: DEFAULT_LABEL.to_owned(),
-        ..Width::default()
+        ..width()
     };
     let shown = render(&BTreeSet::new(), &found);
-    assert!(shown.contains("  flaky            2"), "{shown}");
-    assert!(shown.contains("  varying          3"), "{shown}");
-    assert!(shown.contains("flaky, a second run varied (2):"), "{shown}");
-    assert!(
-        shown.contains("logging/__init__.py  _srcfile, _startTime, raiseExceptions"),
-        "{shown}"
+    shows(&shown, "  flaky            2");
+    shows(&shown, "  varying          3");
+    shows(&shown, "flaky, a second run varied (2):");
+    shows(
+        &shown,
+        "logging/__init__.py  _srcfile, _startTime, raiseExceptions",
     );
-    assert!(shown.contains("whole.py  the whole namespace"), "{shown}");
+    shows(&shown, "whole.py  the whole namespace");
 }
 
 #[test]
@@ -121,9 +106,8 @@ fn the_summary_block_holds_every_count_in_one_column() {
     let found = Width {
         candidates: 12,
         comparable: 9,
-        label: DEFAULT_LABEL.to_owned(),
         uncomparable: stalled(["a.py", "b.py", "c.py"]),
-        ..Width::default()
+        ..width()
     };
     assert_eq!(
         render(&BTreeSet::new(), &found),

--- a/crate/tests/imports/tests/report.rs
+++ b/crate/tests/imports/tests/report.rs
@@ -77,20 +77,43 @@ fn the_flaky_list_caps_at_the_shown_limit() {
     let found = Width {
         candidates: SHOWN + 3,
         comparable: SHOWN + 3,
-        flaky: (0..SHOWN + 3).map(|n| format!("m{n}.py")).collect(),
+        flaky: (0..SHOWN + 3)
+            .map(|n| (format!("m{n:02}.py"), ["N".to_owned()].into()))
+            .collect(),
         label: DEFAULT_LABEL.to_owned(),
         ..Width::default()
     };
     let shown = render(&BTreeSet::new(), &found);
     assert!(
-        shown.contains(&format!(
-            "flaky, a second run did not confirm it ({}):",
-            SHOWN + 3
-        )),
+        shown.contains(&format!("flaky, a second run varied ({}):", SHOWN + 3)),
         "{shown}"
     );
     assert!(shown.contains("... and 3 more"), "{shown}");
     assert!(!shown.contains(&format!("m{SHOWN}.py")), "{shown}");
+}
+
+#[test]
+fn the_flaky_listing_names_each_module_beside_the_names_it_varies_on() {
+    let found = Width {
+        flaky: varied([
+            (
+                "logging/__init__.py",
+                &["_srcfile", "_startTime", "raiseExceptions"],
+            ),
+            ("whole.py", &[]),
+        ]),
+        label: DEFAULT_LABEL.to_owned(),
+        ..Width::default()
+    };
+    let shown = render(&BTreeSet::new(), &found);
+    assert!(shown.contains("  flaky            2"), "{shown}");
+    assert!(shown.contains("  varying          3"), "{shown}");
+    assert!(shown.contains("flaky, a second run varied (2):"), "{shown}");
+    assert!(
+        shown.contains("logging/__init__.py  _srcfile, _startTime, raiseExceptions"),
+        "{shown}"
+    );
+    assert!(shown.contains("whole.py  the whole namespace"), "{shown}");
 }
 
 #[test]
@@ -113,6 +136,7 @@ fn the_summary_block_holds_every_count_in_one_column() {
             "  rebinds          0\n",
             "  timeouts         0\n",
             "  flaky            0\n",
+            "  varying          0\n",
             "  carried          0",
         )
     );

--- a/crate/tests/imports/tests/sweep.rs
+++ b/crate/tests/imports/tests/sweep.rs
@@ -1,0 +1,67 @@
+//! Tests for the two verdicts one sweep reaches on a break, covering the
+//! rerun of the original that never ended cleanly and, once the names a
+//! module varies on are set aside, the comparison the formatted rerun
+//! still has to pass.
+
+use std::{assert_matches, collections::BTreeSet};
+
+use rstest::rstest;
+
+use super::*;
+use crate::{
+    outcome::{Kind, Outcome},
+    sweep::{Confirmed, settled, verdict},
+};
+
+#[test]
+fn a_difference_confined_to_the_varying_names_leaves_the_break_unproven() {
+    let varies = ["_cast_addr".to_owned()].into();
+    let before = bound(&["_cast_addr", "cdll"], &[("_cast_addr", "0x10a")]);
+    let after = bound(&["_cast_addr", "cdll"], &[("_cast_addr", "0x2f8")]);
+    assert_matches!(verdict(&after, &before, varies), Confirmed::Flaky(names) if names.len() == 1);
+}
+
+#[test]
+fn a_difference_outside_the_varying_names_still_breaks() {
+    let varies = ["_cast_addr".to_owned()].into();
+    let before = bound(&["_cast_addr", "cdll"], &[("_cast_addr", "0x10a")]);
+    let after = bound(&["_cast_addr"], &[("_cast_addr", "0x2f8")]);
+    assert_matches!(verdict(&after, &before, varies), Confirmed::Break(names) if names.len() == 1);
+}
+
+#[test]
+fn a_formatted_rerun_leaving_no_record_measures_nothing() {
+    let before = bound(&["cdll"], &[]);
+    let after = Outcome::of(Kind::Unmeasured, "leaves no record");
+    assert_matches!(
+        verdict(&after, &before, BTreeSet::new()),
+        Confirmed::Unmeasured
+    );
+}
+
+#[rstest]
+#[case::raised(Kind::Raised)]
+#[case::timed_out(Kind::Timeout)]
+fn a_formatted_rerun_that_never_bound_a_namespace_breaks_past_any_variance(#[case] kind: Kind) {
+    let varies = ["_cast_addr".to_owned()].into();
+    let before = bound(&["_cast_addr", "cdll"], &[("_cast_addr", "0x10a")]);
+    let after = Outcome::of(kind, "never bound a namespace");
+    assert_matches!(verdict(&after, &before, varies), Confirmed::Break(names) if names.len() == 1);
+}
+
+#[rstest]
+#[case::timed_out(Kind::Timeout)]
+#[case::left_no_record(Kind::Unmeasured)]
+fn a_rerun_that_never_ended_cleanly_measures_nothing(#[case] kind: Kind) {
+    assert_matches!(settled(kind), Some(Confirmed::Unmeasured));
+}
+
+#[test]
+fn a_rerun_that_raised_varies_across_its_whole_namespace() {
+    assert_matches!(settled(Kind::Raised), Some(Confirmed::Flaky(names)) if names.is_empty());
+}
+
+#[test]
+fn a_rerun_that_ran_cleanly_leaves_the_formatted_side_worth_running() {
+    assert_matches!(settled(Kind::Ok), None);
+}


### PR DESCRIPTION
### 🪻 Quick Summary

Gates the `imports` sweep's flaky bucket, which had held any module whose two runs of the original tree disagreed while asserting nothing about how many it held. The bucket's module count now bakes into `crate/tests/imports/baseline.json` as a per-width ceiling, so a change moving modules into it fails a run rather than passing quietly.

A rerun that timed out or left no record now parts from one that ran and disagreed, and a module that genuinely varies records the names it varies on. The comparison sets those names aside rather than the whole module, so a regression elsewhere in the same namespace still reports as a break.

---

### 🗞️ Key Changes

- Adds a `flaky` count to `Counts` and files it among the ceilings `regressions` reads, so a run setting more modules aside than the baseline did fails rather than reporting a quieter number

- Splits the single flake verdict in three through a new `settled`, where a rerun of the original that timed out or left no record reads as `Unmeasured` and one that ran and disagreed reads as variance

- Sets a module aside whole where its rerun raised, since a run binding no namespace carries no individual names to drop, which the record spells as an empty name set and the report renders as `the whole namespace`

- Widens `Width::flaky` from a list of modules to a `BTreeMap<String, BTreeSet<String>>` holding each module beside the names its two runs bound differently

- Adds `Outcome::without`, dropping a name set from both the names a run bound and the plain constants among them, and runs the confirming comparison over both sides with the varying names removed

- Extracts `verdict` from `Sweep::confirm` beside `settled`, leaving `confirm` the two runs and their two decisions, and covering both by unit test where the whole verdict had needed a live interpreter to reach

- Adds `compare::varying`, reporting every name two runs bound differently where `divergence` stops at the first category it finds, so a run that both loses one name and gains another carries each

- Adds a `varying` row to the summary block beside `flaky` and lists each set-aside module against the names it varied on, so the module count and the name count read apart

- Hoists `missing` out of `divergence`'s closure and extracts `respelt` beside it, which `varying` reads rather than rebuilding a set difference and a constant comparison of its own

- Generalizes `keyed` to any value type, folding `bake`'s `counts` and `uncomparable` maps onto the helper only `breaks` had used, and names the shared `entries` that `bake` and `stale` both built inline

- Destructures `Counts` in `regressions` rather than reading it field by field, so a field added later fails the build until it is placed among the floors or the ceilings

- Rewrites `judge` over `entries` and set intersection, pairing it with `stale`'s difference as the two directions of one relation between the same two sets

- Raises the baked generation to `7` and re-bakes `crate/tests/imports/baseline.json`, so a set written before this change reads as unreadable and fails a run until it is refreshed

- Pins each of the four rerun endings, a break surviving the variance set aside around it, a constant only one run binds, and the module and name counts rendering apart

---

### 🧵 Related Issues

- Closes #598
