### PR TITLE
[599] Triage the `imports` sweep's uncomparable modules and recover the coverage they hold

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -18,6 +18,6 @@ bun                            = "1.4.2"
 "github:rustwasm/wasm-bindgen" = "0.2.128"
 maturin                        = "1.15.0"
 "pipx:codecov-cli"             = "11.3.1"
-python                         = "3.14"
+python                         = "3.14.6"
 rust                           = { version = "1.98.1", components = "clippy, rustfmt", profile = "minimal", targets = "wasm32-unknown-unknown" }
 uv                             = "0.12.10"

--- a/.mise/lib/delta.bash
+++ b/.mise/lib/delta.bash
@@ -64,8 +64,16 @@ format_widths() {
 }
 
 stage_corpus() {
+  local glob
+
   staged init -b delta -q
-  staged --work-tree="$1" add -f -- '*.py'
+
+  for glob in '*.py' '*.pyi' '*.pyw'; do
+    if [[ -n $(find "$1" -name "$glob" -print -quit) ]]; then
+      staged --work-tree="$1" add -f -- "$glob"
+    fi
+  done
+
   staged commit -m pristine -q
   staged tag pristine
 }

--- a/corpus/src/bin/mutate.rs
+++ b/corpus/src/bin/mutate.rs
@@ -44,7 +44,7 @@ use rand::{
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use ruff_python_ast::{
-    Expr,
+    Expr, PySourceType,
     token::TokenKind,
     visitor::source_order::{SourceOrderVisitor, walk_body, walk_expr},
 };
@@ -381,16 +381,19 @@ fn suppressed(text: &str, rng: &mut StdRng) -> Option<String> {
     Some(render(&module))
 }
 
-/// Returns every `.py` file under `root` in a stable order. The walk carries
-/// no standard filter, so a hidden directory and an ignored one both enter
-/// the corpus.
+/// Returns every Python source under `root` in a stable order, covering the
+/// `.py`, `.pyw`, and `.pyi` files the walker formats. The walk carries no
+/// standard filter, so a hidden directory and an ignored one both enter the
+/// corpus.
 fn walk(root: &Path) -> Vec<PathBuf> {
     WalkBuilder::new(root)
         .standard_filters(false)
         .build()
         .flatten()
         .map(ignore::DirEntry::into_path)
-        .filter(|path| path.extension().is_some_and(|ext| ext == "py"))
+        .filter(|path| {
+            PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file_or_stub)
+        })
         .sorted()
         .collect()
 }

--- a/crate/tests/common/sweep.rs
+++ b/crate/tests/common/sweep.rs
@@ -19,6 +19,7 @@ use std::{
 use ignore::WalkBuilder;
 use itertools::Itertools;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use ruff_python_ast::PySourceType;
 
 /// The wall clock one probe may take before a sweep treats its run as
 /// non-terminating.
@@ -118,16 +119,20 @@ pub(crate) fn report_verified(what: &str) {
     }
 }
 
-/// The `.py` files under `root`. The walk carries no standard filter, so a
-/// hidden directory and an ignored one both enter the sweep rather than
-/// leaving it short without saying so.
+/// The Python sources under `root`, covering the `.py`, `.pyw`, and `.pyi`
+/// files the walker formats and leaving notebooks to the surface that reads
+/// a `SourceMap`. The walk carries no standard filter, so a hidden directory
+/// and an ignored one both enter the sweep rather than leaving it short
+/// without saying so.
 pub(crate) fn python_files(root: &Path) -> impl Iterator<Item = PathBuf> {
     WalkBuilder::new(root)
         .standard_filters(false)
         .build()
         .flatten()
         .map(ignore::DirEntry::into_path)
-        .filter(|path| path.extension().is_some_and(|ext| ext == "py"))
+        .filter(|path| {
+            PySourceType::try_from_path(path).is_some_and(PySourceType::is_py_file_or_stub)
+        })
 }
 
 /// The value `var` carries, `None` where it is unset or blank.
@@ -212,7 +217,7 @@ fn registry() -> MutexGuard<'static, BTreeMap<usize, (Instant, String)>> {
     IN_FLIGHT.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
-/// The `.py` files under the corpus root, largest first with the path
+/// The Python sources under the corpus root, largest first with the path
 /// breaking ties, so a parallel sweep's tail is one file long and a
 /// failure names the same file across runs. [`CORPUS`] points a sweep
 /// at a directory other than the fixture tree.

--- a/crate/tests/imports/baseline.json
+++ b/crate/tests/imports/baseline.json
@@ -18,6 +18,14 @@
         ]
       },
       {
+        "file": "concurrent/interpreters/_queues.py",
+        "kind": "unbound",
+        "module": "concurrent/interpreters/_queues.py",
+        "names": [
+          "pickle"
+        ]
+      },
+      {
         "file": "pydoc.py",
         "kind": "unbound",
         "module": "pydoc.py",
@@ -27,414 +35,118 @@
       }
     ]
   },
+  "corpus": {
+    "digest": "2f163b4bf4ecfb10",
+    "files": 1060,
+    "interpreter": "3.14.6"
+  },
   "counts": {
     "default": {
       "candidates": 997,
-      "comparable": 898,
+      "comparable": 978,
       "raises": 0,
-      "rebinds": 3,
+      "rebinds": 4,
       "refused": 0
     }
   },
   "uncomparable": {
     "default": {
-      "asyncio/base_events.py": {
-        "raised": "NameError",
-        "reason": "raises NameError: name 'base_events' is not defined"
-      },
-      "asyncio/base_futures.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.base_futures' has no attribute '_future_repr'"
-      },
-      "asyncio/base_subprocess.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.base_subprocess' has no attribute 'BaseSubprocessTransport'"
-      },
-      "asyncio/base_tasks.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.base_tasks' has no attribute '_task_repr'"
-      },
-      "asyncio/events.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.events' has no attribute '_get_event_loop_policy'"
-      },
-      "asyncio/futures.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.futures' has no attribute '_PyFuture'"
-      },
-      "asyncio/graph.py": {
-        "raised": "NameError",
-        "reason": "raises NameError: name 'graph' is not defined"
-      },
-      "asyncio/locks.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.locks' has no attribute 'Lock'"
-      },
-      "asyncio/mixins.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.mixins' has no attribute '_LoopBoundMixin'"
-      },
-      "asyncio/queues.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.queues' has no attribute 'Queue'"
-      },
-      "asyncio/runners.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.runners' has no attribute 'Runner'"
-      },
-      "asyncio/selector_events.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.selector_events' has no attribute 'BaseSelectorEventLoop'"
-      },
-      "asyncio/streams.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.streams' has no attribute 'StreamReader'"
-      },
-      "asyncio/subprocess.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.subprocess' has no attribute 'create_subprocess_exec'"
-      },
-      "asyncio/taskgroups.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'asyncio.taskgroups' has no attribute 'TaskGroup'"
-      },
-      "asyncio/tasks.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'sleep' from 'asyncio.tasks' (<tree>/asyncio/tasks.py)"
-      },
-      "asyncio/threads.py": {
-        "raised": "NameError",
-        "reason": "raises NameError: name 'threads' is not defined"
-      },
-      "asyncio/timeouts.py": {
-        "raised": "NameError",
-        "reason": "raises NameError: name 'timeouts' is not defined"
-      },
-      "asyncio/unix_events.py": {
-        "raised": "NameError",
-        "reason": "raises NameError: name 'unix_events' is not defined"
-      },
       "asyncio/windows_events.py": {
         "raised": "ImportError",
+        "reach": "platform",
         "reason": "raises ImportError: win32 only"
       },
       "asyncio/windows_utils.py": {
         "raised": "ImportError",
+        "reach": "platform",
         "reason": "raises ImportError: win32 only"
-      },
-      "concurrent/interpreters/_queues.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'create' from 'concurrent.interpreters._queues' (<tree>/concurrent/interpreters/_queues.py)"
-      },
-      "ctypes/_endian.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'BigEndianStructure' from 'ctypes._endian' (<tree>/ctypes/_endian.py)"
       },
       "dbm/gnu.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named '_gdbm'"
       },
       "encodings/mbcs.py": {
         "raised": "ImportError",
+        "reach": "module",
         "reason": "raises ImportError: cannot import name 'mbcs_encode' from 'codecs' (<stdlib>/codecs.py)"
       },
       "encodings/oem.py": {
         "raised": "ImportError",
+        "reach": "module",
         "reason": "raises ImportError: cannot import name 'oem_encode' from 'codecs' (<stdlib>/codecs.py)"
-      },
-      "importlib/resources/_common.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'as_file' from 'importlib.resources._common' (<tree>/importlib/resources/_common.py)"
-      },
-      "importlib/resources/_functional.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'contents' from 'importlib.resources._functional' (<tree>/importlib/resources/_functional.py)"
-      },
-      "json/decoder.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'JSONDecoder' from 'json.decoder' (<tree>/json/decoder.py)"
-      },
-      "multiprocessing/context.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'multiprocessing.context' has no attribute '_default_context'"
       },
       "multiprocessing/popen_spawn_win32.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'msvcrt'"
-      },
-      "multiprocessing/reduction.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 'multiprocessing.reduction' has no attribute 'HAVE_SEND_HANDLE'"
-      },
-      "re/_compiler.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 're._compiler' has no attribute 'SRE_FLAG_ASCII'"
-      },
-      "re/_parser.py": {
-        "raised": "AttributeError",
-        "reason": "raises AttributeError: module 're._parser' has no attribute 'TYPE_FLAGS'"
       },
       "site-packages/pip/__pip-runner__.py": {
         "raised": "AssertionError",
+        "reach": "module",
         "reason": "raises AssertionError: Cannot run __pip-runner__.py as a non-main module"
       },
       "site-packages/pip/_internal/locations/_distutils.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'distutils'"
-      },
-      "site-packages/pip/_internal/metadata/base.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'BaseDistribution' from 'site-packages.pip._internal.metadata.base' (<tree>/site-packages/pip/_internal/metadata/base.py)"
-      },
-      "site-packages/pip/_internal/metadata/importlib/_dists.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Distribution' from 'site-packages.pip._internal.metadata.importlib._dists' (<tree>/site-packages/pip/_internal/metadata/importlib/_dists.py)"
-      },
-      "site-packages/pip/_internal/metadata/importlib/_envs.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Environment' from 'site-packages.pip._internal.metadata.importlib._envs' (<tree>/site-packages/pip/_internal/metadata/importlib/_envs.py)"
-      },
-      "site-packages/pip/_vendor/idna/core.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'IDNABidiError' from 'site-packages.pip._vendor.idna.core' (<tree>/site-packages/pip/_vendor/idna/core.py)"
-      },
-      "site-packages/pip/_vendor/msgpack/fallback.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Packer' from 'site-packages.pip._vendor.msgpack.fallback' (<tree>/site-packages/pip/_vendor/msgpack/fallback.py)"
       },
       "site-packages/pip/_vendor/pygments/sphinxext.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'docutils'"
-      },
-      "site-packages/pip/_vendor/pyproject_hooks/_impl.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'BackendUnavailable' from 'site-packages.pip._vendor.pyproject_hooks._impl' (<tree>/site-packages/pip/_vendor/pyproject_hooks/_impl.py)"
-      },
-      "site-packages/pip/_vendor/requests/_internal_utils.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_HEADER_VALIDATORS_BYTE' from 'site-packages.pip._vendor.requests._internal_utils' (<tree>/site-packages/pip/_vendor/requests/_internal_utils.py)"
-      },
-      "site-packages/pip/_vendor/requests/adapters.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'HTTPAdapter' from 'site-packages.pip._vendor.requests.adapters' (<tree>/site-packages/pip/_vendor/requests/adapters.py)"
-      },
-      "site-packages/pip/_vendor/requests/api.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'delete' from 'site-packages.pip._vendor.requests.api' (<tree>/site-packages/pip/_vendor/requests/api.py)"
-      },
-      "site-packages/pip/_vendor/requests/auth.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_basic_auth_str' from 'site-packages.pip._vendor.requests.auth' (<tree>/site-packages/pip/_vendor/requests/auth.py)"
-      },
-      "site-packages/pip/_vendor/requests/cookies.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'cookiejar_from_dict' from 'site-packages.pip._vendor.requests.cookies' (<tree>/site-packages/pip/_vendor/requests/cookies.py)"
-      },
-      "site-packages/pip/_vendor/requests/exceptions.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'RequestsDependencyWarning' from 'site-packages.pip._vendor.requests.exceptions' (<tree>/site-packages/pip/_vendor/requests/exceptions.py)"
-      },
-      "site-packages/pip/_vendor/requests/models.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Response' from 'site-packages.pip._vendor.requests.models' (<tree>/site-packages/pip/_vendor/requests/models.py)"
-      },
-      "site-packages/pip/_vendor/requests/sessions.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Session' from 'site-packages.pip._vendor.requests.sessions' (<tree>/site-packages/pip/_vendor/requests/sessions.py)"
-      },
-      "site-packages/pip/_vendor/requests/status_codes.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'codes' from 'site-packages.pip._vendor.requests.status_codes' (<tree>/site-packages/pip/_vendor/requests/status_codes.py)"
-      },
-      "site-packages/pip/_vendor/requests/structures.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'CaseInsensitiveDict' from 'site-packages.pip._vendor.requests.structures' (<tree>/site-packages/pip/_vendor/requests/structures.py)"
-      },
-      "site-packages/pip/_vendor/requests/utils.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'parse_dict_header' from 'site-packages.pip._vendor.requests.utils' (<tree>/site-packages/pip/_vendor/requests/utils.py)"
-      },
-      "site-packages/pip/_vendor/resolvelib/providers.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'AbstractProvider' from 'site-packages.pip._vendor.resolvelib.providers' (<tree>/site-packages/pip/_vendor/resolvelib/providers.py)"
-      },
-      "site-packages/pip/_vendor/resolvelib/reporters.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'BaseReporter' from 'site-packages.pip._vendor.resolvelib.reporters' (<tree>/site-packages/pip/_vendor/resolvelib/reporters.py)"
-      },
-      "site-packages/pip/_vendor/resolvelib/resolvers/__init__.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'AbstractResolver' from 'site-packages.pip._vendor.resolvelib.resolvers' (<tree>/site-packages/pip/_vendor/resolvelib/resolvers/__init__.py)"
-      },
-      "site-packages/pip/_vendor/resolvelib/resolvers/abstract.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'AbstractResolver' from 'site-packages.pip._vendor.resolvelib.resolvers.abstract' (<tree>/site-packages/pip/_vendor/resolvelib/resolvers/abstract.py)"
-      },
-      "site-packages/pip/_vendor/resolvelib/resolvers/criterion.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Criterion' from 'site-packages.pip._vendor.resolvelib.resolvers.criterion' (<tree>/site-packages/pip/_vendor/resolvelib/resolvers/criterion.py)"
-      },
-      "site-packages/pip/_vendor/resolvelib/resolvers/exceptions.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'InconsistentCandidate' from 'site-packages.pip._vendor.resolvelib.resolvers.exceptions' (<tree>/site-packages/pip/_vendor/resolvelib/resolvers/exceptions.py)"
-      },
-      "site-packages/pip/_vendor/resolvelib/resolvers/resolution.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Resolution' from 'site-packages.pip._vendor.resolvelib.resolvers.resolution' (<tree>/site-packages/pip/_vendor/resolvelib/resolvers/resolution.py)"
       },
       "site-packages/pip/_vendor/rich/_win32_console.py": {
         "raised": "ImportError",
+        "reach": "platform",
         "reason": "raises ImportError: site-packages.pip._vendor.rich._win32_console can only be imported on Windows"
       },
       "site-packages/pip/_vendor/rich/_windows_renderer.py": {
         "raised": "ImportError",
+        "reach": "platform",
         "reason": "raises ImportError: pip._vendor.rich._win32_console can only be imported on Windows"
-      },
-      "site-packages/pip/_vendor/tomli/_parser.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'TOMLDecodeError' from 'site-packages.pip._vendor.tomli._parser' (<tree>/site-packages/pip/_vendor/tomli/_parser.py)"
-      },
-      "site-packages/pip/_vendor/truststore/_api.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'SSLContext' from 'site-packages.pip._vendor.truststore._api' (<tree>/site-packages/pip/_vendor/truststore/_api.py)"
-      },
-      "site-packages/pip/_vendor/truststore/_macos.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_configure_context' from 'site-packages.pip._vendor.truststore._macos' (<tree>/site-packages/pip/_vendor/truststore/_macos.py)"
       },
       "site-packages/pip/_vendor/truststore/_windows.py": {
         "raised": "ImportError",
+        "reach": "platform",
         "reason": "raises ImportError: cannot import name 'WinDLL' from 'ctypes' (<tree>/ctypes/__init__.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/_base_connection.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_TYPE_BODY' from 'site-packages.pip._vendor.urllib3._base_connection' (<tree>/site-packages/pip/_vendor/urllib3/_base_connection.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/_request_methods.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'RequestMethods' from 'site-packages.pip._vendor.urllib3._request_methods' (<tree>/site-packages/pip/_vendor/urllib3/_request_methods.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/connection.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'BaseSSLError' from 'site-packages.pip._vendor.urllib3.connection' (<tree>/site-packages/pip/_vendor/urllib3/connection.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/connectionpool.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'HTTPConnectionPool' from 'site-packages.pip._vendor.urllib3.connectionpool' (<tree>/site-packages/pip/_vendor/urllib3/connectionpool.py)"
       },
       "site-packages/pip/_vendor/urllib3/contrib/emscripten/__init__.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'js'"
       },
       "site-packages/pip/_vendor/urllib3/contrib/emscripten/connection.py": {
         "raised": "ImportError",
+        "reach": "platform",
         "reason": "raises ImportError: cannot import name 'EmscriptenHTTPConnection' from 'site-packages.pip._vendor.urllib3.contrib.emscripten.connection' (<tree>/site-packages/pip/_vendor/urllib3/contrib/emscripten/connection.py)"
       },
       "site-packages/pip/_vendor/urllib3/contrib/emscripten/fetch.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'js'"
       },
       "site-packages/pip/_vendor/urllib3/contrib/emscripten/response.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'js'"
       },
       "site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'OpenSSL'"
       },
       "site-packages/pip/_vendor/urllib3/contrib/socks.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'socks'"
-      },
-      "site-packages/pip/_vendor/urllib3/filepost.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_TYPE_FIELDS' from 'site-packages.pip._vendor.urllib3.filepost' (<tree>/site-packages/pip/_vendor/urllib3/filepost.py)"
       },
       "site-packages/pip/_vendor/urllib3/http2/connection.py": {
         "raised": "ModuleNotFoundError",
+        "reach": "absent",
         "reason": "raises ModuleNotFoundError: No module named 'h2'"
-      },
-      "site-packages/pip/_vendor/urllib3/poolmanager.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'PoolManager' from 'site-packages.pip._vendor.urllib3.poolmanager' (<tree>/site-packages/pip/_vendor/urllib3/poolmanager.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/response.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'BaseHTTPResponse' from 'site-packages.pip._vendor.urllib3.response' (<tree>/site-packages/pip/_vendor/urllib3/response.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/__init__.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_TYPE_SOCKET_OPTIONS' from partially initialized module 'site-packages.pip._vendor.urllib3.util.connection' (most likely due to a circular import) (<tree>/site-packages/pip/_vendor/urllib3/util/connection.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/connection.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_TYPE_SOCKET_OPTIONS' from 'site-packages.pip._vendor.urllib3.util.connection' (<tree>/site-packages/pip/_vendor/urllib3/util/connection.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/proxy.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'connection_requires_http_tunnel' from 'site-packages.pip._vendor.urllib3.util.proxy' (<tree>/site-packages/pip/_vendor/urllib3/util/proxy.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/request.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'SKIP_HEADER' from 'site-packages.pip._vendor.urllib3.util.request' (<tree>/site-packages/pip/_vendor/urllib3/util/request.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/response.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'is_fp_closed' from 'site-packages.pip._vendor.urllib3.util.response' (<tree>/site-packages/pip/_vendor/urllib3/util/response.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/retry.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Retry' from 'site-packages.pip._vendor.urllib3.util.retry' (<tree>/site-packages/pip/_vendor/urllib3/util/retry.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/ssl_.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'ALPN_PROTOCOLS' from 'site-packages.pip._vendor.urllib3.util.ssl_' (<tree>/site-packages/pip/_vendor/urllib3/util/ssl_.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/timeout.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_DEFAULT_TIMEOUT' from 'site-packages.pip._vendor.urllib3.util.timeout' (<tree>/site-packages/pip/_vendor/urllib3/util/timeout.py)"
-      },
-      "site-packages/pip/_vendor/urllib3/util/url.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name '_BRACELESS_IPV6_ADDRZ_RE' from 'site-packages.pip._vendor.urllib3.util.url' (<tree>/site-packages/pip/_vendor/urllib3/util/url.py)"
-      },
-      "tomllib/_parser.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'TOMLDecodeError' from 'tomllib._parser' (<tree>/tomllib/_parser.py)"
-      },
-      "unittest/case.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'addModuleCleanup' from 'unittest.case' (<tree>/unittest/case.py)"
-      },
-      "unittest/loader.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'TestLoader' from 'unittest.loader' (<tree>/unittest/loader.py)"
-      },
-      "unittest/main.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'TestProgram' from 'unittest.main' (<tree>/unittest/main.py)"
-      },
-      "unittest/result.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'TestResult' from 'unittest.result' (<tree>/unittest/result.py)"
-      },
-      "unittest/runner.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'TextTestRunner' from 'unittest.runner' (<tree>/unittest/runner.py)"
-      },
-      "unittest/suite.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'BaseTestSuite' from 'unittest.suite' (<tree>/unittest/suite.py)"
-      },
-      "xml/sax/xmlreader.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'InputSource' from 'xml.sax.xmlreader' (<tree>/xml/sax/xmlreader.py)"
-      },
-      "zipfile/_path/__init__.py": {
-        "raised": "ImportError",
-        "reason": "raises ImportError: cannot import name 'Path' from 'zipfile._path' (<tree>/zipfile/_path/__init__.py)"
       }
     }
   },
-  "version": 6
+  "version": 7
 }

--- a/crate/tests/imports/baseline.json
+++ b/crate/tests/imports/baseline.json
@@ -46,6 +46,7 @@
     "default": {
       "candidates": 997,
       "comparable": 978,
+      "reachable": 994,
       "flaky": 2,
       "raises": 0,
       "rebinds": 4,
@@ -151,5 +152,5 @@
       }
     }
   },
-  "version": 8
+  "version": 9
 }

--- a/crate/tests/imports/compare.rs
+++ b/crate/tests/imports/compare.rs
@@ -54,16 +54,10 @@ pub(crate) fn compare(
             (Kind::Unmeasured, _) | (_, Kind::Unmeasured) => unmeasured.push(module.clone()),
             (Kind::Ok, _) => comparable.push(module.clone()),
             _ => {
-                let left = before.get(module).map_or_else(
-                    || Blocked {
-                        raised: String::new(),
-                        reason: "the original tree was never asked".to_owned(),
-                    },
-                    |ran| Blocked {
-                        raised: ran.raised.clone(),
-                        reason: ran.error.clone(),
-                    },
-                );
+                let Some(ran) = before.get(module) else {
+                    unreachable!("invariant: a run that raised or timed out left a record")
+                };
+                let left = Blocked::of(module, &ran.raised, &ran.error);
                 uncomparable.insert(module.clone(), left);
             }
         }
@@ -155,6 +149,13 @@ pub(crate) fn divergence(formatted: &Outcome, original: &Outcome) -> Option<Dive
     })
 }
 
+/// The kind a run of one module left behind, `unmeasured` where the tree was
+/// never asked about it.
+fn kind(held: &BTreeMap<String, Outcome>, module: &str) -> Kind {
+    held.get(module)
+        .map_or(Kind::Unmeasured, |outcome| outcome.kind)
+}
+
 /// One name and however many followed it, which is the sentence a report
 /// shows rather than the key a baseline holds.
 fn named(first: &str, rest: usize) -> String {
@@ -163,11 +164,4 @@ fn named(first: &str, rest: usize) -> String {
         1 => format!("`{first}` and 1 more name"),
         _ => format!("`{first}` and {rest} more names"),
     }
-}
-
-/// The kind a run of one module left behind, `unmeasured` where the tree was
-/// never asked about it.
-fn kind(held: &BTreeMap<String, Outcome>, module: &str) -> Kind {
-    held.get(module)
-        .map_or(Kind::Unmeasured, |outcome| outcome.kind)
 }

--- a/crate/tests/imports/corpus.rs
+++ b/crate/tests/imports/corpus.rs
@@ -1,58 +1,116 @@
 //! Which modules of a corpus a sweep runs, meaning the interpreter owning
-//! the corpus, the entry points a run leaves out, and the modules a format
-//! run rewrote.
+//! the corpus and the version it reports, the entry points a run leaves out,
+//! the modules a format run rewrote, and the digest that identifies the corpus
+//! a run swept.
 
-use std::{collections::BTreeSet, path::PathBuf, process::Command};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::{common::python_files, records::Corpus};
+
+/// How many characters of the corpus digest name one sweep's corpus.
+const DIGEST_LEN: usize = 16;
 
 /// The module names a walk leaves out wherever they sit, since running
 /// either one launches a program instead of binding a namespace.
 /// `python-config.py` sits under a directory named for the platform, so
 /// matching on the name rather than the path works on every machine.
-const ENTRY_NAMES: &[&str] = &["__main__.py", "python-config.py"];
+const ENTRY_NAMES: &[&str] = &["__main__", "python-config"];
 
 /// The modules a walk leaves out by their full path, so a module of the
 /// same name deeper in the tree stays in.
-const ENTRY_POINTS: &[&str] = &["antigravity.py", "idlelib/idle.py", "webbrowser.py"];
+const ENTRY_POINTS: &[&str] = &["antigravity", "idlelib/idle", "webbrowser"];
 
 /// The directories a walk leaves out wholesale.
 const ENTRY_TREES: &[&str] = &["idle_test", "test", "tests", "turtledemo"];
 
-/// The modules a sweep runs, which is every module the format run rewrote
-/// outside the entry points, sorted.
+/// The modules a sweep runs, which is every importable module the format
+/// run rewrote outside the entry points, sorted.
 pub(crate) fn candidates(rewritten: &BTreeSet<String>) -> Vec<String> {
     rewritten
         .iter()
-        .filter(|relative| !excluded(relative))
+        .filter(|relative| importable(relative) && !excluded(relative))
         .cloned()
         .collect()
 }
 
 /// Reports whether a module is an entry point rather than a library module.
+/// The name is matched with its extension removed, so `idlelib/idle.pyw` is
+/// excluded along with `idlelib/idle.py`. Every path the walk yields carries an
+/// extension, and both callers pass one.
 pub(crate) fn excluded(relative: &str) -> bool {
-    let (directories, last) = relative.rsplit_once('/').unwrap_or(("", relative));
+    let stem = relative.rsplit_once('.').map_or(relative, |(stem, _)| stem);
+    let (directories, last) = stem.rsplit_once('/').unwrap_or(("", stem));
     ENTRY_NAMES.contains(&last)
-        || ENTRY_POINTS.contains(&relative)
+        || ENTRY_POINTS.contains(&stem)
         || directories
             .split('/')
             .any(|part| ENTRY_TREES.contains(&part))
 }
 
+/// Digests the corpus at `root` into an identity, reading each swept file's
+/// path and bytes in sorted order and framing both behind their own length, so
+/// a file that moves, changes, or arrives changes the digest.
+pub(crate) fn identity(root: &Path, interpreter: &str) -> Corpus {
+    let files: BTreeSet<_> = python_files(root).collect();
+    let mut hasher = blake3::Hasher::new();
+    for path in &files {
+        let relative = path.strip_prefix(root).unwrap_or(path);
+        framed(&mut hasher, relative.to_string_lossy().as_bytes());
+        framed(&mut hasher, &fs_err::read(path).unwrap_or_default());
+    }
+    Corpus {
+        digest: hasher.finalize().to_hex()[..DIGEST_LEN].to_owned(),
+        files: files.len(),
+        interpreter: interpreter.to_owned(),
+    }
+}
+
+/// Reports whether a file names a module an import can bind. A `.pyw`
+/// script and a `.pyi` stub both carry Python the formatter rewrites without
+/// naming an importable module, so the walk formats them and this run leaves
+/// them out.
+pub(crate) fn importable(relative: &str) -> bool {
+    relative.ends_with(".py")
+}
+
 /// Asks an interpreter which standard library it owns.
 pub(crate) fn standard_library(python: &str) -> PathBuf {
-    let asked = Command::new(python)
-        .args([
-            "-I",
-            "-c",
-            "import sysconfig; print(sysconfig.get_paths()['stdlib'])",
-        ])
+    PathBuf::from(asked(
+        python,
+        "import sysconfig; print(sysconfig.get_paths()['stdlib'])",
+    ))
+    .canonicalize()
+    .expect("the interpreter names a standard library")
+}
+
+/// The version the interpreter at `python` reports.
+pub(crate) fn version(python: &str) -> String {
+    asked(python, "import sys; print(sys.version.split()[0])")
+}
+
+/// What `python` prints for `code`, trimmed. Panics if the interpreter does not
+/// run or the snippet fails.
+fn asked(python: &str, code: &str) -> String {
+    let ran = Command::new(python)
+        .args(["-I", "-c", code])
         .output()
         .unwrap_or_else(|error| panic!("{python} does not run: {error}"));
     assert!(
-        asked.status.success(),
+        ran.status.success(),
         "{python} does not run: {}",
-        String::from_utf8_lossy(&asked.stderr).trim()
+        String::from_utf8_lossy(&ran.stderr).trim()
     );
-    PathBuf::from(String::from_utf8_lossy(&asked.stdout).trim())
-        .canonicalize()
-        .expect("the interpreter names a standard library")
+    String::from_utf8_lossy(&ran.stdout).trim().to_owned()
+}
+
+/// Feeds `bytes` to the digest behind its own length, so two fields cannot run
+/// together and read as one.
+fn framed(hasher: &mut blake3::Hasher, bytes: &[u8]) {
+    let len = u64::try_from(bytes.len()).expect("a corpus file's length fits a u64");
+    hasher.update(&len.to_le_bytes());
+    hasher.update(bytes);
 }

--- a/crate/tests/imports/main.rs
+++ b/crate/tests/imports/main.rs
@@ -28,9 +28,9 @@ use std::{collections::BTreeSet, iter, num::NonZeroUsize};
 
 use crate::{
     common::{setting, watch_for_a_runaway, widths_or},
-    corpus::standard_library,
+    corpus::{identity, standard_library, version},
     execute::interpreter,
-    ratchet::{bake, baking, baseline, dropped, judge, regressions, stale},
+    ratchet::{bake, baking, baseline, dropped, judge, moved, regressions, stale},
     report::render,
     sweep::{MODULE_VAR, Sweep},
 };
@@ -53,11 +53,15 @@ fn every_rewritten_module_still_imports() {
          carries",
     );
     let held = baked.is_none().then(baseline).unwrap_or_default();
+    let swept = identity(&corpus, &version(&python));
     let budgets = iter::once(None).chain(widths_or(&[]).into_iter().map(NonZeroUsize::new));
     let sweep = Sweep::new(&corpus);
     eprintln!(
-        "corpus      {}\nbinary      the library under test\ninterpreter {python}\nstage       {}",
+        "corpus      {} ({} files, digest {})\nbinary      the library under test\ninterpreter \
+         {python}\nstage       {}",
         corpus.display(),
+        swept.files,
+        swept.digest,
         sweep.runner.stage.root.display(),
     );
     let widths: Vec<_> = budgets.map(|width| sweep.sweep(width)).collect();
@@ -74,6 +78,13 @@ fn every_rewritten_module_still_imports() {
         fresh.extend(found.uncarried(&carried).map(|brk| brk.module.clone()));
     }
     let unmeasured: usize = widths.iter().map(|found| found.unmeasured.len()).sum();
+    if let Some(drift) = moved(&swept, &held) {
+        sweep.runner.stage.keep();
+        panic!(
+            "the corpus moved since the break set was baked, at {drift}, so the counts \
+             below it were measured against a tree the set never swept",
+        );
+    }
     if unmeasured > 0 {
         sweep.runner.stage.keep();
     }
@@ -83,7 +94,7 @@ fn every_rewritten_module_still_imports() {
          be named",
     );
     if let Some(path) = baked {
-        bake(&path, &widths);
+        bake(&path, &swept, &widths);
         eprintln!("break set baked into {}", path.display());
         return;
     }

--- a/crate/tests/imports/probe.py
+++ b/crate/tests/imports/probe.py
@@ -3,9 +3,10 @@ Load one module the way an import loads it and report what it bound.
 
 Usage: probe.py <record> <name> <module> <tree>...
 
-An import here loads the interpreter's own copy into `sys.modules` ahead of
-the tree's, so the probe imports nothing that is not already loaded before
-it runs.
+An import at this level loads the interpreter's own copy into `sys.modules`
+ahead of the tree's, so the probe imports nothing beyond what is already
+loaded when it runs. `Probe.package` imports after `sys.path` puts the trees
+first, so its import resolves against the tree.
 """
 
 from _frozen_importlib          import module_from_spec
@@ -63,6 +64,8 @@ class Probe:
         """
         Execute the module, then record what it bound and what it pulled in.
         """
+        self.package()
+
         spec               = spec_from_file_location(self.name, self.located)
         module             = module_from_spec(spec)
         modules[self.name] = module
@@ -79,6 +82,21 @@ class Probe:
             for held in list(modules.values())
             if getattr(held, "__file__", None)
         ]
+
+    def package(self):
+        """
+        Import the package the module sits in, so a package whose
+        `__init__` reads the module reaches a bound one rather than the
+        empty module this probe is about to register under that name. A
+        package that raises leaves the module's own run to record it.
+        """
+        held, _, _ = self.name.rpartition(".")
+
+        if held:
+            try:
+                __import__(held)
+            except BaseException:
+                pass
 
     def raised(self, exc: BaseException):
         """

--- a/crate/tests/imports/ratchet.rs
+++ b/crate/tests/imports/ratchet.rs
@@ -26,7 +26,7 @@ const BAKE_VAR: &str = "PROSE_IMPORTS_BAKE";
 
 /// The generation a baked set is written and read at, raised by every
 /// change to what a set carries or to the key that holds one break.
-pub(crate) const VERSION: u32 = 8;
+pub(crate) const VERSION: u32 = 9;
 
 /// What one run recorded for a later run to ratchet against, the breaks
 /// it left beside the modules it could not compare, each keyed by width
@@ -85,6 +85,10 @@ pub(crate) struct Counts {
     pub(crate) candidates: usize,
     /// How many of those the original tree ran cleanly.
     pub(crate) comparable: usize,
+    /// How many this machine could reach, which is a floor where
+    /// `comparable` is a figure, since a module bound to another platform
+    /// moves the second and holds the first.
+    pub(crate) reachable: usize,
     /// How many modules a run set aside because two runs of the original
     /// bound different namespaces.
     pub(crate) flaky: usize,
@@ -101,6 +105,7 @@ impl From<&Width> for Counts {
         Self {
             candidates: found.candidates,
             comparable: found.comparable,
+            reachable: found.reachable(),
             flaky: found.flaky.len(),
             raises: found.unimported(),
             rebinds: found.counting(Kind::Ok),
@@ -212,15 +217,16 @@ pub(crate) fn regressions(found: &Width, held: &Baseline) -> Vec<String> {
     };
     let Counts {
         candidates,
-        comparable,
+        comparable: _,
         flaky,
         raises,
+        reachable,
         rebinds,
         refused,
     } = Counts::from(found);
     let short = [
         ("candidates", candidates, baked.candidates),
-        ("comparable", comparable, baked.comparable),
+        ("reachable", reachable, baked.reachable),
     ]
     .into_iter()
     .filter(|(_, reached, want)| reached < want);

--- a/crate/tests/imports/ratchet.rs
+++ b/crate/tests/imports/ratchet.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     common::setting,
     outcome::Kind,
-    records::{Blocked, Break, Width},
+    records::{Blocked, Break, Corpus, Width},
 };
 
 /// The break set the repository tracks beside the harness, which every
@@ -24,13 +24,9 @@ const BAKED: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/imports/baseline
 /// The environment variable naming a file the break set is written to.
 const BAKE_VAR: &str = "PROSE_IMPORTS_BAKE";
 
-/// The exception a module raises where the machine lacks a package or a
-/// platform module it imports.
-const ABSENT: &str = "ModuleNotFoundError";
-
 /// The generation a baked set is written and read at, raised by every
 /// change to what a set carries or to the key that holds one break.
-pub(crate) const VERSION: u32 = 6;
+pub(crate) const VERSION: u32 = 7;
 
 /// What one run recorded for a later run to ratchet against, the breaks
 /// it left beside the modules it could not compare, each keyed by width
@@ -40,6 +36,10 @@ pub(crate) const VERSION: u32 = 6;
 pub(crate) struct Baseline {
     /// The breaks a run left at each frame.
     pub(crate) breaks: BTreeMap<String, BTreeSet<Carried>>,
+    /// The corpus the run swept, which a later run compares its own against,
+    /// so a corpus that changed is reported as that rather than as counts
+    /// that no longer add up.
+    pub(crate) corpus: Corpus,
     /// What each width counted, which a later run measures itself
     /// against so a corpus that shrinks or a defect class that grows
     /// fails rather than passing.
@@ -105,12 +105,13 @@ impl From<&Width> for Counts {
 }
 
 /// Writes the break set of a run, for a later run to ratchet against.
-pub(crate) fn bake(path: &Path, widths: &[Width]) {
+pub(crate) fn bake(path: &Path, corpus: &Corpus, widths: &[Width]) {
     if let Some(parent) = path.parent() {
         fs_err::create_dir_all(parent).expect("create the break set's directory");
     }
     let baked = Baseline {
         breaks: keyed(widths, |found| found.breaks.iter().map(carried).collect()),
+        corpus: corpus.clone(),
         counts: widths
             .iter()
             .map(|found| (found.label.clone(), Counts::from(found)))
@@ -153,10 +154,11 @@ pub(crate) fn baseline_at(path: &Path) -> Option<Baseline> {
 
 /// The modules of one width that the original tree no longer runs cleanly
 /// and the baseline does not already list, meaning coverage the sweep just
-/// lost. A module raising [`ABSENT`] is left out, which trades this check
-/// for the `comparable` floor on that module, since a machine missing a
-/// package it imports drops it here on every run. A baseline recording
-/// nothing at this width has no coverage to lose, so it names none.
+/// lost. A module this machine cannot reach is left out, because a machine
+/// lacking a package it imports or running another platform drops that module
+/// on every run, and the `comparable` floor is what covers it instead. A
+/// baseline recording nothing at this width has no coverage to lose, so it
+/// names none.
 pub(crate) fn dropped(found: &Width, held: &Baseline) -> BTreeSet<String> {
     let Some(known) = held.uncomparable.get(&found.label) else {
         return BTreeSet::new();
@@ -164,7 +166,7 @@ pub(crate) fn dropped(found: &Width, held: &Baseline) -> BTreeSet<String> {
     found
         .uncomparable
         .iter()
-        .filter(|(module, left)| !known.contains_key(*module) && left.raised != ABSENT)
+        .filter(|(module, left)| !known.contains_key(*module) && left.reach.reachable())
         .map(|(module, _)| module.clone())
         .collect()
 }
@@ -197,6 +199,21 @@ pub(crate) fn stale(found: &Width, held: &Baseline) -> BTreeSet<String> {
         .difference(&reproduced)
         .map(|entry| entry.module.clone())
         .collect()
+}
+
+/// How the corpus this run swept differs from the one the baseline
+/// records, `None` where the two match. A baseline that records no corpus has
+/// nothing to differ from, so a set baked before the corpus was tracked reads
+/// as unmoved.
+pub(crate) fn moved(swept: &Corpus, held: &Baseline) -> Option<String> {
+    let baked = &held.corpus;
+    if *baked == Corpus::default() || baked == swept {
+        return None;
+    }
+    Some(format!(
+        "interpreter {} against {} baked, {} files against {}, digest {} against {}",
+        swept.interpreter, baked.interpreter, swept.files, baked.files, swept.digest, baked.digest,
+    ))
 }
 
 /// How one width moved the wrong way against the counts the baseline

--- a/crate/tests/imports/records.rs
+++ b/crate/tests/imports/records.rs
@@ -1,9 +1,10 @@
 //! The records one sweep leaves, meaning a module the rewrite breaks, the
-//! frame it points at, one edit of a recorded fix, and one width's tallies
-//! and findings.
+//! frame it points at, one edit of a recorded fix, why a module could not be
+//! compared, one width's tallies and findings, and the corpus the run read.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fmt::{self, Display, Formatter},
     ops::Range,
 };
 
@@ -11,6 +12,42 @@ use prose::rules::RuleId;
 use serde::{Deserialize, Serialize};
 
 use crate::outcome::{Kind, Outcome};
+
+/// The exception a module raises where the machine lacks a package it
+/// imports.
+const ABSENT: &str = "ModuleNotFoundError";
+
+/// The platform tokens that appear in the path of a module written for another
+/// operating system. Such a module's own error message often does not name the
+/// platform, so the path is what identifies it.
+const PLATFORMS: &[&str] = &["emscripten", "win32", "windows"];
+
+/// What one uncomparable module's own run left, the exception it named
+/// beside the sentence a report shows, so a later read matches the
+/// exception rather than searching the sentence for it, and the reach saying
+/// how far this machine gets with the module.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default)]
+pub(crate) struct Blocked {
+    /// The exception the run named, empty where it named none.
+    pub(crate) raised: String,
+    /// How far a run on this machine reaches the module.
+    pub(crate) reach: Reach,
+    /// The sentence a report shows.
+    pub(crate) reason: String,
+}
+
+impl Blocked {
+    /// What blocked the module at `relative`, whose run raised `raised`
+    /// and reads as `reason`.
+    pub(crate) fn of(relative: &str, raised: &str, reason: &str) -> Self {
+        Self {
+            raised: raised.to_owned(),
+            reach: Reach::of(relative, raised),
+            reason: reason.to_owned(),
+        }
+    }
+}
 
 /// A module the rewrite breaks.
 pub(crate) struct Break {
@@ -48,6 +85,20 @@ impl Break {
     }
 }
 
+/// What one run swept, naming the interpreter that owns the corpus beside
+/// a digest over every file the walk read, so a corpus that moved between
+/// two runs is reported as that, rather than as counts that no longer add up.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(default)]
+pub(crate) struct Corpus {
+    /// The digest over every swept file's path and bytes.
+    pub(crate) digest: String,
+    /// How many files the walk read.
+    pub(crate) files: usize,
+    /// The version of the interpreter the corpus belongs to.
+    pub(crate) interpreter: String,
+}
+
 /// One edit of a recorded fix, as the span it rewrote and the text it wrote.
 pub(crate) struct EditRows {
     /// The text the edit wrote.
@@ -61,18 +112,6 @@ pub(crate) struct EditRows {
 /// The safe fixes one format run recorded, keyed by the file each rewrote.
 pub(crate) type Fixes = BTreeMap<String, Vec<(RuleId, Vec<EditRows>)>>;
 
-/// What one uncomparable module's own run left, the exception it named
-/// beside the sentence a report shows, so a later read matches the
-/// exception rather than searching the sentence for it.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(default)]
-pub(crate) struct Blocked {
-    /// The exception the run named, empty where it named none.
-    pub(crate) raised: String,
-    /// The sentence a report shows.
-    pub(crate) reason: String,
-}
-
 /// The file and row a break points at.
 #[derive(Clone, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct Frame {
@@ -80,6 +119,52 @@ pub(crate) struct Frame {
     pub(crate) file: String,
     /// The row it names, where the traceback gave one.
     pub(crate) row: Option<usize>,
+}
+
+/// How far a run on this machine gets with a module the sweep could not
+/// compare. It separates the modules nothing here could import from the ones
+/// that fail on their own terms.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Reach {
+    /// The module imports a package this machine does not carry.
+    Absent,
+    /// The module runs here and fails on its own terms.
+    #[default]
+    Module,
+    /// The module is written for another platform.
+    Platform,
+}
+
+impl Reach {
+    /// The reach of the module at `relative`, whose run raised `raised`. The
+    /// exception is read first and the path second, since a module written for
+    /// another platform often raises an error that does not name one.
+    pub(crate) fn of(relative: &str, raised: &str) -> Self {
+        if raised == ABSENT {
+            Self::Absent
+        } else if PLATFORMS.iter().any(|token| relative.contains(token)) {
+            Self::Platform
+        } else {
+            Self::Module
+        }
+    }
+
+    /// Reports whether a run here reaches the module at all. One naming an
+    /// absent package or another platform does not.
+    pub(crate) const fn reachable(self) -> bool {
+        matches!(self, Self::Module)
+    }
+}
+
+impl Display for Reach {
+    fn fmt(&self, form: &mut Formatter<'_>) -> fmt::Result {
+        form.write_str(match self {
+            Self::Absent => "absent",
+            Self::Module => "module",
+            Self::Platform => "platform",
+        })
+    }
 }
 
 /// One width's tallies and findings.
@@ -113,6 +198,19 @@ impl Width {
             .iter()
             .filter(|brk| brk.formatted.kind == kind)
             .count()
+    }
+
+    /// How this width's uncomparable modules divide by reach, each class
+    /// paired with its count, in the order a report names them.
+    pub(crate) fn reaches(&self) -> [(Reach, usize); 3] {
+        [Reach::Absent, Reach::Platform, Reach::Module].map(|reach| {
+            let counted = self
+                .uncomparable
+                .values()
+                .filter(|left| left.reach == reach)
+                .count();
+            (reach, counted)
+        })
     }
 
     /// The breaks at this width the baseline does not already hold.

--- a/crate/tests/imports/records.rs
+++ b/crate/tests/imports/records.rs
@@ -20,7 +20,7 @@ const ABSENT: &str = "ModuleNotFoundError";
 /// The platform tokens that appear in the path of a module written for another
 /// operating system. Such a module's own error message often does not name the
 /// platform, so the path is what identifies it.
-const PLATFORMS: &[&str] = &["emscripten", "win32", "windows"];
+const PLATFORMS: &[&str] = &["darwin", "emscripten", "macos", "win32", "windows"];
 
 /// What one uncomparable module's own run left, the exception it named
 /// beside the sentence a report shows, so a later read matches the
@@ -215,6 +215,19 @@ impl Width {
                 .count();
             (reach, counted)
         })
+    }
+
+    /// How many modules this machine could reach, being the ones it compared
+    /// beside the ones no run here could import. A module bound to another
+    /// platform or naming an absent package holds this count where it moves
+    /// `comparable`, so the floor reads the same on every machine.
+    pub(crate) fn reachable(&self) -> usize {
+        let unreachable = self
+            .uncomparable
+            .values()
+            .filter(|left| !left.reach.reachable())
+            .count();
+        self.comparable + unreachable
     }
 
     /// The breaks at this width the baseline does not already hold.

--- a/crate/tests/imports/report.rs
+++ b/crate/tests/imports/report.rs
@@ -45,6 +45,18 @@ pub(crate) fn render(carried: &BTreeSet<String>, found: &Width) -> String {
         lines.push(row("refused", &found.refused));
     }
     let mut rendered = lines.join("\n");
+    if !found.uncomparable.is_empty() {
+        let split = found
+            .reaches()
+            .iter()
+            .map(|(reach, counted)| format!("{counted} {reach}"))
+            .join(", ");
+        let _ = write!(
+            rendered,
+            "\n\nuncomparable by reach ({}):\n  {split}",
+            found.uncomparable.len(),
+        );
+    }
     rendered.push_str(&raising.render("raises"));
     rendered.push_str(&rebinding.render("runs and binds a different namespace"));
     rendered.push_str(&timeouts.render("times out"));

--- a/crate/tests/imports/sweep.rs
+++ b/crate/tests/imports/sweep.rs
@@ -16,7 +16,7 @@ use crate::{
     attribution::Attributor,
     common::setting,
     compare::{compare, divergence},
-    corpus::candidates,
+    corpus::{candidates, excluded, importable},
     execute::Runner,
     format::format_tree,
     outcome::{Kind, Outcome},
@@ -124,8 +124,17 @@ impl Sweep {
         let formatted = self.runner.stage.copy(&format!("formatted-{label}"));
         let run = format_tree(&formatted, &Pipeline::with_defaults(&config));
         self.runner.precompile(&formatted);
-        let modules =
-            setting(MODULE_VAR).map_or_else(|| candidates(&run.rewritten), |only| vec![only]);
+        let modules = setting(MODULE_VAR).map_or_else(
+            || candidates(&run.rewritten),
+            |only| {
+                assert!(
+                    importable(&only) && !excluded(&only),
+                    "{MODULE_VAR} names {only}, which the sweep never runs, because it is an \
+                     entry point or names no module an import can bind",
+                );
+                vec![only]
+            },
+        );
         let after = self.outcomes(&modules, &formatted);
         let before = self.originals(&modules);
         let partition = compare(&after, &before, &modules);

--- a/crate/tests/imports/tests/corpus.rs
+++ b/crate/tests/imports/tests/corpus.rs
@@ -1,9 +1,16 @@
 //! Tests for which modules of a corpus a sweep runs, covering the entry
-//! points the walk leaves out.
+//! points the walk leaves out, the files that name no importable module,
+//! and the identity a run digests its corpus into.
 
 use rstest::rstest;
 
-use crate::corpus::{candidates, excluded};
+use crate::corpus::{candidates, excluded, identity, importable, version};
+
+#[test]
+#[should_panic(expected = "does not run")]
+fn an_interpreter_that_does_not_run_names_itself() {
+    version("/nonexistent/python");
+}
 
 #[test]
 fn candidates_drop_the_entry_points_from_the_rewritten_set() {
@@ -11,6 +18,14 @@ fn candidates_drop_the_entry_points_from_the_rewritten_set() {
         .map(str::to_owned)
         .into();
     assert_eq!(candidates(&rewritten), ["os.py", "re/_parser.py"]);
+}
+
+#[test]
+fn candidates_drop_the_files_naming_no_importable_module() {
+    let rewritten = ["idlelib/idle.pyw", "os.py", "typing.pyi"]
+        .map(str::to_owned)
+        .into();
+    assert_eq!(candidates(&rewritten), ["os.py"]);
 }
 
 #[rstest]
@@ -24,6 +39,7 @@ fn entry_points_leave_the_walk(
         "turtledemo/x.py",
         "antigravity.py",
         "idlelib/idle.py",
+        "idlelib/idle.pyw",
         "webbrowser.py",
         "config-3.14-darwin/python-config.py",
         "config-3.14-x86_64-linux-gnu/python-config.py"
@@ -31,6 +47,45 @@ fn entry_points_leave_the_walk(
     relative: &str,
 ) {
     assert!(excluded(relative));
+}
+
+#[test]
+fn identity_moves_with_every_file_the_widened_walk_reads() {
+    let dir = tempfile::tempdir().expect("a scratch directory");
+    let root = dir.path();
+    let write = |name: &str, text: &str| {
+        fs_err::write(root.join(name), text).expect("write a corpus file");
+    };
+    write("mod.py", "x = 1\n");
+    write("notes.txt", "left out\n");
+    write("book.ipynb", "{}\n");
+    let bare = identity(root, "3.14.6");
+    assert_eq!(bare.files, 1);
+    write("script.pyw", "y = 2\n");
+    write("stub.pyi", "z: int\n");
+    let widened = identity(root, "3.14.6");
+    assert_eq!(widened.files, 3);
+    assert_ne!(widened.digest, bare.digest);
+    assert_eq!(identity(root, "3.14.6").digest, widened.digest);
+    write("mod.py", "x = 2\n");
+    let edited = identity(root, "3.14.6");
+    assert_eq!(edited.files, 3);
+    assert_ne!(edited.digest, widened.digest);
+    assert_eq!(edited.interpreter, "3.14.6");
+}
+
+#[rstest]
+fn importable_names_only_the_files_an_import_can_bind(
+    #[values("os.py", "a/b.py", "pkg/__init__.py")] relative: &str,
+) {
+    assert!(importable(relative));
+}
+
+#[rstest]
+fn importable_rejects_the_files_that_name_no_module(
+    #[values("idlelib/idle.pyw", "typing.pyi", "notes.txt", "data.ipynb")] relative: &str,
+) {
+    assert!(!importable(relative));
 }
 
 #[rstest]

--- a/crate/tests/imports/tests/mod.rs
+++ b/crate/tests/imports/tests/mod.rs
@@ -7,7 +7,8 @@ use std::collections::BTreeMap;
 
 use crate::{
     outcome::Outcome,
-    records::{Blocked, Break, Frame},
+    records::{Blocked, Break, Frame, Width},
+    sweep::DEFAULT_LABEL,
 };
 
 mod bindings;
@@ -20,31 +21,10 @@ mod ratchet;
 mod records;
 mod report;
 
-/// A module the original tree did not run cleanly, whose run raised
-/// `raised` and reads as `reason`.
-fn blocked(raised: &str, reason: &str) -> Blocked {
-    Blocked {
-        raised: raised.to_owned(),
-        reason: reason.to_owned(),
-    }
-}
-
-/// A break at `frame` for `module`, losing `name` and nothing else.
-fn losing(module: &str, frame: &str, name: &str) -> Break {
-    Break {
-        names: vec![name.to_owned()],
-        ..broken(module, frame, &format!("leaves `{name}` unbound"))
-    }
-}
-
-/// The uncomparable map holding each of `modules`, every one raising a
-/// plain `ImportError`, which is the shape a case reaches for wherever
-/// only the module name carries the assertion.
-fn stalled<const N: usize>(modules: [&str; N]) -> BTreeMap<String, Blocked> {
-    modules
-        .iter()
-        .map(|module| ((*module).to_owned(), blocked("ImportError", "raises")))
-        .collect()
+/// The uncomparable entry for the module at `relative`, whose run raised
+/// `raised`.
+fn blocked(relative: &str, raised: &str) -> (String, Blocked) {
+    (relative.to_owned(), Blocked::of(relative, raised, "raises"))
 }
 
 /// A break at `frame` for `module`, diverging for `reason`.
@@ -63,5 +43,32 @@ fn broken(module: &str, frame: &str, reason: &str) -> Break {
         names: Vec::new(),
         original: Outcome::default(),
         reason: reason.to_owned(),
+    }
+}
+
+/// A break at `frame` for `module`, losing `name` and nothing else.
+fn losing(module: &str, frame: &str, name: &str) -> Break {
+    Break {
+        names: vec![name.to_owned()],
+        ..broken(module, frame, &format!("leaves `{name}` unbound"))
+    }
+}
+
+/// The uncomparable map holding each of `modules`, every one raising a
+/// plain `ImportError`, which is the shape a case reaches for wherever
+/// only the module name carries the assertion.
+fn stalled<const N: usize>(modules: [&str; N]) -> BTreeMap<String, Blocked> {
+    modules
+        .iter()
+        .map(|&module| blocked(module, "ImportError"))
+        .collect()
+}
+
+/// A width at the default label holding `uncomparable` and nothing else.
+fn stalling(uncomparable: BTreeMap<String, Blocked>) -> Width {
+    Width {
+        label: DEFAULT_LABEL.to_owned(),
+        uncomparable,
+        ..Width::default()
     }
 }

--- a/crate/tests/imports/tests/ratchet.rs
+++ b/crate/tests/imports/tests/ratchet.rs
@@ -214,6 +214,7 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
                 comparable: 898,
                 flaky: 2,
                 raises: 0,
+                reachable: 900,
                 rebinds: 0,
                 refused: 0,
             },
@@ -232,14 +233,20 @@ fn regressions_name_every_count_that_moved_the_wrong_way() {
         regressions(&short, &held),
         [
             "candidates 900 against 997 baked",
-            "comparable 800 against 898 baked",
+            "reachable 800 against 900 baked",
             "flaky 3 against 2 baked",
             "refused 2 against 0 baked",
         ]
     );
     let reached = Width {
         candidates: 997,
-        comparable: 900,
+        comparable: 897,
+        uncomparable: [
+            blocked("dbm/gnu.py", "ModuleNotFoundError"),
+            blocked("asyncio/windows_events.py", "ImportError"),
+            blocked("truststore/_macos.py", "ImportError"),
+        ]
+        .into(),
         ..width()
     };
     assert_eq!(regressions(&reached, &held), Vec::<String>::new());

--- a/crate/tests/imports/tests/ratchet.rs
+++ b/crate/tests/imports/tests/ratchet.rs
@@ -4,13 +4,15 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use rstest::rstest;
+
 use super::*;
 use crate::{
     ratchet::{
-        Baseline, Carried, Counts, VERSION, bake, baseline, baseline_at, dropped, judge,
+        Baseline, Carried, Counts, VERSION, bake, baseline, baseline_at, dropped, judge, moved,
         regressions, stale,
     },
-    records::{Blocked, Width},
+    records::{Blocked, Corpus, Width},
     sweep::DEFAULT_LABEL,
 };
 
@@ -33,12 +35,13 @@ fn recording(uncomparable: BTreeMap<String, Blocked>) -> Baseline {
     }
 }
 
-/// A width at the default label holding `uncomparable` and nothing else.
-fn stalling(uncomparable: BTreeMap<String, Blocked>) -> Width {
-    Width {
-        label: DEFAULT_LABEL.to_owned(),
-        uncomparable,
-        ..Width::default()
+/// The corpus a baking test records, standing in for the tree a real run
+/// digests.
+fn swept() -> Corpus {
+    Corpus {
+        digest: "0123456789abcdef".to_owned(),
+        files: 3,
+        interpreter: "3.14.6".to_owned(),
     }
 }
 
@@ -52,7 +55,7 @@ fn a_baked_break_set_reads_back_as_the_set_that_wrote_it() {
     };
     let dir = tempfile::tempdir().expect("a scratch directory");
     let baked = dir.path().join("fresh").join("baseline.json");
-    bake(&baked, &[found]);
+    bake(&baked, &swept(), &[found]);
     let held: Baseline = serde_json::from_str(
         &fs_err::read_to_string(&baked).expect("the baked break set reads back"),
     )
@@ -61,6 +64,7 @@ fn a_baked_break_set_reads_back_as_the_set_that_wrote_it() {
         held.breaks[DEFAULT_LABEL],
         [carried("m.py", "re/_parser.py", "X")].into()
     );
+    assert_eq!(held.corpus, swept());
     assert_eq!(held.uncomparable[DEFAULT_LABEL], stalled(["blocked.py"]));
     assert_eq!(held.version, VERSION);
 }
@@ -106,21 +110,18 @@ fn dropped_names_nothing_for_a_package_the_machine_lacks() {
         [
             (
                 "absent.py".to_owned(),
-                blocked(
+                Blocked::of(
+                    "absent.py",
                     "ModuleNotFoundError",
                     "raises ModuleNotFoundError: No module named 'socks'",
                 ),
             ),
             (
                 "lost.py".to_owned(),
-                blocked("ImportError", "raises ImportError: no thing"),
+                Blocked::of("lost.py", "ImportError", "raises ImportError: no thing"),
             ),
         ]
         .into(),
-    );
-    assert_eq!(
-        dropped(&found, &Baseline::default()),
-        BTreeSet::<String>::new()
     );
     assert_eq!(
         dropped(&found, &recording(BTreeMap::new())),
@@ -129,19 +130,26 @@ fn dropped_names_nothing_for_a_package_the_machine_lacks() {
 }
 
 #[test]
+fn dropped_names_nothing_where_the_baseline_records_no_width() {
+    let found = stalling(stalled(["blocked.py"]));
+    assert_eq!(dropped(&found, &Baseline::default()), BTreeSet::new());
+}
+
+#[test]
 fn dropped_reads_the_exception_a_run_named_rather_than_its_sentence() {
     let found = stalling(
         [
             (
                 "quoting.py".to_owned(),
-                blocked(
+                Blocked::of(
+                    "quoting.py",
                     "ImportError",
                     "raises ImportError: ModuleNotFoundError is not it",
                 ),
             ),
             (
                 "silent.py".to_owned(),
-                blocked("ModuleNotFoundError", "the machine lacks it"),
+                Blocked::of("silent.py", "ModuleNotFoundError", "the machine lacks it"),
             ),
         ]
         .into(),
@@ -153,9 +161,31 @@ fn dropped_reads_the_exception_a_run_named_rather_than_its_sentence() {
 }
 
 #[test]
-fn dropped_names_nothing_where_the_baseline_records_no_width() {
-    let found = stalling(stalled(["blocked.py"]));
-    assert_eq!(dropped(&found, &Baseline::default()), BTreeSet::new());
+fn moved_names_nothing_where_the_baseline_records_no_corpus() {
+    assert_eq!(moved(&swept(), &Baseline::default()), None);
+}
+
+#[test]
+fn moved_names_nothing_where_the_corpus_still_matches() {
+    let held = Baseline {
+        corpus: swept(),
+        ..Baseline::default()
+    };
+    assert_eq!(moved(&swept(), &held), None);
+}
+
+#[rstest]
+#[case(Corpus { digest: "fedcba9876543210".to_owned(), ..swept() }, "fedcba9876543210")]
+#[case(Corpus { files: 4, ..swept() }, "4 files")]
+#[case(Corpus { interpreter: "3.14.7".to_owned(), ..swept() }, "3.14.7")]
+fn moved_names_the_corpus_on_either_side(#[case] found: Corpus, #[case] named: &str) {
+    let held = Baseline {
+        corpus: swept(),
+        ..Baseline::default()
+    };
+    let drift = moved(&found, &held).expect("a corpus that moved names the drift");
+    assert!(drift.contains(named), "{drift}");
+    assert!(drift.contains(&swept().digest), "{drift}");
 }
 
 #[test]
@@ -212,26 +242,6 @@ fn regressions_name_nothing_where_the_baseline_records_no_counts() {
 }
 
 #[test]
-fn the_ratchet_carries_a_break_the_baseline_holds_at_the_same_width() {
-    let found = Width {
-        breaks: vec![losing("m.py", "re/_parser.py", "X")],
-        ..stalling(BTreeMap::new())
-    };
-    let held = Baseline {
-        breaks: [(
-            DEFAULT_LABEL.to_owned(),
-            [carried("m.py", "re/_parser.py", "X")].into(),
-        )]
-        .into(),
-        version: VERSION,
-        ..recording(stalled(["a.py"]))
-    };
-    assert_eq!(judge(&found, &held), ["m.py".to_owned()].into());
-    assert_eq!(judge(&found, &Baseline::default()), BTreeSet::new());
-    assert_eq!(held.uncomparable[DEFAULT_LABEL], stalled(["a.py"]));
-}
-
-#[test]
 fn stale_names_a_baked_break_the_run_no_longer_reproduces() {
     let held = Baseline {
         breaks: [(
@@ -271,6 +281,26 @@ fn stale_names_a_break_whose_names_changed_under_one_module() {
 }
 
 #[test]
+fn the_ratchet_carries_a_break_the_baseline_holds_at_the_same_width() {
+    let found = Width {
+        breaks: vec![losing("m.py", "re/_parser.py", "X")],
+        ..stalling(BTreeMap::new())
+    };
+    let held = Baseline {
+        breaks: [(
+            DEFAULT_LABEL.to_owned(),
+            [carried("m.py", "re/_parser.py", "X")].into(),
+        )]
+        .into(),
+        version: VERSION,
+        ..recording(stalled(["a.py"]))
+    };
+    assert_eq!(judge(&found, &held), ["m.py".to_owned()].into());
+    assert_eq!(judge(&found, &Baseline::default()), BTreeSet::new());
+    assert_eq!(held.uncomparable[DEFAULT_LABEL], stalled(["a.py"]));
+}
+
+#[test]
 fn the_tracked_break_set_reads_back_at_the_current_generation() {
     let held = baseline();
     assert_eq!(held.version, VERSION);
@@ -290,7 +320,7 @@ fn two_modules_at_one_frame_bake_as_separate_entries() {
     };
     let dir = tempfile::tempdir().expect("a scratch directory");
     let baked = dir.path().join("baseline.json");
-    bake(&baked, &[found]);
+    bake(&baked, &swept(), &[found]);
     let held = baseline_at(&baked).expect("the baked break set reads back");
     assert_eq!(
         held.breaks[DEFAULT_LABEL]

--- a/crate/tests/imports/tests/records.rs
+++ b/crate/tests/imports/tests/records.rs
@@ -1,12 +1,15 @@
 //! Tests for the records one sweep leaves behind, covering the modules a
-//! break reports as loaded and the counts a width holds.
+//! break reports as loaded, the counts a width holds, and how far a run
+//! reaches a module it could not compare.
 
 use std::collections::BTreeSet;
+
+use rstest::rstest;
 
 use super::*;
 use crate::{
     outcome::{Kind, Outcome},
-    records::Width,
+    records::{Reach, Width},
     report::render,
     sweep::DEFAULT_LABEL,
 };
@@ -42,6 +45,47 @@ fn a_carried_break_leaves_the_tally_the_report_renders() {
     assert!(shown.contains("  carried          1"), "{shown}");
     assert!(shown.contains("fresh.py"), "{shown}");
     assert!(!shown.contains("carried.py"), "{shown}");
+}
+
+#[rstest]
+#[case("dbm/gnu.py", "ModuleNotFoundError", Reach::Absent)]
+#[case(
+    "multiprocessing/popen_spawn_win32.py",
+    "ModuleNotFoundError",
+    Reach::Absent
+)]
+#[case("asyncio/windows_events.py", "ImportError", Reach::Platform)]
+#[case("pip/_vendor/truststore/_windows.py", "ImportError", Reach::Platform)]
+#[case(
+    "pip/_vendor/urllib3/contrib/emscripten/connection.py",
+    "ImportError",
+    Reach::Platform
+)]
+#[case("encodings/mbcs.py", "ImportError", Reach::Module)]
+#[case("pip/__pip-runner__.py", "AssertionError", Reach::Module)]
+fn a_reach_reads_the_exception_then_the_path(
+    #[case] relative: &str,
+    #[case] raised: &str,
+    #[case] want: Reach,
+) {
+    let reach = Reach::of(relative, raised);
+    assert_eq!(reach, want);
+    assert_eq!(reach.reachable(), want == Reach::Module);
+}
+
+#[rstest]
+#[case(Reach::Absent, "absent")]
+#[case(Reach::Module, "module")]
+#[case(Reach::Platform, "platform")]
+fn a_reach_spells_one_word_for_the_report_and_the_baked_set(
+    #[case] reach: Reach,
+    #[case] spelt: &str,
+) {
+    assert_eq!(reach.to_string(), spelt);
+    assert_eq!(
+        serde_json::to_string(&reach).expect("a reach renders"),
+        format!("\"{spelt}\""),
+    );
 }
 
 #[test]

--- a/crate/tests/imports/tests/report.rs
+++ b/crate/tests/imports/tests/report.rs
@@ -1,6 +1,6 @@
 //! Tests for the rendering of one width's findings, covering the summary
-//! block of counts, the listings capped at a shown limit, and the command
-//! that reproduces one break alone.
+//! block of counts, the reach split beneath it, the listings capped at a
+//! shown limit, and the command that reproduces one break alone.
 
 use std::collections::BTreeSet;
 
@@ -28,6 +28,7 @@ fn a_break_the_report_names_carries_its_frame_reason_and_repro() {
     let shown = render(&["kept.py".to_owned()].into(), &found);
     assert!(shown.contains("  carried          1"), "{shown}");
     assert!(shown.contains("  refused          1"), "{shown}");
+    assert!(!shown.contains("uncomparable by reach"), "{shown}");
     assert!(
         shown.contains(
             "re/_parser.py:111 raises NameError: no MAXGROUPS, under `prune-inert-imports`"
@@ -58,10 +59,8 @@ fn a_repro_at_a_pinned_width_carries_the_width_knob() {
 #[test]
 fn an_unmeasured_module_replaces_the_uncomparable_count() {
     let found = Width {
-        label: DEFAULT_LABEL.to_owned(),
-        uncomparable: stalled(["a.py"]),
         unmeasured: vec!["u.py".to_owned()],
-        ..Width::default()
+        ..stalling(stalled(["a.py"]))
     };
     let shown = render(&BTreeSet::new(), &found);
     assert!(shown.contains("  uncomparable unmeasured"), "{shown}");
@@ -94,16 +93,33 @@ fn the_flaky_list_caps_at_the_shown_limit() {
 }
 
 #[test]
+fn the_reach_split_names_every_class_beneath_the_block() {
+    let found = stalling(
+        [
+            blocked("dbm/gnu.py", "ModuleNotFoundError"),
+            blocked("asyncio/windows_events.py", "ImportError"),
+            blocked("encodings/mbcs.py", "ImportError"),
+        ]
+        .into(),
+    );
+    let shown = render(&BTreeSet::new(), &found);
+    assert!(shown.contains("uncomparable by reach (3):"), "{shown}");
+    assert!(shown.contains("1 absent, 1 platform, 1 module"), "{shown}");
+}
+
+#[test]
 fn the_summary_block_holds_every_count_in_one_column() {
     let found = Width {
         candidates: 12,
         comparable: 9,
-        label: DEFAULT_LABEL.to_owned(),
-        uncomparable: stalled(["a.py", "b.py", "c.py"]),
-        ..Width::default()
+        ..stalling(stalled(["a.py", "b.py", "c.py"]))
     };
+    let shown = render(&BTreeSet::new(), &found);
     assert_eq!(
-        render(&BTreeSet::new(), &found),
+        shown
+            .split("\n\n")
+            .next()
+            .expect("the block opens the render"),
         concat!(
             "  candidates      12\n",
             "  comparable       9\n",

--- a/crate/tests/integration.rs
+++ b/crate/tests/integration.rs
@@ -12,6 +12,7 @@ use std::{fmt::Write, path::Path};
 
 use itertools::Itertools;
 use prose::{diagnostics::Diagnostic, findings::lint_records, pipeline::Pipeline, source::Source};
+use ruff_python_ast::PySourceType;
 use ruff_python_formatter::{PyFormatOptions, format_module_source};
 use ruff_source_file::{LineEnding, UniversalNewlines};
 
@@ -32,7 +33,7 @@ fn fixtures() {
         // `diagnose` reads the source as written, so it runs before the
         // rewrite consumes it. A notebook pins its diagnostics through
         // the CLI tests.
-        let module = path.extension().is_some_and(|ext| ext == "py");
+        let module = !PySourceType::from(path).is_ipynb();
         let diagnostics = module.then(|| pipeline.diagnose(&source));
 
         let (formatted, records, _) = pipeline


### PR DESCRIPTION
### 🪻 Quick Summary

Triages every module the `imports` sweep could not compare and recovers the 80 that failed through the harness rather than on their own terms. `crate/tests/imports/probe.py` now imports the package holding a module before registering that module in `sys.modules`, which takes `comparable` from 898 to 978 against 997 candidates. The 19 that remain each carry a class saying how far this machine gets with them, the corpus walk widens to every Python source the walker formats, and the baked set records the corpus it was measured against.

---

### 🗞️ Key Changes

- Imports the package holding a module before `Probe.load` registers that module under its dotted name, so a package whose `__init__` reads the submodule finds a bound object rather than the empty one the probe had just put in `sys.modules`

- Adds a `Reach` enum recording `absent`, `platform`, or `module` on every `Blocked` entry, read from the exception the run named and then the module's path, never from the rendered sentence

- Replaces `dropped`'s comparison against the `ModuleNotFoundError` string with `left.reach.reachable()`, so a module written for another platform is exempt from the coverage-lost check alongside one naming a package the machine lacks

- Renders the uncomparable total split by reach beneath the report's counts, so a run says how many modules this machine could never execute apart from how many fail here on their own terms

- Widens `python_files` in `crate/tests/common/sweep.rs` from a hand-rolled extension test to `ruff_python_ast::PySourceType`, and matches it in `corpus/src/bin/mutate.rs` and `.mise/lib/delta.bash` so the settle, mutation, delta, and imports probes read one corpus again

- Adds `corpus::importable`, keeping a `.pyw` script and a `.pyi` stub out of the execution set while the walk still formats both, since neither names a module an import can bind

- Matches an entry point with its extension removed, so `idlelib/idle.pyw` leaves the walk beside `idlelib/idle.py` rather than reaching a run that starts the program it wraps

- Asserts on a `PROSE_IMPORTS_MODULE` naming an entry point or a file that binds no module, which had previously run and reported one uncomparable module under a malformed dotted name

- Pins `python` to `3.14.6` in `.mise/config.toml` and records the interpreter version, the file count, and a digest over every swept file in the baked set, with `ratchet::moved` failing a judging run that read a corpus the set never swept

- Raises the baked-set generation to 7 and re-bakes `crate/tests/imports/baseline.json`, which now carries a reach per uncomparable module and the corpus the run measured

- Replaces the unreachable `Blocked` fallback in `compare`'s uncomparable arm with an `unreachable!` invariant, since a module reaching that arm raised or timed out and therefore left a record

---

### ☕ Implementation Notes

#### The Corpus Digest Reports Drift Rather Than Preventing It

Only part of the corpus is named by a manifest. `.mise/config.toml` pins the interpreter down to its patch, which fixes the standard library, whereas the 404 files under `site-packages` come from a `pip` that the interpreter's own build installed from PyPI over the copy `ensurepip` bundles, and no manifest in the repository names that version. A run therefore records what it swept rather than guaranteeing what it will sweep, so `ratchet::moved` fails a judging run whose corpus differs from the baked one and names the interpreter version, the file count, and the digest on either side.

---

### 🧵 Related Issues

- Closes #599
